### PR TITLE
fix: retry with force-refreshed token on 401

### DIFF
--- a/core/auth/src/wasmJsMain/kotlin/core/auth/AuthRepository.kt
+++ b/core/auth/src/wasmJsMain/kotlin/core/auth/AuthRepository.kt
@@ -104,18 +104,18 @@ class AuthRepositoryImpl : AuthRepository {
 
     override suspend fun refreshToken(): String? {
         return try {
-            val resultJs = getIdTokenResult(auth).await<JsAny?>()
+            val resultJs = forceRefreshIdToken(auth).await<JsAny?>()
             val token = resultJs?.let { getTokenFromResult(it).toString() }
             if (token != null) {
                 val isAdmin = getIsAdminFromResult(resultJs).toBoolean()
-                AuthStateHolder.idToken = token
-                // admin 状態も更新
                 val currentState = AuthStateHolder.state
                 if (currentState is AuthState.Authenticated) {
                     AuthStateHolder.setAuthenticated(
                         currentState.user.copy(isAdmin = isAdmin),
                         token,
                     )
+                } else {
+                    AuthStateHolder.idToken = token
                 }
             }
             token

--- a/core/auth/src/wasmJsMain/kotlin/core/auth/FirebaseInterop.kt
+++ b/core/auth/src/wasmJsMain/kotlin/core/auth/FirebaseInterop.kt
@@ -40,6 +40,18 @@ external fun getIdToken(auth: JsAny): Promise<JsAny?>
 )
 external fun getIdTokenResult(auth: JsAny): Promise<JsAny?>
 
+// IDトークンを強制リフレッシュ → Promise<{ token, isAdmin }> を返す
+@JsFun(
+    """(auth) => {
+    if (!auth.currentUser) return Promise.resolve(null);
+    return auth.currentUser.getIdTokenResult(true).then((result) => ({
+        token: result.token,
+        isAdmin: result.claims.admin === true
+    }));
+}""",
+)
+external fun forceRefreshIdToken(auth: JsAny): Promise<JsAny?>
+
 // IDトークン結果からトークン文字列を取得
 @JsFun("(obj) => obj.token")
 external fun getTokenFromResult(obj: JsAny): JsString

--- a/core/network/src/wasmJsMain/kotlin/core/network/AuthHttpClient.kt
+++ b/core/network/src/wasmJsMain/kotlin/core/network/AuthHttpClient.kt
@@ -1,5 +1,6 @@
 package core.network
 
+import core.auth.AuthRepository
 import core.auth.AuthStateHolder
 import io.ktor.client.*
 import io.ktor.client.plugins.*
@@ -36,7 +37,7 @@ fun createUnauthenticatedClient(): HttpClient =
         }
     }
 
-fun createAuthenticatedClient(): HttpClient =
+fun createAuthenticatedClient(authRepository: AuthRepository): HttpClient =
     HttpClient {
         install(ContentNegotiation) {
             json(Json { ignoreUnknownKeys = true })
@@ -47,10 +48,29 @@ fun createAuthenticatedClient(): HttpClient =
                 headers.append("Authorization", "Bearer $token")
             }
         }
+        // 401 時にトークンを強制リフレッシュして1回だけリトライ
+        install(HttpRequestRetry) {
+            retryIf(maxRetries = 1) { _, response ->
+                response.status == HttpStatusCode.Unauthorized
+            }
+            delay {
+                // delay は suspend なのでトークンリフレッシュを実行できる
+                authRepository.refreshToken()
+            }
+            modifyRequest { request ->
+                val token = AuthStateHolder.idToken
+                if (token != null) {
+                    request.headers.remove("Authorization")
+                    request.headers.append("Authorization", "Bearer $token")
+                }
+            }
+        }
+        // リトライ後も 401 の場合のみここに到達
         HttpResponseValidator {
             validateResponse { response ->
                 if (response.status == HttpStatusCode.Unauthorized) {
-                    AuthStateHolder.setUnauthenticated()
+                    // Firebase からサインアウトして認証状態を完全にリセット
+                    authRepository.signOut()
                     throw Exception("認証エラー: 再ログインしてください")
                 }
                 if (!response.status.isSuccess()) {

--- a/core/network/src/wasmJsMain/kotlin/core/network/di/NetworkModule.kt
+++ b/core/network/src/wasmJsMain/kotlin/core/network/di/NetworkModule.kt
@@ -18,7 +18,7 @@ import org.koin.dsl.module
 
 val networkModule =
     module {
-        single<HttpClient> { createAuthenticatedClient() }
+        single<HttpClient> { createAuthenticatedClient(get()) }
         single<PetRepository> { PetRepositoryImpl(get()) }
         single<FeedingRepository> { FeedingRepositoryImpl(get()) }
         single<GarbageScheduleRepository> { GarbageScheduleRepositoryImpl(get()) }


### PR DESCRIPTION
## Summary
- 401レスポンス時にトークンを強制リフレッシュして自動リトライ（1回）する仕組みを追加
- リトライ後も401の場合のみFirebase `signOut()` を呼び、認証状態を完全にリセット
- 従来は401即座に `setUnauthenticated()` を呼んでいたが、Firebase の `signOut()` を呼んでいなかったため、再ログイン時に `onAuthStateChanged` が発火せずログイン画面が表示されたままになるバグを修正

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `FirebaseInterop.kt` | `forceRefreshIdToken()` 追加（`getIdTokenResult(true)` で強制リフレッシュ）|
| `AuthRepository.kt` | `refreshToken()` で `forceRefreshIdToken` を使用 |
| `AuthHttpClient.kt` | `HttpRequestRetry` プラグインで401時にトークンリフレッシュ＋リトライ、最終的な401で `signOut()` |
| `NetworkModule.kt` | `createAuthenticatedClient(get())` で `AuthRepository` を注入 |

## Test plan
- [ ] トークン期限切れ後にAPI呼び出し → 自動リフレッシュで透過的にリトライされること
- [ ] リフレッシュ不可能な場合 → ログイン画面に遷移すること
- [ ] ログイン画面から再ログイン → 正常にダッシュボードが表示されること
- [ ] フロントエンドビルド成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)