### PR TITLE
fix: add data/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ kotlin-js-store/
 # Firebase
 firebase-service-account.json
 
+# Local data (SQLite DB etc.)
+data/
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary
- `data/` ディレクトリを `.gitignore` に追加
- `passkey.db`（WebAuthn 認証情報）等のローカルデータファイルの誤コミットを防止

## Test plan
- [x] `data/` が `git status` の untracked に表示されなくなることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)