### PR TITLE
chore: enable Gradle parallel build and caching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.caching=true
 kotlin.code.style=official


### PR DESCRIPTION
## Summary
- `org.gradle.parallel=true` で12サブプロジェクトの並行ビルドを有効化
- `org.gradle.caching=true` でローカルビルドキャッシュを有効化

## Test plan
- [x] `./gradlew :server:test -PskipFrontend` 通過
- [ ] フルビルドのビルド時間短縮を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)