### PR TITLE
chore: improve Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:recommended"],
   "labels": ["dependencies"],
   "schedule": ["every weekend"],
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],
@@ -27,6 +28,15 @@
     {
       "groupName": "Exposed",
       "matchPackagePrefixes": ["org.jetbrains.exposed"]
+    },
+    {
+      "groupName": "Server dependencies",
+      "matchPackageNames": [
+        "ch.qos.logback:logback-classic",
+        "com.google.firebase:firebase-admin",
+        "com.webauthn4j:webauthn4j-core",
+        "org.xerial:sqlite-jdbc"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `minimumReleaseAge: "3 days"` 追加 — リリース直後の不安定版を回避
- サーバー依存（Logback, Firebase Admin, WebAuthn4J, SQLite JDBC）をグループ化し1つの PR にまとめる

## Test plan
- [x] JSON 構文が正しいことを確認
- [ ] 次回 Renovate 実行時にグループ化が反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)