### PR TITLE
fix: add route guard for admin-only screens

### DIFF
--- a/web-frontend/src/wasmJsMain/kotlin/app/App.kt
+++ b/web-frontend/src/wasmJsMain/kotlin/app/App.kt
@@ -88,7 +88,15 @@ fun App() {
 }
 
 @Composable
-private fun ScreenContent(currentScreen: Screen) {
+private fun ScreenContent(
+    currentScreen: Screen,
+    isAdmin: Boolean,
+) {
+    // 管理者専用画面に非管理者がアクセスした場合はダッシュボードにリダイレクト
+    if (currentScreen.adminOnly && !isAdmin) {
+        Navigator.navigateTo(Screen.Dashboard)
+        return
+    }
     when (currentScreen) {
         Screen.Dashboard -> DashboardScreen()
         Screen.Feeding -> FeedingScreen()
@@ -113,7 +121,7 @@ private fun ExpandedLayout(
             onSignOut = onSignOut,
             isAdmin = isAdmin,
         )
-        ScreenContent(currentScreen)
+        ScreenContent(currentScreen, isAdmin)
     }
 }
 
@@ -132,7 +140,7 @@ private fun MediumLayout(
             isAdmin = isAdmin,
             expandable = false,
         )
-        ScreenContent(currentScreen)
+        ScreenContent(currentScreen, isAdmin)
     }
 }
 
@@ -174,7 +182,7 @@ private fun CompactLayout(
             },
         ) { innerPadding ->
             Surface(modifier = Modifier.padding(innerPadding)) {
-                ScreenContent(currentScreen)
+                ScreenContent(currentScreen, isAdmin)
             }
         }
     }

--- a/web-frontend/src/wasmJsMain/kotlin/app/Navigator.kt
+++ b/web-frontend/src/wasmJsMain/kotlin/app/Navigator.kt
@@ -6,12 +6,12 @@ import androidx.compose.runtime.setValue
 import kotlinx.browser.window
 import org.w3c.dom.events.Event
 
-enum class Screen(val title: String, val path: String) {
+enum class Screen(val title: String, val path: String, val adminOnly: Boolean = false) {
     Dashboard("ダッシュボード", "/dashboard"),
     Feeding("ごはん", "/feeding"),
     Payment("お支払い", "/payment"),
     Report("家計レポート", "/report"),
-    Money("お金の管理", "/money"),
+    Money("お金の管理", "/money", adminOnly = true),
     Settings("設定", "/settings"),
     ;
 


### PR DESCRIPTION
## Summary
- `Screen` enum に `adminOnly` フラグを追加（`Money` のみ `true`）
- `ScreenContent` に `isAdmin` パラメータを追加し、管理者専用画面に非管理者がアクセスした場合はダッシュボードにリダイレクト
- URL 直接アクセスによる認可バイパスを防止

## Test plan
- [x] WASM ビルド成功
- [ ] 非管理者ユーザーで `/money` にアクセスするとダッシュボードに遷移することを確認
- [ ] 管理者ユーザーでは通常通りアクセスできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)