### PR TITLE
refactor: extract JST time functions to core/ui

### DIFF
--- a/core/ui/src/wasmJsMain/kotlin/core/ui/util/DateUtils.kt
+++ b/core/ui/src/wasmJsMain/kotlin/core/ui/util/DateUtils.kt
@@ -119,3 +119,32 @@ external fun weekOfMonthJs(): Int
 }""",
 )
 external fun dayOfWeekIndexJs(): Int
+
+/** ISO タイムスタンプを JST の HH:MM 形式に変換 */
+@JsFun(
+    """(iso) => {
+    const d = new Date(iso);
+    return d.toLocaleTimeString('ja-JP', {
+        hour: '2-digit', minute: '2-digit', hour12: false, timeZone: 'Asia/Tokyo',
+    });
+}""",
+)
+external fun toJstHHMM(iso: JsString): JsString
+
+/** ISO タイムスタンプから JST の時を取得 */
+@JsFun(
+    """(iso) => {
+    const d = new Date(iso);
+    return d.toLocaleString('en-US', { hour: '2-digit', hour12: false, timeZone: 'Asia/Tokyo' });
+}""",
+)
+external fun toJstHour(iso: JsString): JsString
+
+/** ISO タイムスタンプから JST の分を取得 */
+@JsFun(
+    """(iso) => {
+    const d = new Date(iso);
+    return d.toLocaleString('en-US', { minute: '2-digit', timeZone: 'Asia/Tokyo' });
+}""",
+)
+external fun toJstMinute(iso: JsString): JsString

--- a/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardScreen.kt
+++ b/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardScreen.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalWasmJsInterop::class)
-
 package feature.dashboard
 
 import androidx.compose.foundation.background
@@ -25,6 +23,7 @@ import core.ui.theme.displayExLarge
 import core.ui.theme.displayOrder
 import core.ui.theme.icon
 import core.ui.theme.label
+import core.ui.util.toJstHHMM
 import model.FeedingLog
 import model.GarbageType
 import model.MealTime

--- a/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
+++ b/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalWasmJsInterop::class)
-
 package feature.dashboard
 
 import androidx.compose.runtime.getValue
@@ -24,16 +22,6 @@ import model.FeedingLog
 import model.GarbageType
 import model.GarbageTypeSchedule
 import model.MealTime
-
-@JsFun(
-    """(iso) => {
-    const d = new Date(iso);
-    return d.toLocaleTimeString('ja-JP', {
-        hour: '2-digit', minute: '2-digit', hour12: false, timeZone: 'Asia/Tokyo',
-    });
-}""",
-)
-external fun toJstHHMM(iso: JsString): JsString
 
 data class DashboardUiState(
     val feedingLog: FeedingLog = FeedingLog(date = ""),

--- a/feature/feeding/src/wasmJsMain/kotlin/feature/feeding/FeedingScreen.kt
+++ b/feature/feeding/src/wasmJsMain/kotlin/feature/feeding/FeedingScreen.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalWasmJsInterop::class)
-
 package feature.feeding
 
 import androidx.compose.foundation.layout.*
@@ -28,37 +26,14 @@ import core.ui.theme.displayOrder
 import core.ui.theme.icon
 import core.ui.theme.label
 import core.ui.util.dayOfWeekShortJs
+import core.ui.util.toJstHHMM
+import core.ui.util.toJstHour
+import core.ui.util.toJstMinute
 import core.ui.util.todayDateJs
 import model.Feeding
 import model.FeedingLog
 import model.MealTime
 import org.koin.compose.viewmodel.koinViewModel
-
-@JsFun(
-    """(iso) => {
-    const d = new Date(iso);
-    return d.toLocaleTimeString('ja-JP', {
-        hour: '2-digit', minute: '2-digit', hour12: false, timeZone: 'Asia/Tokyo',
-    });
-}""",
-)
-private external fun toJstHHMM(iso: JsString): JsString
-
-@JsFun(
-    """(iso) => {
-    const d = new Date(iso);
-    return d.toLocaleString('en-US', { hour: '2-digit', hour12: false, timeZone: 'Asia/Tokyo' });
-}""",
-)
-private external fun toJstHour(iso: JsString): JsString
-
-@JsFun(
-    """(iso) => {
-    const d = new Date(iso);
-    return d.toLocaleString('en-US', { minute: '2-digit', timeZone: 'Asia/Tokyo' });
-}""",
-)
-private external fun toJstMinute(iso: JsString): JsString
 
 @Composable
 fun FeedingScreen(vm: FeedingViewModel = koinViewModel()) {


### PR DESCRIPTION
## Summary
- `toJstHHMM`, `toJstHour`, `toJstMinute` を `core/ui/util/DateUtils.kt` に統合
- `DashboardViewModel.kt` と `FeedingScreen.kt` から重複定義を削除し、共有関数を import

## Test plan
- [x] `./gradlew :web-frontend:wasmJsBrowserDistribution` ビルド成功
- [x] ktlint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)