### PR TITLE
fix: add contents:read permission to CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       packages: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 概要
- CD ワークフローに `contents: read` 権限を追加
- `permissions` で `packages: write` のみ指定すると、デフォルトの `contents: read` が無効化されるため、プライベートリポジトリで `actions/checkout` が失敗していた

## テスト
- [ ] マージ後にタグ push で CD が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)