### PR TITLE
fix: disable provenance attestations in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           context: .
           push: true
+          provenance: false
           build-args: COMMIT_HASH=${{ github.sha }}
           tags: |
             ghcr.io/ptknktq/crabshell:latest


### PR DESCRIPTION
## Summary
- `docker/build-push-action` に `provenance: false` を追加
- buildx の provenance attestations が GHCR push 時に 403 Forbidden を引き起こす既知の問題を回避

## Test plan
- [ ] マージ後 `git tag v0.0.4 && git push origin v0.0.4` でタグ push
- [ ] Actions タブで CD ワークフローが成功することを確認
- [ ] GHCR にイメージが push されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)