### PR TITLE
fix: replace buildx with standard docker build/push

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,14 +17,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          provenance: false
-          sbom: false
-          build-args: COMMIT_HASH=${{ github.sha }}
-          tags: |
-            ghcr.io/ptknktq/crabshell:latest
-            ghcr.io/ptknktq/crabshell:${{ github.ref_name }}
+      - name: Build and push Docker image
+        run: |
+          docker build --build-arg COMMIT_HASH=${{ github.sha }} \
+            -t ghcr.io/ptknktq/crabshell:latest \
+            -t ghcr.io/ptknktq/crabshell:${{ github.ref_name }} .
+          docker push ghcr.io/ptknktq/crabshell:latest
+          docker push ghcr.io/ptknktq/crabshell:${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- `docker/setup-buildx-action` + `docker/build-push-action` を削除
- 標準の `docker build` + `docker push` コマンドに切り替え
- buildx の `docker-container` ドライバが GHCR への blob HEAD request で 403 を返す問題を根本的に回避
- シングルプラットフォームビルドのため buildx の機能は不要

## Test plan
- [ ] マージ後 `v0.0.6` タグを push して CD ワークフローの成功を確認
- [ ] GHCR にイメージが push されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)