### PR TITLE
fix: switch runtime image from Alpine to Noble

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,10 @@ COPY core/ core/
 COPY feature/ feature/
 RUN gradle :server:buildFatJar --no-daemon
 
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:21-jre-noble
 WORKDIR /app
 COPY --from=build /app/server/build/libs/*-all.jar app.jar
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-  CMD wget -qO /dev/null http://localhost:8080/ || exit 1
-CMD ["java", "-Dio.netty.handler.ssl.noOpenSsl=true", "-jar", "app.jar"]
+  CMD curl -sf http://localhost:8080/ > /dev/null || exit 1
+CMD ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## Summary
- 実行ステージを `eclipse-temurin:21-jre-alpine` → `eclipse-temurin:21-jre-noble` に変更
- gRPC がバンドルする shaded netty-tcnative は `-Dio.netty.handler.ssl.noOpenSsl=true` が効かず、Alpine (musl libc) 上で SIGSEGV が発生する
- glibc ベースの Noble で根本解決
- HEALTHCHECK: `wget` → `curl`

## Test plan
- [ ] マージ後タグ push して CD 成功を確認
- [ ] コンテナが SIGSEGV なく正常起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)