### PR TITLE
fix: use short commit hash in sidebar

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push Docker image
         run: |
-          docker build --build-arg COMMIT_HASH=${{ github.sha }} \
+          docker build --build-arg COMMIT_HASH=${GITHUB_SHA::7} \
             -t ghcr.io/ptknktq/crabshell:latest \
             -t ghcr.io/ptknktq/crabshell:${{ github.ref_name }} .
           docker push ghcr.io/ptknktq/crabshell:latest


### PR DESCRIPTION
## Summary
- CD ワークフローの `COMMIT_HASH` ビルド引数をフルハッシュ (`github.sha`) から短縮版 (`${GITHUB_SHA::7}`) に変更
- サイドバーのバージョン表示が7文字の短縮ハッシュになる

## Test plan
- [ ] マージ後タグ push して CD 成功を確認
- [ ] サイドバーのバージョン表示が短縮ハッシュになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)