### PR TITLE
refactor: user_points/point_history を users/{uid} サブコレクションに統合

### DIFF
--- a/server/src/main/kotlin/server/quest/PointRoutes.kt
+++ b/server/src/main/kotlin/server/quest/PointRoutes.kt
@@ -27,7 +27,7 @@ fun Route.pointRoutes() {
                 val token = call.attributes[FirebaseTokenKey]
                 val doc =
                     firestore
-                        .collection("user_points")
+                        .collection("users")
                         .document(token.uid)
                         .get()
                         .await()
@@ -49,8 +49,9 @@ fun Route.pointRoutes() {
                 val token = call.attributes[FirebaseTokenKey]
                 val docs =
                     firestore
+                        .collection("users")
+                        .document(token.uid)
                         .collection("point_history")
-                        .whereEqualTo("uid", token.uid)
                         .get()
                         .await()
                         .documents
@@ -179,7 +180,7 @@ fun Route.pointRoutes() {
 
                 val pointsRef =
                     firestore
-                        .collection("user_points")
+                        .collection("users")
                         .document(token.uid)
                 val pointsDoc = pointsRef.get().await()
                 val currentBalance = if (pointsDoc.exists()) (pointsDoc.data!!["balance"] as? Number)?.toInt() ?: 0 else 0
@@ -200,6 +201,8 @@ fun Route.pointRoutes() {
                 // 履歴追加
                 val rewardName = rewardData["name"] as? String ?: ""
                 firestore
+                    .collection("users")
+                    .document(token.uid)
                     .collection("point_history")
                     .add(
                         mapOf(
@@ -227,7 +230,7 @@ suspend fun awardPoints(
 ) {
     val pointsRef =
         firestore
-            .collection("user_points")
+            .collection("users")
             .document(uid)
     val doc = pointsRef.get().await()
     val currentBalance = if (doc.exists()) (doc.data!!["balance"] as? Number)?.toInt() ?: 0 else 0
@@ -251,6 +254,8 @@ suspend fun awardPoints(
         historyData["questId"] = questId
     }
     firestore
+        .collection("users")
+        .document(uid)
         .collection("point_history")
         .add(historyData)
         .await()


### PR DESCRIPTION
## Summary
- `user_points/{uid}` → `users/{uid}` にポイント残高を移動
- `point_history` トップレベルコレクション → `users/{uid}/point_history` サブコレクションに移動
- `whereEqualTo("uid", ...)` フィルタが不要になり、パスで uid が確定するよう改善

## 変更箇所（PointRoutes.kt 6箇所）
- GET /api/points: `collection("user_points")` → `collection("users")`
- GET /api/points/history: `collection("point_history").whereEqualTo(...)` → `collection("users").document(uid).collection("point_history")`
- POST /api/rewards/{id}/exchange（ポイント減算）: 同上
- POST /api/rewards/{id}/exchange（履歴追加）: 同上
- awardPoints()（ポイント加算）: 同上
- awardPoints()（履歴追加）: 同上

## モデル・クライアント変更なし
- `UserPoints` / `PointHistory` モデルはそのまま（API レスポンス互換）
- クライアント側の変更は不要

## Test plan
- [x] `./gradlew :server:ktlintFormat` パス
- [x] `./gradlew :server:test -PskipFrontend` パス
- [ ] ポイント残高表示の動作確認
- [ ] クエスト作成→承認→ポイント付与の動作確認
- [ ] 報酬交換→ポイント減算の動作確認
- [ ] 履歴タブで履歴表示の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)