### PR TITLE
fix: デプロイ後のチャンク読み込みエラー対策

### DIFF
--- a/app/webpack.config.d/output.js
+++ b/app/webpack.config.d/output.js
@@ -1,0 +1,2 @@
+// チャンクファイル名にコンテンツハッシュを含め、キャッシュバスティングを実現
+config.output.chunkFilename = '[id]-[contenthash].js';

--- a/server/src/main/kotlin/server/Application.kt
+++ b/server/src/main/kotlin/server/Application.kt
@@ -1,5 +1,6 @@
 package server
 
+import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
@@ -59,6 +60,25 @@ fun Application.module() {
         // Compose Wasm フロントエンドを配信
         staticResources("/", "static") {
             default("index.html")
+            cacheControl { url ->
+                val path = url.path
+                when {
+                    // エントリーポイント: 毎回サーバーに再検証（ETag/304）
+                    path.endsWith("index.html") ||
+                        path.endsWith("app.js") ||
+                        path.endsWith("firebase-config.js") ->
+                        listOf(CacheControl.NoCache(null))
+                    // ハッシュ付きファイル（チャンク JS, WASM, フォント等）: 1年キャッシュ
+                    else ->
+                        listOf(
+                            CacheControl.MaxAge(
+                                maxAgeSeconds = 31536000,
+                                mustRevalidate = false,
+                                visibility = CacheControl.Visibility.Public,
+                            ),
+                        )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

デプロイ後にブラウザキャッシュの古い `app.js` が存在しないチャンク（`185.js` 等）をリクエストし `ChunkLoadError` が発生する問題を修正。

- webpack チャンクファイル名にコンテンツハッシュを追加（`185.js` → `185-a1b2c3d4.js`）
- Ktor 静的ファイルに Cache-Control ヘッダーを設定（エントリーポイントは `no-cache`、ハッシュ付きアセットは `max-age=1year`）

## キャッシュ戦略

| ファイル | ハッシュ | Cache-Control | 理由 |
|---------|---------|--------------|------|
| `index.html` | なし | `no-cache` | 常に最新の HTML を取得 |
| `app.js` | なし | `no-cache` | 常に最新のエントリーポイントを取得 |
| `firebase-config.js` | なし | `no-cache` | 設定変更に即応 |
| `185-a1b2c3d4.js` | あり | `public, max-age=31536000` | ファイル名が変わるので安全 |
| `*.wasm` | あり | `public, max-age=31536000` | 同上 |

## Test plan

- [x] `./gradlew :server:ktlintFormat` — PASS
- [x] `./gradlew :server:test -PskipFrontend` — PASS
- [x] `./gradlew :app:wasmJsBrowserDistribution` でチャンクファイル名にハッシュ付与を確認（`185-bf2deab75040727f5f9a.js`）

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)