### PR TITLE
docs: CLAUDE.md のバージョン情報を更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,9 +111,9 @@ The `server/build.gradle.kts` has a `copyWasmFrontend` task that copies the fron
 
 ## Tech Stack
 
-- **Kotlin** 2.3.0, **Compose Multiplatform** 1.10.0, **Ktor** 3.4.0
+- **Kotlin** 2.3.10, **Compose Multiplatform** 1.10.1, **Ktor** 3.4.0
 - **DI**: Koin 4.2.0-RC1（Kotlin 2.3.0 wasmJs 互換の唯一のバージョン）
-- **Serialization**: kotlinx-serialization-json 1.8.1
+- **Serialization**: kotlinx-serialization-json 1.10.0
 - **Dependency versions**: managed in `gradle/libs.versions.toml` (bundles: `ktor-server`, `ktor-client`, `koin`, `exposed`)
 - **Kotlin code style**: official (set in `gradle.properties`)
 


### PR DESCRIPTION
## Summary

依存関係更新 PR (#80, #81, #82, #83) のマージに伴い、CLAUDE.md の Tech Stack セクションを更新。

- Kotlin 2.3.0 → 2.3.10
- Compose Multiplatform 1.10.0 → 1.10.1
- kotlinx-serialization-json 1.8.1 → 1.10.0

## Test plan

- ドキュメント変更のみ、テスト不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 複数の技術スタック依存関係をアップデートしました。Kotlin、Compose Multiplatform、kotlinx-serialization-json など主要なライブラリをアップデートし、最新のバージョンに対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->