### PR TITLE
feat: 設定画面にパスキー管理機能を追加

### DIFF
--- a/feature/settings/src/commonMain/kotlin/feature/settings/PasskeyManagementViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/PasskeyManagementViewModel.kt
@@ -1,0 +1,74 @@
+package feature.settings
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import core.network.PasskeyRepository
+import kotlinx.coroutines.launch
+
+data class PasskeyManagementUiState(
+    val isLoading: Boolean = true,
+    val isAvailable: Boolean = false,
+    val isRegistering: Boolean = false,
+    val credentialCount: Int = 0,
+    val errorMessage: String? = null,
+    val successMessage: String? = null,
+)
+
+class PasskeyManagementViewModel(
+    private val passkeyRepository: PasskeyRepository,
+) : ViewModel() {
+    var uiState by mutableStateOf(PasskeyManagementUiState())
+        private set
+
+    init {
+        loadStatus()
+    }
+
+    private fun loadStatus() {
+        uiState = uiState.copy(isLoading = true)
+        viewModelScope.launch {
+            val result = passkeyRepository.getPasskeyStatus()
+            if (result.isSuccess) {
+                val status = result.getOrThrow()
+                // サーバーは機能無効時 registered=true, credentialCount=0 を返す
+                val available = !(status.registered && status.credentialCount == 0)
+                uiState =
+                    uiState.copy(
+                        isLoading = false,
+                        isAvailable = available,
+                        credentialCount = status.credentialCount,
+                    )
+            } else {
+                uiState =
+                    uiState.copy(
+                        isLoading = false,
+                        isAvailable = false,
+                    )
+            }
+        }
+    }
+
+    fun onRegisterPasskey() {
+        uiState = uiState.copy(isRegistering = true, errorMessage = null, successMessage = null)
+        viewModelScope.launch {
+            val result = passkeyRepository.registerPasskey()
+            if (result.isSuccess) {
+                uiState =
+                    uiState.copy(
+                        isRegistering = false,
+                        successMessage = "パスキーを登録しました",
+                    )
+                loadStatus()
+            } else {
+                uiState =
+                    uiState.copy(
+                        isRegistering = false,
+                        errorMessage = result.exceptionOrNull()?.message ?: "パスキーの登録に失敗しました",
+                    )
+            }
+        }
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
@@ -35,7 +36,10 @@ import org.koin.compose.viewmodel.koinViewModel
 private val dayLabels = listOf("日", "月", "火", "水", "木", "金", "土")
 
 @Composable
-fun SettingsScreen(passwordVm: PasswordChangeViewModel = koinViewModel()) {
+fun SettingsScreen(
+    passwordVm: PasswordChangeViewModel = koinViewModel(),
+    passkeyVm: PasskeyManagementViewModel = koinViewModel(),
+) {
     val isAdmin = (AuthStateHolder.state as? AuthState.Authenticated)?.user?.isAdmin == true
     val koin = getKoin()
     val userNameVm = remember(isAdmin) { if (isAdmin) koin.get<UserNameViewModel>() else null }
@@ -57,6 +61,12 @@ fun SettingsScreen(passwordVm: PasswordChangeViewModel = koinViewModel()) {
         onNewPasswordChanged = passwordVm::onNewPasswordChanged,
         onConfirmPasswordChanged = passwordVm::onConfirmPasswordChanged,
         onChangePassword = passwordVm::onChangePassword,
+        passkeyAvailable = passkeyVm.uiState.isAvailable,
+        passkeyRegistering = passkeyVm.uiState.isRegistering,
+        credentialCount = passkeyVm.uiState.credentialCount,
+        passkeyError = passkeyVm.uiState.errorMessage,
+        passkeySuccess = passkeyVm.uiState.successMessage,
+        onRegisterPasskey = passkeyVm::onRegisterPasskey,
         users = userNameVm?.uiState?.users ?: emptyList(),
         usersSaving = userNameVm?.uiState?.isSaving ?: false,
         usersMessage = userNameVm?.uiState?.message,
@@ -96,6 +106,12 @@ internal fun SettingsContent(
     onNewPasswordChanged: (String) -> Unit,
     onConfirmPasswordChanged: (String) -> Unit,
     onChangePassword: () -> Unit,
+    passkeyAvailable: Boolean = false,
+    passkeyRegistering: Boolean = false,
+    credentialCount: Int = 0,
+    passkeyError: String? = null,
+    passkeySuccess: String? = null,
+    onRegisterPasskey: () -> Unit = {},
     users: List<User>,
     usersSaving: Boolean,
     usersMessage: String?,
@@ -147,6 +163,16 @@ internal fun SettingsContent(
                     onChangePassword = onChangePassword,
                     modifier = cardModifier,
                 )
+                if (passkeyAvailable) {
+                    PasskeyManagementCard(
+                        credentialCount = credentialCount,
+                        isRegistering = passkeyRegistering,
+                        errorMessage = passkeyError,
+                        successMessage = passkeySuccess,
+                        onRegisterPasskey = onRegisterPasskey,
+                        modifier = cardModifier,
+                    )
+                }
             }
 
             if (isAdmin) {
@@ -596,6 +622,89 @@ private fun PasswordChangeCard(
                     )
                 } else {
                     Text("変更する")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PasskeyManagementCard(
+    credentialCount: Int,
+    isRegistering: Boolean,
+    errorMessage: String?,
+    successMessage: String?,
+    onRegisterPasskey: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier,
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            ),
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp).fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Fingerprint,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    text = "パスキー管理",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+
+            Text(
+                text = "登録済み: $credentialCount 件",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Text(
+                text = "別の端末やブラウザからログインするには、パスキーを追加してください。",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            if (errorMessage != null) {
+                Text(
+                    text = errorMessage,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+
+            if (successMessage != null) {
+                Text(
+                    text = successMessage,
+                    color = MaterialTheme.colorScheme.primary,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+
+            Button(
+                onClick = onRegisterPasskey,
+                modifier = Modifier.height(48.dp),
+                enabled = !isRegistering,
+            ) {
+                if (isRegistering) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                } else {
+                    Text("パスキーを追加")
                 }
             }
         }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/di/SettingsModule.kt
@@ -1,6 +1,7 @@
 package feature.settings.di
 
 import feature.settings.GarbageScheduleViewModel
+import feature.settings.PasskeyManagementViewModel
 import feature.settings.PasswordChangeViewModel
 import feature.settings.UserNameViewModel
 import feature.settings.WebhookViewModel
@@ -10,6 +11,7 @@ import org.koin.dsl.module
 val settingsModule =
     module {
         viewModel { PasswordChangeViewModel(get()) }
+        viewModel { PasskeyManagementViewModel(get()) }
         // Admin のみ条件付き生成
         factory { UserNameViewModel(get()) }
         factory { GarbageScheduleViewModel(get()) }


### PR DESCRIPTION
## Summary
- 設定画面の「アカウント」セクションにパスキー管理カードを追加（追加登録の導線）

## 変更内容

### パスキー管理
- `PasskeyManagementViewModel` を新規作成（状態取得 + 追加登録）
- `SettingsModule` に ViewModel を Koin 登録
- `SettingsScreen` にパスキー管理カードを追加（stateful/stateless 分離）
- サーバーでパスキー機能が無効の場合はカード非表示

## Test plan
- [ ] `./gradlew :server:test -PskipFrontend` がパス
- [ ] パスキー登録済みの状態で設定画面にカードが表示される
- [ ] 「パスキーを追加」でブラウザの WebAuthn ダイアログが出る
- [ ] 登録成功後、件数が増える
- [ ] サーバーでパスキー機能が無効の場合、カードが表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)