### PR TITLE
docs: CORS 不要・セキュリティヘッダはリバースプロキシ管理である旨を明記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,11 @@ docker compose pull && docker compose up -d
 - patch 更新は自動マージ、Kotlin & Compose / Ktor / Koin / Exposed はグループ化して1つの PR にまとめる。
 - `gradle/libs.versions.toml` の `[bundles]` セクションで関連ライブラリをグループ化済み。新しいライブラリ追加時は既存 bundle に含められるか確認すること。
 
+## Security
+
+- **CORS は不要。** サーバーがフロントエンドを同一オリジンで配信し、開発時も webpack がプロキシするため。過去に導入→削除した経緯あり（PR #48）。再導入しないこと。
+- **セキュリティヘッダ（HSTS, X-Frame-Options, CSP 等）はリバースプロキシ側で設定する。** アプリケーション側では設定しない（重複するとヘッダ値が矛盾するため）。
+
 ## Notes
 
 - Comments in build files are in Japanese.

--- a/README.md
+++ b/README.md
@@ -243,6 +243,26 @@ docker compose up -d
 docker compose pull && docker compose up -d
 ```
 
+## セキュリティ
+
+### CORS
+
+サーバーはフロントエンド（WASM）を同一オリジンで配信する構成のため、CORS プラグインは不要であり、意図的に設定していない。開発時も webpack dev server がプロキシするため、フロントエンドから見れば同一オリジンとなる。
+
+> **Note:** 過去に CORS プラグインを導入→削除した経緯がある（PR #48）。同一オリジン配信である限り、再導入は不要。
+
+### セキュリティヘッダ
+
+以下のヘッダは本番環境のリバースプロキシ側で設定する。アプリケーション側では設定しない（重複するとヘッダ値が矛盾し、挙動が不定になるため）。
+
+| ヘッダ | 推奨値 |
+|--------|--------|
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` |
+| `X-Frame-Options` | `SAMEORIGIN` |
+| `X-Content-Type-Options` | `nosniff` |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` |
+| `Permissions-Policy` | `geolocation=(), camera=(), microphone=()` |
+
 ## 認証
 
 Firebase Auth + Passkey (WebAuthn) のハイブリッド認証。


### PR DESCRIPTION
## 概要

CORS プラグインやセキュリティヘッダをアプリ側で設定しない理由をドキュメントに明記し、今後同じ議論が繰り返されることを防ぐ。

### 背景

- CORS は過去に導入→削除した経緯がある（PR #48）。同一オリジン配信のため不要
- セキュリティヘッダ（HSTS, X-Frame-Options 等）は本番のリバースプロキシ側で設定済み。アプリ側で重複設定するとヘッダ値が矛盾し、挙動が不定になる

### 変更内容

- `README.md`: 「セキュリティ」セクションを追加（CORS 不要の理由、セキュリティヘッダの推奨値一覧）
- `CLAUDE.md`: Security セクションを追加（CORS 再導入禁止、ヘッダはリバースプロキシ管理の旨）

Closes #96

## テスト計画

- [x] ドキュメントのみの変更のため、ビルド・テスト不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)