### PR TITLE
テストインフラ整備: MockK・ktor-server-test-host・coroutines-test 追加

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,8 @@ exposed = "0.61.0"
 sqlite-jdbc = "3.51.2.0"
 dotenv-java = "3.2.0"
 ktor-openapi-tools = "5.5.0"
+mockk = "1.14.9"
+kotlinx-coroutines = "1.10.2"
 
 [libraries]
 # Koin DI
@@ -46,6 +48,11 @@ sqlite-jdbc = { module = "org.xerial:sqlite-jdbc", version.ref = "sqlite-jdbc" }
 dotenv-java = { module = "io.github.cdimascio:dotenv-java", version.ref = "dotenv-java" }
 ktor-openapi = { module = "io.github.smiley4:ktor-openapi", version.ref = "ktor-openapi-tools" }
 ktor-swagger-ui = { module = "io.github.smiley4:ktor-swagger-ui", version.ref = "ktor-openapi-tools" }
+
+# Testing
+ktor-server-test-host = { module = "io.ktor:ktor-server-test-host-jvm", version.ref = "ktor" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 # Ktor Client (for Compose frontend)
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -43,6 +43,13 @@ dependencies {
     implementation(libs.ktor.serialization.kotlinx.json)
 
     testImplementation(kotlin("test"))
+    testImplementation(libs.ktor.server.test.host)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 // Compose Wasm フロントエンドのビルド出力をサーバーの静的リソースにコピー


### PR DESCRIPTION
## Summary
- `gradle/libs.versions.toml` に MockK 1.14.9、kotlinx-coroutines-test 1.10.2、ktor-server-test-host を追加
- `server/build.gradle.kts` にテスト依存を追加し、JUnit 5 (`useJUnitPlatform()`) を明示設定
- テストコード自体は次の PR で追加

## 対応 Issue
#121 item 6（テストインフラ整備）

## テスト
```bash
./gradlew :server:test -PskipFrontend  # 既存テスト（ChallengeStoreTest, MoneyParsingTest）が通ること
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)