### PR TITLE
給餌画面の日付境界を5時基準に統一

### DIFF
--- a/feature/feeding/src/wasmJsMain/kotlin/feature/feeding/FeedingViewModel.kt
+++ b/feature/feeding/src/wasmJsMain/kotlin/feature/feeding/FeedingViewModel.kt
@@ -7,8 +7,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import core.network.FeedingRepository
 import core.network.PetRepository
+import core.ui.util.feedingDateJs
 import core.ui.util.shiftDateJs
-import core.ui.util.todayDateJs
 import kotlinx.coroutines.launch
 import model.FeedingLog
 import model.MealTime
@@ -30,8 +30,8 @@ class FeedingViewModel(
 ) : ViewModel() {
     var uiState by mutableStateOf(
         FeedingUiState(
-            log = FeedingLog(date = todayDateJs().toString()),
-            selectedDate = todayDateJs().toString(),
+            log = FeedingLog(date = feedingDateJs().toString()),
+            selectedDate = feedingDateJs().toString(),
         ),
     )
         private set


### PR DESCRIPTION
## Summary
- 給餌画面（FeedingViewModel）の初期日付を `todayDateJs()`（0時基準）から `feedingDateJs()`（JST 5時基準）に変更
- ダッシュボードの給餌情報と同じ日付境界で統一

## 変更内容
`FeedingViewModel` で `todayDateJs()` → `feedingDateJs()` に差し替え（2箇所）

## 影響
JST 0:00〜4:59 に給餌画面を開いた場合、以前は当日が表示されていたが、変更後は前日が表示される（ダッシュボードと同じ挙動）

## テスト
- JST 5時前後に給餌画面を開き、ダッシュボードと同じ日付が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)