### PR TITLE
dev.sh にシェル補完を追加

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -324,6 +324,38 @@ USAGE
 # -----------------------------------------------------------------------------
 
 case "${1:-}" in
+    --completions)
+        # シェル補完スクリプトを出力（zsh/bash 両対応）
+        # 使い方: eval "$(./dev.sh --completions)"
+        cat <<'COMPLETIONS'
+if [ -n "$ZSH_VERSION" ]; then
+    _dev_sh() {
+        local -a subcmds=('server' 'frontend' 'start' 'stop' 'restart' 'status' 'help')
+        local -a actions=('start' 'stop' 'restart' 'log' 'status')
+        case $CURRENT in
+            2) _describe 'command' subcmds ;;
+            3) [[ $words[2] == (server|frontend) ]] && _describe 'action' actions ;;
+        esac
+    }
+    compdef _dev_sh dev.sh ./dev.sh
+elif [ -n "$BASH_VERSION" ]; then
+    _dev_sh() {
+        local cur prev
+        cur="${COMP_WORDS[COMP_CWORD]}"
+        prev="${COMP_WORDS[COMP_CWORD-1]}"
+        case $COMP_CWORD in
+            1) COMPREPLY=($(compgen -W "server frontend start stop restart status help" -- "$cur")) ;;
+            2)
+                case "$prev" in
+                    server|frontend) COMPREPLY=($(compgen -W "start stop restart log status" -- "$cur")) ;;
+                esac
+                ;;
+        esac
+    }
+    complete -F _dev_sh dev.sh ./dev.sh
+fi
+COMPLETIONS
+        ;;
     server)
         case "${2:-}" in
             start)   server_start ;;


### PR DESCRIPTION
## Summary
- `./dev.sh --completions` サブコマンドを追加（zsh/bash 両対応の補完スクリプトを出力）
- Tab キーで `server`/`frontend` やそのアクション（`start`/`stop`/`restart`/`log`/`status`）を補完可能

## セットアップ
`.zshrc` に以下を追加:
```bash
eval "$(./dev.sh --completions)"
```

## Test plan
- [ ] `./dev.sh --completions` が補完スクリプトを正しく出力することを確認
- [ ] 新しいシェルセッションで `./dev.sh [TAB]` がコマンド候補を表示することを確認
- [ ] `./dev.sh server [TAB]` がアクション候補を表示することを確認
- [ ] 既存のコマンド（`start`, `stop` 等）が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)