### PR TITLE
朝10時以降はゴミバッジを翌日表示に切り替え

### DIFF
--- a/core/ui/src/wasmJsMain/kotlin/core/ui/util/DateUtils.kt
+++ b/core/ui/src/wasmJsMain/kotlin/core/ui/util/DateUtils.kt
@@ -120,6 +120,26 @@ external fun weekOfMonthJs(): Int
 )
 external fun dayOfWeekIndexJs(): Int
 
+/** 明日の曜日を 0(日)〜6(土) で返す */
+@JsFun(
+    """() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 1);
+    return d.getDay();
+}""",
+)
+external fun tomorrowDayOfWeekIndexJs(): Int
+
+/** 明日が月内の第何週か返す (1-5)。日曜始まりで計算。 */
+@JsFun(
+    """() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 1);
+    return Math.ceil(d.getDate() / 7);
+}""",
+)
+external fun tomorrowWeekOfMonthJs(): Int
+
 /** ISO タイムスタンプを JST の HH:MM 形式に変換 */
 @JsFun(
     """(iso) => {

--- a/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
+++ b/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
@@ -14,14 +14,16 @@ import core.ui.util.dayOfWeekIndexJs
 import core.ui.util.feedingDateJs
 import core.ui.util.formattedTodayJs
 import core.ui.util.todayDateJs
+import core.ui.util.tomorrowDayOfWeekIndexJs
+import core.ui.util.tomorrowWeekOfMonthJs
 import core.ui.util.weekOfMonthJs
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import model.CollectionFrequency
 import model.FeedingLog
 import model.GarbageType
 import model.GarbageTypeSchedule
 import model.MealTime
+import model.resolveGarbageTypes
 
 data class DashboardUiState(
     val feedingLog: FeedingLog = FeedingLog(date = ""),
@@ -140,27 +142,12 @@ class DashboardViewModel(
     }
 
     private fun refreshGarbageForToday() {
-        val dayOfWeek = dayOfWeekIndexJs()
-        val weekOfMonth = weekOfMonthJs()
-        uiState =
-            uiState.copy(
-                todayGarbageTypes =
-                    cachedSchedules
-                        .filter { schedule ->
-                            dayOfWeek in schedule.daysOfWeek && matchesFrequency(schedule.frequency, weekOfMonth)
-                        }.map { it.garbageType },
-            )
+        val hour = currentTimeJs().toString().substringBefore(":").toIntOrNull() ?: 0
+        val isAfter10 = hour >= 10
+        val dayOfWeek = if (isAfter10) tomorrowDayOfWeekIndexJs() else dayOfWeekIndexJs()
+        val weekOfMonth = if (isAfter10) tomorrowWeekOfMonthJs() else weekOfMonthJs()
+        uiState = uiState.copy(todayGarbageTypes = resolveGarbageTypes(cachedSchedules, dayOfWeek, weekOfMonth))
     }
-
-    private fun matchesFrequency(
-        frequency: CollectionFrequency,
-        weekOfMonth: Int,
-    ): Boolean =
-        when (frequency) {
-            CollectionFrequency.WEEKLY -> true
-            CollectionFrequency.WEEK_1_3 -> weekOfMonth == 1 || weekOfMonth == 3
-            CollectionFrequency.WEEK_2_4 -> weekOfMonth == 2 || weekOfMonth == 4
-        }
 
     private suspend fun silentRefreshFeeding() {
         val id = petId ?: return

--- a/shared/src/commonMain/kotlin/model/GarbageSchedule.kt
+++ b/shared/src/commonMain/kotlin/model/GarbageSchedule.kt
@@ -14,3 +14,24 @@ data class GarbageTypeSchedule(
     val daysOfWeek: List<Int>,
     val frequency: CollectionFrequency = CollectionFrequency.WEEKLY,
 )
+
+/** 指定された曜日・月内週に該当するゴミ種を返す */
+fun resolveGarbageTypes(
+    schedules: List<GarbageTypeSchedule>,
+    dayOfWeek: Int,
+    weekOfMonth: Int,
+): List<GarbageType> =
+    schedules
+        .filter { schedule ->
+            dayOfWeek in schedule.daysOfWeek && matchesFrequency(schedule.frequency, weekOfMonth)
+        }.map { it.garbageType }
+
+private fun matchesFrequency(
+    frequency: CollectionFrequency,
+    weekOfMonth: Int,
+): Boolean =
+    when (frequency) {
+        CollectionFrequency.WEEKLY -> true
+        CollectionFrequency.WEEK_1_3 -> weekOfMonth == 1 || weekOfMonth == 3
+        CollectionFrequency.WEEK_2_4 -> weekOfMonth == 2 || weekOfMonth == 4
+    }

--- a/shared/src/commonTest/kotlin/model/GarbageScheduleTest.kt
+++ b/shared/src/commonTest/kotlin/model/GarbageScheduleTest.kt
@@ -3,6 +3,7 @@ package model
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class GarbageScheduleTest {
     private val json = Json
@@ -34,5 +35,75 @@ class GarbageScheduleTest {
         val decoded = json.decodeFromString(GarbageTypeSchedule.serializer(), encoded)
         assertEquals(schedule, decoded)
         assertEquals(CollectionFrequency.WEEKLY, decoded.frequency)
+    }
+
+    // --- resolveGarbageTypes テスト ---
+
+    private val schedules =
+        listOf(
+            GarbageTypeSchedule(GarbageType.BURNABLE, listOf(1, 4)), // 月・木、毎週
+            GarbageTypeSchedule(GarbageType.NON_BURNABLE, listOf(3), CollectionFrequency.WEEK_1_3), // 水、第1・3週
+            GarbageTypeSchedule(GarbageType.RECYCLABLE, listOf(3), CollectionFrequency.WEEK_2_4), // 水、第2・4週
+        )
+
+    @Test
+    fun resolveWeeklyMatchesDayOfWeek() {
+        // 月曜(1)・第1週 → 可燃のみ
+        assertEquals(listOf(GarbageType.BURNABLE), resolveGarbageTypes(schedules, dayOfWeek = 1, weekOfMonth = 1))
+    }
+
+    @Test
+    fun resolveWeek13MatchesWeek1() {
+        // 水曜(3)・第1週 → 不燃（WEEK_1_3）
+        assertEquals(listOf(GarbageType.NON_BURNABLE), resolveGarbageTypes(schedules, dayOfWeek = 3, weekOfMonth = 1))
+    }
+
+    @Test
+    fun resolveWeek13MatchesWeek3() {
+        // 水曜(3)・第3週 → 不燃（WEEK_1_3）
+        assertEquals(listOf(GarbageType.NON_BURNABLE), resolveGarbageTypes(schedules, dayOfWeek = 3, weekOfMonth = 3))
+    }
+
+    @Test
+    fun resolveWeek24MatchesWeek2() {
+        // 水曜(3)・第2週 → 資源（WEEK_2_4）
+        assertEquals(listOf(GarbageType.RECYCLABLE), resolveGarbageTypes(schedules, dayOfWeek = 3, weekOfMonth = 2))
+    }
+
+    @Test
+    fun resolveWeek24MatchesWeek4() {
+        // 水曜(3)・第4週 → 資源（WEEK_2_4）
+        assertEquals(listOf(GarbageType.RECYCLABLE), resolveGarbageTypes(schedules, dayOfWeek = 3, weekOfMonth = 4))
+    }
+
+    @Test
+    fun resolveNoMatchReturnsEmpty() {
+        // 日曜(0) → 該当なし
+        assertTrue(resolveGarbageTypes(schedules, dayOfWeek = 0, weekOfMonth = 1).isEmpty())
+    }
+
+    @Test
+    fun resolveWeek5NoFrequencyMatch() {
+        // 水曜(3)・第5週 → WEEK_1_3 も WEEK_2_4 も該当しない
+        assertTrue(resolveGarbageTypes(schedules, dayOfWeek = 3, weekOfMonth = 5).isEmpty())
+    }
+
+    @Test
+    fun resolveMultipleMatches() {
+        // 複数のスケジュールが同じ曜日にマッチするケース
+        val overlapping =
+            listOf(
+                GarbageTypeSchedule(GarbageType.BURNABLE, listOf(1)),
+                GarbageTypeSchedule(GarbageType.RECYCLABLE, listOf(1)),
+            )
+        assertEquals(
+            listOf(GarbageType.BURNABLE, GarbageType.RECYCLABLE),
+            resolveGarbageTypes(overlapping, dayOfWeek = 1, weekOfMonth = 1),
+        )
+    }
+
+    @Test
+    fun resolveEmptySchedules() {
+        assertTrue(resolveGarbageTypes(emptyList(), dayOfWeek = 1, weekOfMonth = 1).isEmpty())
     }
 }


### PR DESCRIPTION
## Summary
- 朝10時以降は翌日のゴミ捨て情報を表示するように変更
- ゴミ種解決ロジック (`resolveGarbageTypes`) を shared モジュールに抽出しテスト追加

## Changes
- `DateUtils.kt`: `tomorrowDayOfWeekIndexJs()` / `tomorrowWeekOfMonthJs()` を追加
- `GarbageSchedule.kt`: `resolveGarbageTypes()` を純粋関数として抽出
- `DashboardViewModel.kt`: 10時判定で今日/明日を切り替え、抽出した関数を利用
- `GarbageScheduleTest.kt`: resolveGarbageTypes の各パターンテスト（9ケース追加）

## Test plan
- [x] `./gradlew :shared:jvmTest --tests "model.GarbageScheduleTest"` 通過
- [ ] `./dev.sh frontend restart` で反映確認
- [ ] 10時以降にブラウザで翌日のゴミが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)