### PR TITLE
Firebase config をサーバー API 経由で動的配信する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ FIREBASE_MESSAGING_SENDER_ID=000000000000
 FIREBASE_APP_ID=1:000000000000:web:xxxxxxxxxxxx
 
 # Firebase サービスアカウント（任意、デフォルト: firebase-service-account.json）
+# Docker 環境ではボリュームマウント先に合わせて設定する（例: /app/firebase-service-account.json）
 # FIREBASE_SERVICE_ACCOUNT_PATH=firebase-service-account.json
 
 # Passkey DB（任意、デフォルト: data/passkey.db）

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,14 @@ WEBAUTHN_ORIGIN=http://localhost:8080,http://localhost:3000
 # GEMINI_API_KEY=your-api-key
 # GEMINI_MODEL=gemini-2.5-flash
 
+# Firebase クライアント設定（必須、フロントエンドの Firebase 初期化に使用）
+FIREBASE_API_KEY=your-api-key
+FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+FIREBASE_PROJECT_ID=your-project-id
+FIREBASE_STORAGE_BUCKET=your-project.firebasestorage.app
+FIREBASE_MESSAGING_SENDER_ID=000000000000
+FIREBASE_APP_ID=1:000000000000:web:xxxxxxxxxxxx
+
 # Firebase サービスアカウント（任意、デフォルト: firebase-service-account.json）
 # FIREBASE_SERVICE_ACCOUNT_PATH=firebase-service-account.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ kotlin-js-store/
 
 # Firebase
 firebase-service-account.json
+firebase-config.js
 
 # Local data (SQLite DB etc.)
 data/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,12 @@ cp .env.example .env
 
 | 変数 | 説明 | 必須 |
 |------|------|------|
+| `FIREBASE_API_KEY` | Firebase クライアント API キー | はい |
+| `FIREBASE_AUTH_DOMAIN` | Firebase Auth ドメイン（例: `your-project.firebaseapp.com`） | はい |
+| `FIREBASE_PROJECT_ID` | Firebase プロジェクト ID | はい |
+| `FIREBASE_STORAGE_BUCKET` | Firebase Storage バケット | はい |
+| `FIREBASE_MESSAGING_SENDER_ID` | Firebase Cloud Messaging 送信者 ID | はい |
+| `FIREBASE_APP_ID` | Firebase アプリ ID | はい |
 | `WEBAUTHN_RP_ID` | WebAuthn の Relying Party ID（開発時は `localhost`） | はい |
 | `WEBAUTHN_ORIGIN` | WebAuthn の許可オリジン（カンマ区切り） | はい |
 | `GEMINI_API_KEY` | Google AI Studio の API キー（クエスト AI テキスト生成用） | いいえ（未設定時は AI 生成ボタン非表示） |

--- a/README.md
+++ b/README.md
@@ -235,9 +235,9 @@ services:
   crabshell:
     image: ghcr.io/ptknktq/crabshell:latest
     container_name: crabshell
-    env_file: .env
+    env_file: .env  # environment: は env_file より優先される
     environment:
-      - FIREBASE_SERVICE_ACCOUNT_PATH=/app/firebase-service-account.json
+      - FIREBASE_SERVICE_ACCOUNT_PATH=/app/firebase-service-account.json  # コンテナ内パスに上書き
     volumes:
       - ./firebase-service-account.json:/app/firebase-service-account.json:ro
       - app-data:/app/data

--- a/README.md
+++ b/README.md
@@ -235,9 +235,7 @@ services:
   crabshell:
     image: ghcr.io/ptknktq/crabshell:latest
     container_name: crabshell
-    env_file: .env  # environment: は env_file より優先される
-    environment:
-      - FIREBASE_SERVICE_ACCOUNT_PATH=/app/firebase-service-account.json  # コンテナ内パスに上書き
+    env_file: .env
     volumes:
       - ./firebase-service-account.json:/app/firebase-service-account.json:ro
       - app-data:/app/data

--- a/README.md
+++ b/README.md
@@ -235,11 +235,9 @@ services:
   crabshell:
     image: ghcr.io/ptknktq/crabshell:latest
     container_name: crabshell
+    env_file: .env
     environment:
       - FIREBASE_SERVICE_ACCOUNT_PATH=/app/firebase-service-account.json
-      - WEBAUTHN_RP_ID=${WEBAUTHN_RP_ID}
-      - WEBAUTHN_ORIGIN=${WEBAUTHN_ORIGIN}
-      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
     volumes:
       - ./firebase-service-account.json:/app/firebase-service-account.json:ro
       - app-data:/app/data
@@ -352,6 +350,12 @@ node -e "
 
 | 変数 | 必須 | 説明 |
 |-----|------|------|
+| `FIREBASE_API_KEY` | **必須** | Firebase クライアント API キー |
+| `FIREBASE_AUTH_DOMAIN` | **必須** | Firebase Auth ドメイン（例: `your-project.firebaseapp.com`） |
+| `FIREBASE_PROJECT_ID` | **必須** | Firebase プロジェクト ID |
+| `FIREBASE_STORAGE_BUCKET` | **必須** | Firebase Storage バケット |
+| `FIREBASE_MESSAGING_SENDER_ID` | **必須** | Firebase Cloud Messaging 送信者 ID |
+| `FIREBASE_APP_ID` | **必須** | Firebase アプリ ID |
 | `FIREBASE_SERVICE_ACCOUNT_PATH` | | Firebase サービスアカウントキー（デフォルト: `firebase-service-account.json`） |
 | `WEBAUTHN_RP_ID` | **必須** | Relying Party ID（例: `localhost`, `example.com`） |
 | `WEBAUTHN_ORIGIN` | **必須** | 許可するオリジン（カンマ区切り。例: `https://example.com`） |

--- a/app/src/wasmJsMain/resources/firebase-config.js
+++ b/app/src/wasmJsMain/resources/firebase-config.js
@@ -1,9 +1,0 @@
-var firebaseConfig = {
-    apiKey: "AIzaSyBZkmr4YzzA57mph_CfUrmolEsPeLPTaEY",
-    authDomain: "crabshell-d0206.firebaseapp.com",
-    projectId: "crabshell-d0206",
-    storageBucket: "crabshell-d0206.firebasestorage.app",
-    messagingSenderId: "642027990476",
-    appId: "1:642027990476:web:326d78c90b8fa515c8c169",
-};
-firebase.initializeApp(firebaseConfig);

--- a/app/src/wasmJsMain/resources/index.html
+++ b/app/src/wasmJsMain/resources/index.html
@@ -35,7 +35,7 @@
 </div>
 <script src="https://www.gstatic.com/firebasejs/10.14.1/firebase-app-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/10.14.1/firebase-auth-compat.js"></script>
-<script src="firebase-config.js"></script>
+<script src="/api/firebase-config.js"></script>
 <script src="app.js"></script>
 </body>
 </html>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,7 @@ services:
       resources:
         limits:
           memory: 512m
-    environment:
-      - FIREBASE_SERVICE_ACCOUNT_PATH=/app/firebase-service-account.json
-      - WEBAUTHN_RP_ID=${WEBAUTHN_RP_ID:?WEBAUTHN_RP_ID is required}
-      - WEBAUTHN_ORIGIN=${WEBAUTHN_ORIGIN:?WEBAUTHN_ORIGIN is required}
-      # - PASSKEY_DB_PATH=/app/data/passkey.db
+    env_file: .env
     volumes:
       - ./firebase-service-account.json:/app/firebase-service-account.json:ro
     logging:

--- a/server/src/main/kotlin/server/Application.kt
+++ b/server/src/main/kotlin/server/Application.kt
@@ -33,6 +33,7 @@ import server.auth.configureAuth
 import server.auth.firebasePrincipal
 import server.cache.cacheRoutes
 import server.config.EnvConfig
+import server.config.firebaseConfigRoute
 import server.di.serverModule
 import server.feeding.FeedingReminderService
 import server.feeding.feedingRoutes
@@ -149,6 +150,7 @@ fun Application.module() {
         }
 
         route("/api") {
+            firebaseConfigRoute()
             userRoutes()
             petRoutes()
             feedingRoutes()
@@ -170,8 +172,7 @@ fun Application.module() {
                 when {
                     // エントリーポイント: 毎回サーバーに再検証（ETag/304）
                     path.endsWith("index.html") ||
-                        path.endsWith("app.js") ||
-                        path.endsWith("firebase-config.js") ->
+                        path.endsWith("app.js") ->
                         listOf(CacheControl.NoCache(null))
                     // ハッシュ付きファイル（チャンク JS, WASM, フォント等）: 1年キャッシュ
                     else ->

--- a/server/src/main/kotlin/server/config/FirebaseConfigRoute.kt
+++ b/server/src/main/kotlin/server/config/FirebaseConfigRoute.kt
@@ -4,29 +4,36 @@ import io.ktor.http.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 
+private val REQUIRED_KEYS =
+    listOf(
+        "FIREBASE_API_KEY",
+        "FIREBASE_AUTH_DOMAIN",
+        "FIREBASE_PROJECT_ID",
+        "FIREBASE_STORAGE_BUCKET",
+        "FIREBASE_MESSAGING_SENDER_ID",
+        "FIREBASE_APP_ID",
+    )
+
+private fun escapeJs(value: String): String = value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
+
 fun Route.firebaseConfigRoute() {
     get("/firebase-config.js") {
-        val apiKey = EnvConfig["FIREBASE_API_KEY"]
-        val authDomain = EnvConfig["FIREBASE_AUTH_DOMAIN"]
-        val projectId = EnvConfig["FIREBASE_PROJECT_ID"]
-        val storageBucket = EnvConfig["FIREBASE_STORAGE_BUCKET"]
-        val messagingSenderId = EnvConfig["FIREBASE_MESSAGING_SENDER_ID"]
-        val appId = EnvConfig["FIREBASE_APP_ID"]
-
-        if (apiKey == null || projectId == null) {
-            call.respond(HttpStatusCode.InternalServerError, "Firebase config is not set")
+        val config = REQUIRED_KEYS.associateWith { EnvConfig[it] }
+        val missing = config.filterValues { it == null }.keys
+        if (missing.isNotEmpty()) {
+            call.respond(HttpStatusCode.InternalServerError, "Missing Firebase config: ${missing.joinToString()}")
             return@get
         }
 
         val js =
             """
             var firebaseConfig = {
-                apiKey: "$apiKey",
-                authDomain: "$authDomain",
-                projectId: "$projectId",
-                storageBucket: "$storageBucket",
-                messagingSenderId: "$messagingSenderId",
-                appId: "$appId",
+                apiKey: "${escapeJs(config["FIREBASE_API_KEY"]!!)}",
+                authDomain: "${escapeJs(config["FIREBASE_AUTH_DOMAIN"]!!)}",
+                projectId: "${escapeJs(config["FIREBASE_PROJECT_ID"]!!)}",
+                storageBucket: "${escapeJs(config["FIREBASE_STORAGE_BUCKET"]!!)}",
+                messagingSenderId: "${escapeJs(config["FIREBASE_MESSAGING_SENDER_ID"]!!)}",
+                appId: "${escapeJs(config["FIREBASE_APP_ID"]!!)}",
             };
             firebase.initializeApp(firebaseConfig);
             """.trimIndent()

--- a/server/src/main/kotlin/server/config/FirebaseConfigRoute.kt
+++ b/server/src/main/kotlin/server/config/FirebaseConfigRoute.kt
@@ -38,6 +38,7 @@ fun Route.firebaseConfigRoute() {
             firebase.initializeApp(firebaseConfig);
             """.trimIndent()
 
+        call.response.header(HttpHeaders.CacheControl, "no-cache")
         call.respondText(js, ContentType("application", "javascript"))
     }
 }

--- a/server/src/main/kotlin/server/config/FirebaseConfigRoute.kt
+++ b/server/src/main/kotlin/server/config/FirebaseConfigRoute.kt
@@ -1,0 +1,36 @@
+package server.config
+
+import io.ktor.http.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+
+fun Route.firebaseConfigRoute() {
+    get("/firebase-config.js") {
+        val apiKey = EnvConfig["FIREBASE_API_KEY"]
+        val authDomain = EnvConfig["FIREBASE_AUTH_DOMAIN"]
+        val projectId = EnvConfig["FIREBASE_PROJECT_ID"]
+        val storageBucket = EnvConfig["FIREBASE_STORAGE_BUCKET"]
+        val messagingSenderId = EnvConfig["FIREBASE_MESSAGING_SENDER_ID"]
+        val appId = EnvConfig["FIREBASE_APP_ID"]
+
+        if (apiKey == null || projectId == null) {
+            call.respond(HttpStatusCode.InternalServerError, "Firebase config is not set")
+            return@get
+        }
+
+        val js =
+            """
+            var firebaseConfig = {
+                apiKey: "$apiKey",
+                authDomain: "$authDomain",
+                projectId: "$projectId",
+                storageBucket: "$storageBucket",
+                messagingSenderId: "$messagingSenderId",
+                appId: "$appId",
+            };
+            firebase.initializeApp(firebaseConfig);
+            """.trimIndent()
+
+        call.respondText(js, ContentType("application", "javascript"))
+    }
+}

--- a/server/src/main/kotlin/server/config/FirebaseConfigRoute.kt
+++ b/server/src/main/kotlin/server/config/FirebaseConfigRoute.kt
@@ -14,14 +14,22 @@ private val REQUIRED_KEYS =
         "FIREBASE_APP_ID",
     )
 
-private fun escapeJs(value: String): String = value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
+private fun escapeJs(value: String): String =
+    value
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("\n", "\\n")
+        .replace("</", "<\\/")
 
 fun Route.firebaseConfigRoute() {
     get("/firebase-config.js") {
         val config = REQUIRED_KEYS.associateWith { EnvConfig[it] }
         val missing = config.filterValues { it == null }.keys
         if (missing.isNotEmpty()) {
-            call.respond(HttpStatusCode.InternalServerError, "Missing Firebase config: ${missing.joinToString()}")
+            call.respondText(
+                "Missing Firebase config: ${missing.joinToString()}",
+                status = HttpStatusCode.InternalServerError,
+            )
             return@get
         }
 


### PR DESCRIPTION
## Summary
- `firebase-config.js` を静的ファイルから削除し、サーバーが `/api/firebase-config.js` で環境変数から動的に生成して配信するように変更
- `.env` に Firebase クライアント設定（`FIREBASE_API_KEY` 等 6 項目）を集約
- 同一コンテナイメージを `.env` の差し替えだけで dev/prod 両方で使えるようになる

## 変更内容
- `GET /api/firebase-config.js`: 環境変数から Firebase config JS を生成して返すエンドポイントを追加
- `index.html`: `<script src="firebase-config.js">` → `<script src="/api/firebase-config.js">` に変更（webpack プロキシ経由で dev でも動作）
- `firebase-config.js` を `.gitignore` に追加し、git 管理から除外
- `.env.example`、`CLAUDE.md`、`README.md` のドキュメント更新

## Test plan
- [x] `./gradlew :server:compileKotlin -PskipFrontend` ビルド成功
- [x] `curl http://localhost:8080/api/firebase-config.js` で正しい JS が返ることを確認
- [ ] ブラウザで Firebase 認証が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)