### PR TITLE
設定画面をカテゴリ選択ベースのナビゲーションに改修

### DIFF
--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -354,7 +354,7 @@ internal fun SettingsContent(
                 categories = categories,
                 selectedCategory = selectedCategory,
                 onSelectCategory = { selectedCategory = it },
-                modifier = Modifier.width(280.dp).fillMaxHeight().padding(24.dp),
+                modifier = Modifier.width(320.dp).fillMaxHeight().padding(24.dp),
             )
 
             VerticalDivider()
@@ -450,7 +450,10 @@ private fun CategoryItem(
                 tint = contentColor,
                 modifier = Modifier.size(24.dp),
             )
-            Column(modifier = Modifier.weight(1f)) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
                 Text(
                     text = category.title,
                     style = MaterialTheme.typography.bodyLarge,

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -450,14 +450,15 @@ private fun CategoryItem(
                 tint = contentColor,
                 modifier = Modifier.size(24.dp),
             )
-            Text(
-                text = category.title,
-                style = MaterialTheme.typography.bodyLarge,
-                color = contentColor,
-                modifier = Modifier.weight(1f),
-            )
-            if (category.adminOnly) {
-                AdminBadge()
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = category.title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = contentColor,
+                )
+                if (category.adminOnly) {
+                    AdminBadge()
+                }
             }
             Icon(
                 imageVector = Icons.Default.ChevronRight,

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -4,14 +4,22 @@ import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Cached
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.Fingerprint
+import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -37,6 +45,18 @@ import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 private val dayLabels = listOf("日", "月", "火", "水", "木", "金", "土")
+
+internal enum class SettingsCategory(
+    val title: String,
+    val icon: ImageVector,
+    val adminOnly: Boolean = false,
+) {
+    Account("アカウント", Icons.Default.Person),
+    UserManagement("ユーザー管理", Icons.Default.Group, adminOnly = true),
+    Garbage("ゴミ出し", Icons.Default.DeleteSweep, adminOnly = true),
+    Webhook("Webhook 通知", Icons.Default.Notifications, adminOnly = true),
+    Cache("サーバーキャッシュ", Icons.Default.Cached, adminOnly = true),
+}
 
 @Composable
 fun SettingsScreen(
@@ -199,20 +219,12 @@ internal fun SettingsContent(
     windowSizeClass: WindowSizeClass = WindowSizeClass.Expanded,
 ) {
     val isCompact = windowSizeClass == WindowSizeClass.Compact
+    val categories = SettingsCategory.entries.filter { !it.adminOnly || isAdmin }
+    var selectedCategory by remember { mutableStateOf<SettingsCategory?>(if (isCompact) null else categories.first()) }
 
-    Box(modifier = Modifier.fillMaxSize()) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(if (isCompact) 16.dp else 24.dp)
-                    .verticalScroll(scrollState),
-            horizontalAlignment = if (isCompact) Alignment.Start else Alignment.CenterHorizontally,
-        ) {
-            val cardModifier = if (isCompact) Modifier.fillMaxWidth() else Modifier.widthIn(max = 480.dp)
-
-            // アカウントセクション
-            SettingsSection(title = "アカウント") {
+    val categoryContent: @Composable (SettingsCategory, Modifier) -> Unit = { category, cardModifier ->
+        when (category) {
+            SettingsCategory.Account -> {
                 PasswordChangeCard(
                     currentPassword = currentPassword,
                     newPassword = newPassword,
@@ -237,101 +249,154 @@ internal fun SettingsContent(
                     )
                 }
             }
+            SettingsCategory.UserManagement -> {
+                UserNameManagementCard(
+                    isLoading = usersLoading,
+                    loadError = usersLoadError,
+                    loadErrorMessage = usersLoadErrorMessage,
+                    users = users,
+                    usersSaving = usersSaving,
+                    usersMessage = usersMessage,
+                    onUpdateDisplayName = onUpdateDisplayName,
+                    onRetry = onRetryUsers,
+                    modifier = cardModifier,
+                )
+            }
+            SettingsCategory.Garbage -> {
+                GarbageScheduleCard(
+                    isLoading = garbageLoading,
+                    loadError = garbageLoadError,
+                    loadErrorMessage = garbageLoadErrorMessage,
+                    schedules = garbageSchedules,
+                    garbageMessage = garbageMessage,
+                    garbageSaving = garbageSaving,
+                    onToggleDay = onToggleDay,
+                    onFrequencyChange = onFrequencyChange,
+                    onSaveClick = onSaveGarbageSchedule,
+                    onRetry = onRetryGarbageSchedule,
+                    modifier = cardModifier,
+                )
+                GarbageNotificationCard(
+                    isLoading = garbageNotificationLoading,
+                    loadError = garbageNotificationLoadError,
+                    loadErrorMessage = garbageNotificationLoadErrorMessage,
+                    enabled = garbageNotificationEnabled,
+                    webhookUrl = garbageNotificationWebhookUrl,
+                    notifyHour = garbageNotificationHour,
+                    prefix = garbageNotificationPrefix,
+                    isSaving = garbageNotificationSaving,
+                    isHourValid = garbageNotificationHourValid,
+                    message = garbageNotificationMessage,
+                    onEnabledChanged = onGarbageNotificationEnabledChanged,
+                    onWebhookUrlChanged = onGarbageNotificationWebhookUrlChanged,
+                    onNotifyHourChanged = onGarbageNotificationHourChanged,
+                    onPrefixChanged = onGarbageNotificationPrefixChanged,
+                    onSave = onSaveGarbageNotification,
+                    onRetry = onRetryGarbageNotification,
+                    modifier = cardModifier,
+                )
+            }
+            SettingsCategory.Webhook -> {
+                WebhookSettingsCard(
+                    isLoading = webhookLoading,
+                    loadError = webhookLoadError,
+                    loadErrorMessage = webhookLoadErrorMessage,
+                    url = webhookUrl,
+                    enabled = webhookEnabled,
+                    events = webhookEvents,
+                    isSaving = webhookSaving,
+                    message = webhookMessage,
+                    onUrlChanged = onWebhookUrlChanged,
+                    onEnabledChanged = onWebhookEnabledChanged,
+                    onToggleEvent = onWebhookToggleEvent,
+                    onSave = onSaveWebhook,
+                    onRetry = onRetryWebhook,
+                    modifier = cardModifier,
+                )
+            }
+            SettingsCategory.Cache -> {
+                CacheRefreshCard(
+                    isClearing = cacheClearing,
+                    message = cacheMessage,
+                    onClearCache = onClearCache,
+                    modifier = cardModifier,
+                )
+            }
+        }
+    }
 
-            if (isAdmin) {
-                Spacer(modifier = Modifier.height(32.dp))
+    if (isCompact) {
+        // Compact: カテゴリリスト ↔ カテゴリ詳細の切り替え
+        val selected = selectedCategory
+        if (selected == null) {
+            CategoryListPane(
+                categories = categories,
+                selectedCategory = null,
+                onSelectCategory = { selectedCategory = it },
+                modifier = Modifier.fillMaxSize().padding(16.dp),
+            )
+        } else {
+            CategoryDetailPane(
+                category = selected,
+                scrollState = scrollState,
+                showBackButton = true,
+                onBack = { selectedCategory = null },
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                categoryContent(selected, Modifier.fillMaxWidth())
+            }
+        }
+    } else {
+        // Medium / Expanded: 左カテゴリリスト + 右詳細の2ペイン
+        Row(modifier = Modifier.fillMaxSize()) {
+            CategoryListPane(
+                categories = categories,
+                selectedCategory = selectedCategory,
+                onSelectCategory = { selectedCategory = it },
+                modifier = Modifier.width(280.dp).fillMaxHeight().padding(24.dp),
+            )
 
-                // ユーザー名管理セクション（管理者のみ）
-                SettingsSection(title = "ユーザー名管理", showAdminBadge = true) {
-                    UserNameManagementCard(
-                        isLoading = usersLoading,
-                        loadError = usersLoadError,
-                        loadErrorMessage = usersLoadErrorMessage,
-                        users = users,
-                        usersSaving = usersSaving,
-                        usersMessage = usersMessage,
-                        onUpdateDisplayName = onUpdateDisplayName,
-                        onRetry = onRetryUsers,
-                        modifier = cardModifier,
-                    )
-                }
+            VerticalDivider()
 
-                Spacer(modifier = Modifier.height(32.dp))
+            val selected = selectedCategory ?: categories.first()
+            CategoryDetailPane(
+                category = selected,
+                scrollState = scrollState,
+                showBackButton = false,
+                onBack = {},
+                modifier = Modifier.weight(1f).fillMaxHeight(),
+            ) {
+                categoryContent(selected, Modifier.widthIn(max = 480.dp))
+            }
+        }
+    }
+}
 
-                // ゴミ出しセクション（管理者のみ）
-                SettingsSection(title = "ゴミ出し", showAdminBadge = true) {
-                    GarbageScheduleCard(
-                        isLoading = garbageLoading,
-                        loadError = garbageLoadError,
-                        loadErrorMessage = garbageLoadErrorMessage,
-                        schedules = garbageSchedules,
-                        garbageMessage = garbageMessage,
-                        garbageSaving = garbageSaving,
-                        onToggleDay = onToggleDay,
-                        onFrequencyChange = onFrequencyChange,
-                        onSaveClick = onSaveGarbageSchedule,
-                        onRetry = onRetryGarbageSchedule,
-                        modifier = cardModifier,
-                    )
-                    GarbageNotificationCard(
-                        isLoading = garbageNotificationLoading,
-                        loadError = garbageNotificationLoadError,
-                        loadErrorMessage = garbageNotificationLoadErrorMessage,
-                        enabled = garbageNotificationEnabled,
-                        webhookUrl = garbageNotificationWebhookUrl,
-                        notifyHour = garbageNotificationHour,
-                        prefix = garbageNotificationPrefix,
-                        isSaving = garbageNotificationSaving,
-                        isHourValid = garbageNotificationHourValid,
-                        message = garbageNotificationMessage,
-                        onEnabledChanged = onGarbageNotificationEnabledChanged,
-                        onWebhookUrlChanged = onGarbageNotificationWebhookUrlChanged,
-                        onNotifyHourChanged = onGarbageNotificationHourChanged,
-                        onPrefixChanged = onGarbageNotificationPrefixChanged,
-                        onSave = onSaveGarbageNotification,
-                        onRetry = onRetryGarbageNotification,
-                        modifier = cardModifier,
-                    )
-                }
+@Composable
+private fun CategoryListPane(
+    categories: List<SettingsCategory>,
+    selectedCategory: SettingsCategory?,
+    onSelectCategory: (SettingsCategory) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val listScrollState = rememberScrollState()
 
-                Spacer(modifier = Modifier.height(32.dp))
-
-                // Webhook 設定セクション（管理者のみ）
-                SettingsSection(title = "Webhook 通知", showAdminBadge = true) {
-                    WebhookSettingsCard(
-                        isLoading = webhookLoading,
-                        loadError = webhookLoadError,
-                        loadErrorMessage = webhookLoadErrorMessage,
-                        url = webhookUrl,
-                        enabled = webhookEnabled,
-                        events = webhookEvents,
-                        isSaving = webhookSaving,
-                        message = webhookMessage,
-                        onUrlChanged = onWebhookUrlChanged,
-                        onEnabledChanged = onWebhookEnabledChanged,
-                        onToggleEvent = onWebhookToggleEvent,
-                        onSave = onSaveWebhook,
-                        onRetry = onRetryWebhook,
-                        modifier = cardModifier,
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(32.dp))
-
-                // サーバーキャッシュセクション（管理者のみ）
-                SettingsSection(title = "サーバーキャッシュ", showAdminBadge = true) {
-                    CacheRefreshCard(
-                        isClearing = cacheClearing,
-                        message = cacheMessage,
-                        onClearCache = onClearCache,
-                        modifier = cardModifier,
-                    )
-                }
+    Box(modifier = modifier) {
+        Column(
+            modifier = Modifier.fillMaxSize().verticalScroll(listScrollState),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            categories.forEach { category ->
+                CategoryItem(
+                    category = category,
+                    isSelected = category == selectedCategory,
+                    onClick = { onSelectCategory(category) },
+                )
             }
         }
 
         VerticalScrollbar(
-            adapter = rememberScrollbarAdapter(scrollState),
+            adapter = rememberScrollbarAdapter(listScrollState),
             modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
             style =
                 ScrollbarStyle(
@@ -347,27 +412,126 @@ internal fun SettingsContent(
 }
 
 @Composable
-private fun SettingsSection(
-    title: String,
-    showAdminBadge: Boolean = false,
-    content: @Composable ColumnScope.() -> Unit,
+private fun CategoryItem(
+    category: SettingsCategory,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    val containerColor =
+        if (isSelected) {
+            MaterialTheme.colorScheme.secondaryContainer
+        } else {
+            MaterialTheme.colorScheme.surface
+        }
+    val contentColor =
+        if (isSelected) {
+            MaterialTheme.colorScheme.onSecondaryContainer
+        } else {
+            MaterialTheme.colorScheme.onSurface
+        }
+
+    Surface(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        color = containerColor,
+    ) {
         Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.primary,
+            Icon(
+                imageVector = category.icon,
+                contentDescription = null,
+                tint = contentColor,
+                modifier = Modifier.size(24.dp),
             )
-            if (showAdminBadge) {
+            Text(
+                text = category.title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = contentColor,
+                modifier = Modifier.weight(1f),
+            )
+            if (category.adminOnly) {
                 AdminBadge()
             }
+            Icon(
+                imageVector = Icons.Default.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
         }
-        content()
+    }
+}
+
+@Composable
+private fun CategoryDetailPane(
+    category: SettingsCategory,
+    scrollState: ScrollState,
+    showBackButton: Boolean,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Box(modifier = modifier) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(24.dp)
+                    .verticalScroll(scrollState),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // ヘッダー（戻るボタン + タイトル）
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                if (showBackButton) {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "戻る",
+                        )
+                    }
+                }
+                Icon(
+                    imageVector = category.icon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp),
+                )
+                Text(
+                    text = category.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                if (category.adminOnly) {
+                    AdminBadge()
+                }
+            }
+            content()
+        }
+
+        VerticalScrollbar(
+            adapter = rememberScrollbarAdapter(scrollState),
+            modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
+            style =
+                ScrollbarStyle(
+                    minimalHeight = 48.dp,
+                    thickness = 8.dp,
+                    shape = MaterialTheme.shapes.small,
+                    hoverDurationMillis = 300,
+                    unhoverColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                    hoverColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                ),
+        )
     }
 }
 

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -228,14 +228,14 @@ internal fun SettingsContent(
 ) {
     val isCompact = windowSizeClass == WindowSizeClass.Compact
     val categories = SettingsCategory.entries.filter { !it.adminOnly || isAdmin }
-    var selectedCategory by remember { mutableStateOf<SettingsCategory?>(if (isCompact) null else categories.first()) }
+    var selectedCategory by remember { mutableStateOf<SettingsCategory?>(if (isCompact) null else categories.firstOrNull()) }
 
     // Compact ↔ Expanded 切り替え時に selectedCategory を適切にリセット
     LaunchedEffect(isCompact) {
         if (isCompact) {
             selectedCategory = null
         } else if (selectedCategory == null) {
-            selectedCategory = categories.first()
+            selectedCategory = categories.firstOrNull()
         }
     }
 
@@ -386,18 +386,20 @@ internal fun SettingsContent(
 
             VerticalDivider()
 
-            val selected = selectedCategory ?: categories.first()
-            key(selected) {
-                val detailScrollState = rememberScrollState()
-                CategoryDetailPane(
-                    category = selected,
-                    scrollState = detailScrollState,
-                    showBackButton = false,
-                    onBack = {},
-                    modifier = Modifier.weight(1f).fillMaxHeight(),
-                    contentModifier = Modifier.widthIn(max = 480.dp),
-                ) {
-                    categoryContent(selected, Modifier.widthIn(max = 480.dp))
+            val selected = selectedCategory ?: categories.firstOrNull()
+            if (selected != null) {
+                key(selected) {
+                    val detailScrollState = rememberScrollState()
+                    CategoryDetailPane(
+                        category = selected,
+                        scrollState = detailScrollState,
+                        showBackButton = false,
+                        onBack = {},
+                        modifier = Modifier.weight(1f).fillMaxHeight(),
+                        contentModifier = Modifier.widthIn(max = 480.dp),
+                    ) {
+                        categoryContent(selected, Modifier.widthIn(max = 480.dp))
+                    }
                 }
             }
         }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -46,6 +46,17 @@ import org.koin.compose.viewmodel.koinViewModel
 
 private val dayLabels = listOf("日", "月", "火", "水", "木", "金", "土")
 
+@Composable
+private fun settingsScrollbarStyle() =
+    ScrollbarStyle(
+        minimalHeight = 48.dp,
+        thickness = 8.dp,
+        shape = MaterialTheme.shapes.small,
+        hoverDurationMillis = 300,
+        unhoverColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+        hoverColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+    )
+
 internal enum class SettingsCategory(
     val title: String,
     val icon: ImageVector,
@@ -218,6 +229,22 @@ internal fun SettingsContent(
     val isCompact = windowSizeClass == WindowSizeClass.Compact
     val categories = SettingsCategory.entries.filter { !it.adminOnly || isAdmin }
     var selectedCategory by remember { mutableStateOf<SettingsCategory?>(if (isCompact) null else categories.first()) }
+
+    // Compact ↔ Expanded 切り替え時に selectedCategory を適切にリセット
+    LaunchedEffect(isCompact) {
+        if (isCompact) {
+            selectedCategory = null
+        } else if (selectedCategory == null) {
+            selectedCategory = categories.first()
+        }
+    }
+
+    // isAdmin 変化等で categories から selectedCategory が除外された場合にリセット
+    LaunchedEffect(categories) {
+        if (selectedCategory != null && selectedCategory !in categories) {
+            selectedCategory = if (isCompact) null else categories.firstOrNull()
+        }
+    }
 
     val categoryContent: @Composable (SettingsCategory, Modifier) -> Unit = { category, cardModifier ->
         when (category) {
@@ -403,15 +430,7 @@ private fun CategoryListPane(
         VerticalScrollbar(
             adapter = rememberScrollbarAdapter(listScrollState),
             modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
-            style =
-                ScrollbarStyle(
-                    minimalHeight = 48.dp,
-                    thickness = 8.dp,
-                    shape = MaterialTheme.shapes.small,
-                    hoverDurationMillis = 300,
-                    unhoverColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
-                    hoverColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
-                ),
+            style = settingsScrollbarStyle(),
         )
     }
 }
@@ -532,15 +551,7 @@ private fun CategoryDetailPane(
         VerticalScrollbar(
             adapter = rememberScrollbarAdapter(scrollState),
             modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
-            style =
-                ScrollbarStyle(
-                    minimalHeight = 48.dp,
-                    thickness = 8.dp,
-                    shape = MaterialTheme.shapes.small,
-                    hoverDurationMillis = 300,
-                    unhoverColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
-                    hoverColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
-                ),
+            style = settingsScrollbarStyle(),
         )
     }
 }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -342,6 +342,7 @@ internal fun SettingsContent(
                 showBackButton = true,
                 onBack = { selectedCategory = null },
                 modifier = Modifier.fillMaxSize(),
+                contentModifier = Modifier.fillMaxWidth(),
             ) {
                 categoryContent(selected, Modifier.fillMaxWidth())
             }
@@ -365,6 +366,7 @@ internal fun SettingsContent(
                 showBackButton = false,
                 onBack = {},
                 modifier = Modifier.weight(1f).fillMaxHeight(),
+                contentModifier = Modifier.widthIn(max = 480.dp),
             ) {
                 categoryContent(selected, Modifier.widthIn(max = 480.dp))
             }
@@ -474,6 +476,7 @@ private fun CategoryDetailPane(
     showBackButton: Boolean,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
+    contentModifier: Modifier = Modifier,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Box(modifier = modifier) {
@@ -488,7 +491,7 @@ private fun CategoryDetailPane(
         ) {
             // ヘッダー（戻るボタン + タイトル）
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = contentModifier,
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -70,11 +70,9 @@ fun SettingsScreen(
     val garbageVm = remember(isAdmin) { if (isAdmin) koin.get<GarbageScheduleViewModel>() else null }
     val webhookVm = remember(isAdmin) { if (isAdmin) koin.get<WebhookViewModel>() else null }
     val cacheVm = remember(isAdmin) { if (isAdmin) koin.get<CacheRefreshViewModel>() else null }
-    val scrollState = rememberScrollState()
     val windowSizeClass = LocalWindowSizeClass.current
 
     SettingsContent(
-        scrollState = scrollState,
         isAdmin = isAdmin,
         currentPassword = passwordVm.uiState.currentPassword,
         newPassword = passwordVm.uiState.newPassword,
@@ -148,7 +146,6 @@ fun SettingsScreen(
 
 @Composable
 internal fun SettingsContent(
-    scrollState: ScrollState,
     isAdmin: Boolean,
     currentPassword: String,
     newPassword: String,
@@ -336,15 +333,18 @@ internal fun SettingsContent(
                 modifier = Modifier.fillMaxSize().padding(16.dp),
             )
         } else {
-            CategoryDetailPane(
-                category = selected,
-                scrollState = scrollState,
-                showBackButton = true,
-                onBack = { selectedCategory = null },
-                modifier = Modifier.fillMaxSize(),
-                contentModifier = Modifier.fillMaxWidth(),
-            ) {
-                categoryContent(selected, Modifier.fillMaxWidth())
+            key(selected) {
+                val detailScrollState = rememberScrollState()
+                CategoryDetailPane(
+                    category = selected,
+                    scrollState = detailScrollState,
+                    showBackButton = true,
+                    onBack = { selectedCategory = null },
+                    modifier = Modifier.fillMaxSize(),
+                    contentModifier = Modifier.fillMaxWidth(),
+                ) {
+                    categoryContent(selected, Modifier.fillMaxWidth())
+                }
             }
         }
     } else {
@@ -360,15 +360,18 @@ internal fun SettingsContent(
             VerticalDivider()
 
             val selected = selectedCategory ?: categories.first()
-            CategoryDetailPane(
-                category = selected,
-                scrollState = scrollState,
-                showBackButton = false,
-                onBack = {},
-                modifier = Modifier.weight(1f).fillMaxHeight(),
-                contentModifier = Modifier.widthIn(max = 480.dp),
-            ) {
-                categoryContent(selected, Modifier.widthIn(max = 480.dp))
+            key(selected) {
+                val detailScrollState = rememberScrollState()
+                CategoryDetailPane(
+                    category = selected,
+                    scrollState = detailScrollState,
+                    showBackButton = false,
+                    onBack = {},
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                    contentModifier = Modifier.widthIn(max = 480.dp),
+                ) {
+                    categoryContent(selected, Modifier.widthIn(max = 480.dp))
+                }
             }
         }
     }
@@ -466,7 +469,7 @@ private fun CategoryItem(
             Icon(
                 imageVector = Icons.Default.ChevronRight,
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                tint = contentColor,
                 modifier = Modifier.size(20.dp),
             )
         }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -422,13 +422,13 @@ private fun CategoryItem(
 ) {
     val containerColor =
         if (isSelected) {
-            MaterialTheme.colorScheme.secondaryContainer
+            MaterialTheme.colorScheme.primaryContainer
         } else {
             MaterialTheme.colorScheme.surface
         }
     val contentColor =
         if (isSelected) {
-            MaterialTheme.colorScheme.onSecondaryContainer
+            MaterialTheme.colorScheme.onPrimaryContainer
         } else {
             MaterialTheme.colorScheme.onSurface
         }


### PR DESCRIPTION
## Summary
- 設定画面を「カテゴリ一覧 → カテゴリ詳細」のナビゲーション構造に改修
- Compact 画面: カテゴリリストと詳細画面の切り替え（戻るボタン付き）
- Medium / Expanded 画面: 左にカテゴリリスト、右に詳細の2ペインレイアウト
- カテゴリ: アカウント / ユーザー管理(Admin) / ゴミ出し(Admin) / Webhook通知(Admin) / サーバーキャッシュ(Admin)
- 詳細ペインのヘッダー幅をカード幅と揃えて統一感を確保
- 既存の Card コンポーネント（PasswordChangeCard 等）はそのまま活用
- カテゴリ切り替え時にスクロール位置をリセット（key による scrollState 再生成）
- Compact ↔ Expanded リサイズ時に selectedCategory を適切にリセット
- admin 状態変化時に admin-only カテゴリの選択状態を整合
- 選択状態の ChevronRight アイコン色を contentColor に統一
- ScrollbarStyle の重複を settingsScrollbarStyle() に共通化
- カテゴリ選択で `firstOrNull()` に統一し、将来的にカテゴリ構成が変わった場合の安全性を確保

## Test plan
- [ ] Compact 画面でカテゴリリスト → 各カテゴリ詳細 → 戻るボタンの遷移が正常に動作すること
- [ ] Medium / Expanded 画面で左ペインのカテゴリ選択 → 右ペインの内容切り替えが正常に動作すること
- [ ] 管理者ユーザーで全カテゴリが表示されること
- [ ] 一般ユーザーでアカウントカテゴリのみ表示されること
- [ ] 各カテゴリの設定操作（パスワード変更、パスキー登録、ゴミ出し設定等）が従来通り動作すること
- [ ] カテゴリ切り替え時にスクロール位置が先頭にリセットされること
- [ ] ブラウザウィンドウのリサイズ（Compact ↔ Expanded）で適切にナビゲーション状態がリセットされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)