### PR TITLE
お金の管理: 金額0円の項目登録を許可 & TextField外タップでフォーカス解除

### DIFF
--- a/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
+++ b/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
@@ -409,8 +409,9 @@ private fun MoneyItemForm(
         )
     }
 
-    val amount = amountText.toLongOrNull() ?: 0L
-    val isAmountValid = amountText.toLongOrNull() != null
+    val parsedAmount = amountText.toLongOrNull()
+    val isAmountValid = parsedAmount != null
+    val amount = parsedAmount ?: 0L
     val payments =
         paymentAmounts.mapNotNull { (uid, text) ->
             val a = text.toLongOrNull()

--- a/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
+++ b/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
@@ -410,6 +410,7 @@ private fun MoneyItemForm(
     }
 
     val amount = amountText.toLongOrNull() ?: 0L
+    val isAmountValid = amountText.toLongOrNull() != null
     val payments =
         paymentAmounts.mapNotNull { (uid, text) ->
             val a = text.toLongOrNull()
@@ -518,7 +519,7 @@ private fun MoneyItemForm(
                                         put(user.uid, (amount / 2).toString())
                                     }
                             },
-                            enabled = !saving && amountText.isNotBlank(),
+                            enabled = !saving && isAmountValid,
                             contentPadding = PaddingValues(horizontal = 8.dp),
                         ) {
                             Text("半額", style = MaterialTheme.typography.labelSmall)
@@ -530,7 +531,7 @@ private fun MoneyItemForm(
                                         put(user.uid, amount.toString())
                                     }
                             },
-                            enabled = !saving && amountText.isNotBlank(),
+                            enabled = !saving && isAmountValid,
                             contentPadding = PaddingValues(horizontal = 8.dp),
                         ) {
                             Text("全額", style = MaterialTheme.typography.labelSmall)
@@ -547,7 +548,7 @@ private fun MoneyItemForm(
                                         put(user.uid, (amount - othersTotal).toString())
                                     }
                             },
-                            enabled = !saving && amountText.isNotBlank(),
+                            enabled = !saving && isAmountValid,
                             contentPadding = PaddingValues(horizontal = 8.dp),
                         ) {
                             Text("残額", style = MaterialTheme.typography.labelSmall)
@@ -605,7 +606,7 @@ private fun MoneyItemForm(
                 Spacer(modifier = Modifier.width(8.dp))
                 Button(
                     onClick = { onSave(name, amount, note, payments, selectedTags) },
-                    enabled = name.isNotBlank() && amountText.isNotBlank() && !saving && !locked,
+                    enabled = name.isNotBlank() && isAmountValid && !saving && !locked,
                 ) {
                     Text(if (isEditing) "保存" else "追加")
                 }

--- a/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
+++ b/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
@@ -1,5 +1,6 @@
 package feature.money
 
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -19,6 +20,8 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -87,13 +90,21 @@ internal fun MoneyContent(
     val isCompact = windowSizeClass == WindowSizeClass.Compact
     // Compact 用: フォーム表示切替
     var showFormCompact by remember { mutableStateOf(false) }
+    val focusManager = LocalFocusManager.current
 
     // editingItem がクリアされたらフォームを閉じる（保存成功時）
     LaunchedEffect(editingItem) {
         if (editingItem == null) showFormCompact = false
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    detectTapGestures(onTap = { focusManager.clearFocus() })
+                },
+    ) {
         if (isCompact) {
             if (showFormCompact) {
                 // Compact: フォーム表示
@@ -507,7 +518,7 @@ private fun MoneyItemForm(
                                         put(user.uid, (amount / 2).toString())
                                     }
                             },
-                            enabled = !saving && amount != 0L,
+                            enabled = !saving && amountText.isNotBlank(),
                             contentPadding = PaddingValues(horizontal = 8.dp),
                         ) {
                             Text("半額", style = MaterialTheme.typography.labelSmall)
@@ -519,7 +530,7 @@ private fun MoneyItemForm(
                                         put(user.uid, amount.toString())
                                     }
                             },
-                            enabled = !saving && amount != 0L,
+                            enabled = !saving && amountText.isNotBlank(),
                             contentPadding = PaddingValues(horizontal = 8.dp),
                         ) {
                             Text("全額", style = MaterialTheme.typography.labelSmall)
@@ -536,7 +547,7 @@ private fun MoneyItemForm(
                                         put(user.uid, (amount - othersTotal).toString())
                                     }
                             },
-                            enabled = !saving && amount != 0L,
+                            enabled = !saving && amountText.isNotBlank(),
                             contentPadding = PaddingValues(horizontal = 8.dp),
                         ) {
                             Text("残額", style = MaterialTheme.typography.labelSmall)
@@ -594,7 +605,7 @@ private fun MoneyItemForm(
                 Spacer(modifier = Modifier.width(8.dp))
                 Button(
                     onClick = { onSave(name, amount, note, payments, selectedTags) },
-                    enabled = name.isNotBlank() && amount != 0L && !saving && !locked,
+                    enabled = name.isNotBlank() && amountText.isNotBlank() && !saving && !locked,
                 ) {
                     Text(if (isEditing) "保存" else "追加")
                 }


### PR DESCRIPTION
## Summary
- 金額0円の項目を登録可能に変更（金額未定だが項目として追加したいケースに対応）
- 保存ボタン・配分ボタン（半額/全額/残額）の有効条件を `amount != 0L` から `amountText.toLongOrNull() != null` に変更し、「未入力」「不正入力」と「意図的な0円」を区別
- お金の管理画面で TextField 外をタップするとフォーカスが外れるように改善

## Test plan
- [ ] 金額に `0` を入力して項目を追加できること
- [ ] 金額欄が空欄の場合は保存ボタンが無効のままであること
- [ ] 不正入力（`-` のみ等）の場合もボタンが無効であること
- [ ] 半額/全額/残額ボタンが金額入力済みで有効、空欄で無効であること
- [ ] TextField にフォーカスした状態で外側をクリックするとフォーカスが外れること
- [ ] 既存の金額入力・編集・削除が従来通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)