### PR TITLE
CD の並列ビルドを無効化して OOM を解消

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,7 @@ name: CD
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY core/ core/
 COPY feature/ feature/
 RUN gradle :server:buildFatJar --no-daemon \
     -Dorg.gradle.jvmargs="-Xmx2g -Dfile.encoding=UTF-8" \
-    -Dorg.gradle.workers.max=2
+    -Dorg.gradle.parallel=false
 
 FROM eclipse-temurin:21.0.10_7-jre-noble
 WORKDIR /app


### PR DESCRIPTION
## Overview
`v0.0.21` の CD が `:app:compileProductionExecutableKotlinWasmJs` の OOM で失敗していた問題を修正。

## Changes
- **Dockerfile:** `org.gradle.parallel=false` を追加し、Docker ビルド内でモジュールの並列コンパイルを無効化
- **Dockerfile:** 並列ビルド抑制により不要になった `workers.max=2` を削除
- **cd.yml:** `workflow_dispatch` トリガーを追加し、手動実行を可能に

## Note
- `gradle.properties` の `org.gradle.parallel=true` が Docker ビルド内でも有効なため、複数 feature/core モジュールの Kotlin コンパイルが同時に走りメモリを食い合っていた
- PR #174 で `workers.max=2` に制限したが、これは1タスク内のワーカー数の制限であり、タスク自体の並列実行（parallel）は別制御
- `parallel=false` にすることでモジュールが順次ビルドされ、メモリピークが大幅に下がる
- ローカル開発には影響なし（`gradle.properties` の設定はそのまま）

🤖 Generated with [Claude Code](https://claude.com/claude-code)