### PR TITLE
fix: タブ復帰時にダッシュボードの時刻・日付・ゴミ表示を即時更新

### DIFF
--- a/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
+++ b/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
@@ -18,6 +18,7 @@ import core.ui.util.todayDateJs
 import core.ui.util.tomorrowDayOfWeekIndexJs
 import core.ui.util.tomorrowWeekOfMonthJs
 import core.ui.util.weekOfMonthJs
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import model.FeedingLog
@@ -53,6 +54,7 @@ class DashboardViewModel(
     private var lastFeedingHalfHour = -1
     private var garbageRefreshedToday =
         (currentTimeJs().toString().substringBefore(":").toIntOrNull() ?: 0) >= GARBAGE_SWITCH_HOUR
+    private var pollingJob: Job? = null
 
     var uiState by mutableStateOf(
         DashboardUiState(
@@ -77,22 +79,30 @@ class DashboardViewModel(
         }
         loadGarbageSchedule()
         startDateChangePolling()
-        // バックグラウンド復帰時にタブ抑制で遅れた表示を即座に追い付かせ、給餌データも再取得
+        // バックグラウンド復帰時: ブラウザの throttle / freeze により遅れた表示を即座に追い付かせ、
+        // ポーリングも再起動して delay サイクルを確実にリセットする。
         viewModelScope.launch {
             tabResumedEvent.events.collect {
+                val feedingDateBefore = trackedFeedingDate
                 refreshClockAndSchedules()
-                onRefreshFeeding()
+                // 日跨ぎ復帰時は refreshClockAndSchedules 内で onRefreshFeeding が既に呼ばれているため二重起動を避ける
+                if (feedingDateBefore == trackedFeedingDate) {
+                    onRefreshFeeding()
+                }
+                startDateChangePolling()
             }
         }
     }
 
     private fun startDateChangePolling() {
-        viewModelScope.launch {
-            while (true) {
-                delay(10_000)
-                refreshClockAndSchedules()
+        pollingJob?.cancel()
+        pollingJob =
+            viewModelScope.launch {
+                while (true) {
+                    delay(10_000)
+                    refreshClockAndSchedules()
+                }
             }
-        }
     }
 
     /**

--- a/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
+++ b/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
@@ -77,9 +77,12 @@ class DashboardViewModel(
         }
         loadGarbageSchedule()
         startDateChangePolling()
-        // バックグラウンド復帰時（トークンリフレッシュ完了後）にデータ再取得
+        // バックグラウンド復帰時にタブ抑制で遅れた表示を即座に追い付かせ、給餌データも再取得
         viewModelScope.launch {
-            tabResumedEvent.events.collect { onRefreshFeeding() }
+            tabResumedEvent.events.collect {
+                tick()
+                onRefreshFeeding()
+            }
         }
     }
 
@@ -87,43 +90,47 @@ class DashboardViewModel(
         viewModelScope.launch {
             while (true) {
                 delay(10_000)
-                val timeStr = currentTimeJs().toString()
-                uiState = uiState.copy(currentTime = timeStr)
-                val newDate = todayDateJs().toString()
-                if (newDate != trackedDate) {
-                    trackedDate = newDate
-                    garbageRefreshedToday = false
-                    uiState =
-                        uiState.copy(
-                            currentYear = currentYearJs().toString(),
-                            dateWithDay = formattedTodayJs().toString(),
-                        )
-                    refreshGarbageForToday()
-                }
-                val newFeedingDate = feedingDateJs().toString()
-                if (newFeedingDate != trackedFeedingDate) {
-                    trackedFeedingDate = newFeedingDate
-                    onRefreshFeeding()
-                }
-                // 毎時0分・30分に給餌情報をサイレント更新
-                val minute = timeStr.substringAfter(":").toIntOrNull() ?: 0
-                val halfHour =
-                    timeStr
-                        .substringBefore(":")
-                        .toIntOrNull()
-                        ?.times(2)
-                        ?.plus(minute / 30) ?: 0
-                if (lastFeedingHalfHour != -1 && halfHour != lastFeedingHalfHour) {
-                    silentRefreshFeeding()
-                }
-                lastFeedingHalfHour = halfHour
-                // 更新時刻にゴミ出しスケジュールを再取得
-                val hour = timeStr.substringBefore(":").toIntOrNull() ?: 0
-                if (hour >= GARBAGE_SWITCH_HOUR && !garbageRefreshedToday) {
-                    garbageRefreshedToday = true
-                    loadGarbageSchedule()
-                }
+                tick()
             }
+        }
+    }
+
+    private suspend fun tick() {
+        val timeStr = currentTimeJs().toString()
+        uiState = uiState.copy(currentTime = timeStr)
+        val newDate = todayDateJs().toString()
+        if (newDate != trackedDate) {
+            trackedDate = newDate
+            garbageRefreshedToday = false
+            uiState =
+                uiState.copy(
+                    currentYear = currentYearJs().toString(),
+                    dateWithDay = formattedTodayJs().toString(),
+                )
+            refreshGarbageForToday()
+        }
+        val newFeedingDate = feedingDateJs().toString()
+        if (newFeedingDate != trackedFeedingDate) {
+            trackedFeedingDate = newFeedingDate
+            onRefreshFeeding()
+        }
+        // 毎時0分・30分に給餌情報をサイレント更新
+        val minute = timeStr.substringAfter(":").toIntOrNull() ?: 0
+        val halfHour =
+            timeStr
+                .substringBefore(":")
+                .toIntOrNull()
+                ?.times(2)
+                ?.plus(minute / 30) ?: 0
+        if (lastFeedingHalfHour != -1 && halfHour != lastFeedingHalfHour) {
+            silentRefreshFeeding()
+        }
+        lastFeedingHalfHour = halfHour
+        // 更新時刻にゴミ出しスケジュールを再取得
+        val hour = timeStr.substringBefore(":").toIntOrNull() ?: 0
+        if (hour >= GARBAGE_SWITCH_HOUR && !garbageRefreshedToday) {
+            garbageRefreshedToday = true
+            loadGarbageSchedule()
         }
     }
 

--- a/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
+++ b/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
@@ -19,6 +19,7 @@ import core.ui.util.tomorrowDayOfWeekIndexJs
 import core.ui.util.tomorrowWeekOfMonthJs
 import core.ui.util.weekOfMonthJs
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import model.FeedingLog
@@ -80,13 +81,13 @@ class DashboardViewModel(
         loadGarbageSchedule()
         startDateChangePolling()
         // バックグラウンド復帰時: ブラウザの throttle / freeze により遅れた表示を即座に追い付かせ、
-        // ポーリングも再起動して delay サイクルを確実にリセットする。
+        // ポーリングも cancelAndJoin で古いジョブを確実に停止してから再起動する。
         viewModelScope.launch {
             tabResumedEvent.events.collect {
-                val feedingDateBefore = trackedFeedingDate
-                refreshClockAndSchedules()
-                // 日跨ぎ復帰時は refreshClockAndSchedules 内で onRefreshFeeding が既に呼ばれているため二重起動を避ける
-                if (feedingDateBefore == trackedFeedingDate) {
+                pollingJob?.cancelAndJoin()
+                val feedingRefetched = refreshClockAndSchedules()
+                // refreshClockAndSchedules 内で日跨ぎ／半時間跨ぎ検知により再取得済みなら二重起動を避ける
+                if (!feedingRefetched) {
                     onRefreshFeeding()
                 }
                 startDateChangePolling()
@@ -95,9 +96,10 @@ class DashboardViewModel(
     }
 
     private fun startDateChangePolling() {
-        pollingJob?.cancel()
         pollingJob =
             viewModelScope.launch {
+                // ポーリング起点の即時同期は init 直後や TabResumedEvent ハンドラ側で行うため、
+                // ここでは delay から開始して 10 秒周期で refreshClockAndSchedules を繰り返すだけに留める。
                 while (true) {
                     delay(10_000)
                     refreshClockAndSchedules()
@@ -108,8 +110,11 @@ class DashboardViewModel(
     /**
      * 時刻カードを現在時刻に更新し、日付・給餌・ゴミの時刻依存スケジュールを同期する。
      * ポーリング（10 秒毎）とタブ復帰イベントの両方から呼ばれる。
+     *
+     * @return 内部で給餌ログの再取得（onRefreshFeeding / silentRefreshFeeding）を発火したか
      */
-    private suspend fun refreshClockAndSchedules() {
+    private suspend fun refreshClockAndSchedules(): Boolean {
+        var feedingRefetched = false
         val timeStr = currentTimeJs().toString()
         uiState = uiState.copy(currentTime = timeStr)
         val newDate = todayDateJs().toString()
@@ -127,6 +132,7 @@ class DashboardViewModel(
         if (newFeedingDate != trackedFeedingDate) {
             trackedFeedingDate = newFeedingDate
             onRefreshFeeding()
+            feedingRefetched = true
         }
         // 毎時0分・30分に給餌情報をサイレント更新
         val minute = timeStr.substringAfter(":").toIntOrNull() ?: 0
@@ -138,6 +144,7 @@ class DashboardViewModel(
                 ?.plus(minute / 30) ?: 0
         if (lastFeedingHalfHour != -1 && halfHour != lastFeedingHalfHour) {
             silentRefreshFeeding()
+            feedingRefetched = true
         }
         lastFeedingHalfHour = halfHour
         // 更新時刻にゴミ出しスケジュールを再取得
@@ -146,6 +153,7 @@ class DashboardViewModel(
             garbageRefreshedToday = true
             loadGarbageSchedule()
         }
+        return feedingRefetched
     }
 
     private suspend fun loadToday() {

--- a/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
+++ b/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
@@ -80,7 +80,7 @@ class DashboardViewModel(
         // バックグラウンド復帰時にタブ抑制で遅れた表示を即座に追い付かせ、給餌データも再取得
         viewModelScope.launch {
             tabResumedEvent.events.collect {
-                tick()
+                refreshClockAndSchedules()
                 onRefreshFeeding()
             }
         }
@@ -90,12 +90,16 @@ class DashboardViewModel(
         viewModelScope.launch {
             while (true) {
                 delay(10_000)
-                tick()
+                refreshClockAndSchedules()
             }
         }
     }
 
-    private suspend fun tick() {
+    /**
+     * 時刻カードを現在時刻に更新し、日付・給餌・ゴミの時刻依存スケジュールを同期する。
+     * ポーリング（10 秒毎）とタブ復帰イベントの両方から呼ばれる。
+     */
+    private suspend fun refreshClockAndSchedules() {
         val timeStr = currentTimeJs().toString()
         uiState = uiState.copy(currentTime = timeStr)
         val newDate = todayDateJs().toString()

--- a/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
+++ b/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
@@ -79,27 +79,24 @@ class DashboardViewModel(
             }
         }
         loadGarbageSchedule()
-        startDateChangePolling()
+        viewModelScope.launch { restartDateChangePolling() }
         // バックグラウンド復帰時: ブラウザの throttle / freeze により遅れた表示を即座に追い付かせ、
         // ポーリングも cancelAndJoin で古いジョブを確実に停止してから再起動する。
         viewModelScope.launch {
             tabResumedEvent.events.collect {
-                pollingJob?.cancelAndJoin()
                 refreshTimeAndGarbage()
                 onRefreshFeeding()
-                startDateChangePolling()
+                restartDateChangePolling()
             }
         }
     }
 
     /**
-     * ポーリングジョブを (再) 起動する。
-     *
-     * 呼び出し契約: 古いジョブが存在する場合は呼び出し側で `pollingJob?.cancelAndJoin()` を
-     * 完了してから呼ぶこと。本関数は cancel を行わないため、そのまま再呼び出しすると
-     * ジョブがリークする。
+     * ポーリングジョブを停止して再起動する。古いジョブが存在する場合は [cancelAndJoin] で
+     * 完了を待ってから新規ジョブを launch するため、呼び出し側は in-flight 競合を意識する必要がない。
      */
-    private fun startDateChangePolling() {
+    private suspend fun restartDateChangePolling() {
+        pollingJob?.cancelAndJoin()
         pollingJob =
             viewModelScope.launch {
                 // ポーリング起点の即時同期は init 時の uiState 初期値 / TabResumedEvent ハンドラ側で担当するため、

--- a/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
+++ b/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
@@ -95,6 +95,13 @@ class DashboardViewModel(
         }
     }
 
+    /**
+     * ポーリングジョブを (再) 起動する。
+     *
+     * 呼び出し契約: 古いジョブが存在する場合は呼び出し側で `pollingJob?.cancelAndJoin()` を
+     * 完了してから呼ぶこと。本関数は cancel を行わないため、そのまま再呼び出しすると
+     * ジョブがリークする。
+     */
     private fun startDateChangePolling() {
         pollingJob =
             viewModelScope.launch {

--- a/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
+++ b/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
@@ -85,11 +85,8 @@ class DashboardViewModel(
         viewModelScope.launch {
             tabResumedEvent.events.collect {
                 pollingJob?.cancelAndJoin()
-                val feedingRefetched = refreshClockAndSchedules()
-                // refreshClockAndSchedules 内で日跨ぎ／半時間跨ぎ検知により再取得済みなら二重起動を避ける
-                if (!feedingRefetched) {
-                    onRefreshFeeding()
-                }
+                refreshTimeAndGarbage()
+                onRefreshFeeding()
                 startDateChangePolling()
             }
         }
@@ -105,23 +102,18 @@ class DashboardViewModel(
     private fun startDateChangePolling() {
         pollingJob =
             viewModelScope.launch {
-                // ポーリング起点の即時同期は init 直後や TabResumedEvent ハンドラ側で行うため、
-                // ここでは delay から開始して 10 秒周期で refreshClockAndSchedules を繰り返すだけに留める。
+                // ポーリング起点の即時同期は init 時の uiState 初期値 / TabResumedEvent ハンドラ側で担当するため、
+                // ここは delay から開始し、10 秒周期で時刻・ゴミ・給餌のカードを同期するだけに留める。
                 while (true) {
                     delay(10_000)
-                    refreshClockAndSchedules()
+                    refreshTimeAndGarbage()
+                    autoRefreshFeedingOnTick()
                 }
             }
     }
 
-    /**
-     * 時刻カードを現在時刻に更新し、日付・給餌・ゴミの時刻依存スケジュールを同期する。
-     * ポーリング（10 秒毎）とタブ復帰イベントの両方から呼ばれる。
-     *
-     * @return 内部で給餌ログの再取得（onRefreshFeeding / silentRefreshFeeding）を発火したか
-     */
-    private suspend fun refreshClockAndSchedules(): Boolean {
-        var feedingRefetched = false
+    /** 時刻カード・年月日・ゴミバッジなど時刻依存の「非給餌」表示を同期する。 */
+    private fun refreshTimeAndGarbage() {
         val timeStr = currentTimeJs().toString()
         uiState = uiState.copy(currentTime = timeStr)
         val newDate = todayDateJs().toString()
@@ -135,32 +127,39 @@ class DashboardViewModel(
                 )
             refreshGarbageForToday()
         }
-        val newFeedingDate = feedingDateJs().toString()
-        if (newFeedingDate != trackedFeedingDate) {
-            trackedFeedingDate = newFeedingDate
-            onRefreshFeeding()
-            feedingRefetched = true
-        }
-        // 毎時0分・30分に給餌情報をサイレント更新
-        val minute = timeStr.substringAfter(":").toIntOrNull() ?: 0
-        val halfHour =
-            timeStr
-                .substringBefore(":")
-                .toIntOrNull()
-                ?.times(2)
-                ?.plus(minute / 30) ?: 0
-        if (lastFeedingHalfHour != -1 && halfHour != lastFeedingHalfHour) {
-            silentRefreshFeeding()
-            feedingRefetched = true
-        }
-        lastFeedingHalfHour = halfHour
-        // 更新時刻にゴミ出しスケジュールを再取得
         val hour = timeStr.substringBefore(":").toIntOrNull() ?: 0
         if (hour >= GARBAGE_SWITCH_HOUR && !garbageRefreshedToday) {
             garbageRefreshedToday = true
             loadGarbageSchedule()
         }
-        return feedingRefetched
+    }
+
+    /**
+     * ポーリング tick で日跨ぎ・半時間跨ぎを検知し、必要な場合のみ給餌ログを再取得する。
+     * タブ復帰時は [onRefreshFeeding] で無条件再取得するため本関数を呼ばない。
+     */
+    private suspend fun autoRefreshFeedingOnTick() {
+        val newFeedingDate = feedingDateJs().toString()
+        if (newFeedingDate != trackedFeedingDate) {
+            // 日跨ぎは全量再取得に任せ、同一 tick 内での半時間判定はスキップ（二重 fetch 回避）
+            onRefreshFeeding()
+            return
+        }
+        val halfHour = computeCurrentHalfHour()
+        if (lastFeedingHalfHour != -1 && halfHour != lastFeedingHalfHour) {
+            silentRefreshFeeding()
+        }
+        lastFeedingHalfHour = halfHour
+    }
+
+    private fun computeCurrentHalfHour(): Int {
+        val timeStr = currentTimeJs().toString()
+        val minute = timeStr.substringAfter(":").toIntOrNull() ?: 0
+        return timeStr
+            .substringBefore(":")
+            .toIntOrNull()
+            ?.times(2)
+            ?.plus(minute / 30) ?: 0
     }
 
     private suspend fun loadToday() {
@@ -203,9 +202,15 @@ class DashboardViewModel(
         }
     }
 
+    /**
+     * 給餌ログを無条件に再取得する。手動更新ボタン・タブ復帰・日跨ぎ検知から呼ばれる。
+     * 次回 [autoRefreshFeedingOnTick] で日跨ぎ・半時間跨ぎ判定が再発火しないよう tracker も同期する。
+     */
     fun onRefreshFeeding() {
         val newDate = feedingDateJs().toString()
         today = newDate
+        trackedFeedingDate = newDate
+        lastFeedingHalfHour = computeCurrentHalfHour()
         viewModelScope.launch {
             uiState =
                 uiState.copy(


### PR DESCRIPTION
## Summary

- タブを長時間バックグラウンドに置いて戻したときに、時刻カードが止まったまま・ゴミバッジが前日のまま表示される不具合を修正
- 責務を「時刻/ゴミ」と「給餌」の 2 関数に分割し、ポーリング・タブ復帰の挙動をシンプルに

## 原因

- 非アクティブタブではブラウザが `setTimeout` を throttle（最低約 1 分）、さらに長時間経過で Page Lifecycle の freeze 状態に入り、`delay(10_000)` ベースのポーリングループが停止／大幅遅延
- 復帰時の `TabResumedEvent` ハンドラは `onRefreshFeeding()` しか呼んでおらず、時刻カード・年月日・ゴミバッジは次の `delay` 完了まで古いまま
- freeze からの復帰直後は `setTimeout` コールバック発火が遅れることもあり、秒〜分オーダーで表示が追い付かない

## 修正内容

- ポーリング本体を責務で分割:
  - `refreshTimeAndGarbage()`: 時刻カード・年月日・ゴミバッジ
  - `autoRefreshFeedingOnTick()`: 日跨ぎ・半時間跨ぎ検知による給餌自動再取得（日跨ぎ時は半時間判定を `return` でスキップ）
- `onRefreshFeeding()` が `trackedFeedingDate` / `lastFeedingHalfHour` の同期も内包するよう拡張し、手動更新／タブ復帰の後に `autoRefreshFeedingOnTick` が誤発火しないよう保証
- `startDateChangePolling()` は `delay(10_000)` → `refreshTimeAndGarbage()` + `autoRefreshFeedingOnTick()` のループのみ（呼び出し契約：古いジョブは呼び出し側で `cancelAndJoin` 済みであること）
- `tabResumedEvent.events.collect` のブロックで:
  - `pollingJob?.cancelAndJoin()` で古いポーリングを確実に停止
  - `refreshTimeAndGarbage()` で時刻/ゴミを即時同期
  - `onRefreshFeeding()` を無条件で呼び出し（tracker 同期込みなので次 tick の誤発火なし）
  - `startDateChangePolling()` で新しいポーリングジョブを起動し `delay` サイクルをリセット

## 副次的な改善

- 日跨ぎ + 半時間跨ぎ同時成立時の `getFeedingLog` 二重 fetch を構造的に解消（`autoRefreshFeedingOnTick` の早期 return）
- 旧実装の `Boolean` 戻り値によるハンドラ側二重起動抑止は責務分割で不要になり廃止

## スコープ外（別 Issue / 別 PR で追跡）

- `TabResumedEvent._events = MutableSharedFlow<Unit>()` の buffer 設定（`replay=0, extraBufferCapacity=0`）が、ViewModel 生成タイミングや非可視↔可視の高速往復時にイベント取りこぼし・並行受信レースを生む可能性

## Test plan

- [x] `./gradlew :feature:dashboard:compileKotlinWasmJs` が成功すること
- [ ] ダッシュボードを開いた状態で別タブに切り替え、数分〜数十分放置してから戻る
  - [ ] 時刻カードがほぼ即時に現在時刻へ更新される
  - [ ] ゴミバッジが現在の日付の内容に更新される（日付を跨いでいた場合）
  - [ ] 給餌カードのローディング二重チラつきが発生しない
- [ ] ブラウザを最小化して放置 → 復元でも同様に表示が追い付くこと
- [ ] 通常のフォアグラウンド滞在時も時刻が 10 秒ごとに更新され続けること
- [ ] 手動更新ボタン押下直後に給餌カードのローディングが二重に走らないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)