### PR TITLE
月次支払いのステータスを 3 段階 enum 化 (PENDING/CONFIRMED/FROZEN)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,10 +266,6 @@ docker compose pull && docker compose up -d
 
 - **Popup 系コンポーネント（AlertDialog, DropdownMenu 等）は使用禁止。** Compose for WASM の描画システム上、Popup の DOM teardown とリスト recomposition が同時に走ると高確率で UI フリーズが発生するため。入力フォームはインライン（Card ベース）、選択 UI はインライン（FilterChip 等）で実装すること。
 
-## API Design
-
-- **リクエスト body は 1 フィールドでも必ず DTO でラップする。** `setBody(status)` のように enum / プリミティブを直接渡すと、JSON ルートが裸の文字列 (`"FROZEN"`) やリテラルになり、クライアント実装者にとって直感に反する。また将来フィールドを追加する場合に互換性が壊れる。`MonthlyMoneyStatusUpdate(status)` のような単一フィールド DTO を `shared/` に定義して `{ "status": "..." }` 形式で送受信すること。Swagger UI の body 表示も自然になる。
-
 ## Testing
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,6 +266,10 @@ docker compose pull && docker compose up -d
 
 - **Popup 系コンポーネント（AlertDialog, DropdownMenu 等）は使用禁止。** Compose for WASM の描画システム上、Popup の DOM teardown とリスト recomposition が同時に走ると高確率で UI フリーズが発生するため。入力フォームはインライン（Card ベース）、選択 UI はインライン（FilterChip 等）で実装すること。
 
+## API Design
+
+- **リクエスト body は 1 フィールドでも必ず DTO でラップする。** `setBody(status)` のように enum / プリミティブを直接渡すと、JSON ルートが裸の文字列 (`"FROZEN"`) やリテラルになり、クライアント実装者にとって直感に反する。また将来フィールドを追加する場合に互換性が壊れる。`MonthlyMoneyStatusUpdate(status)` のような単一フィールド DTO を `shared/` に定義して `{ "status": "..." }` 形式で送受信すること。Swagger UI の body 表示も自然になる。
+
 ## Testing
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ server/              → Ktor server (Netty, JVM)
                        Koin DI でリポジトリ注入（ServerModule）
                        Repository 層: interface + Firestore 実装 class
                        ルートハンドラは HTTP 処理 + ビジネスルール判定のみ
+                       ※ API 設計方針（リクエスト body の DTO ラップ等）は README.md の「API 設計」セクションを参照
 
 core/common/         → 環境判定（isDevEnvironment）、AppLogger、TabResumedEvent など横断的ユーティリティ (commonMain)
                        wasmJs: window.location.port による開発環境判定、PageVisibility (visibilitychange)

--- a/README.md
+++ b/README.md
@@ -285,6 +285,14 @@ docker compose up -d
 docker compose pull && docker compose up -d
 ```
 
+## API 設計
+
+### リクエスト body の DTO ラップ
+
+リクエスト body は 1 フィールドでも必ず DTO でラップする。`setBody(status)` のように enum / プリミティブを直接渡すと、JSON ルートが裸の文字列（`"FROZEN"` など）やリテラルになり、クライアント実装者にとって直感に反する。また将来フィールドを追加する場合に互換性が壊れる。
+
+`MonthlyMoneyStatusUpdate(status)` のような単一フィールド DTO を `shared/` に定義して `{ "status": "..." }` 形式で送受信する。Swagger UI の body 表示も自然になる。
+
 ## セキュリティ
 
 ### CORS

--- a/core/network/src/commonMain/kotlin/core/network/MoneyRepository.kt
+++ b/core/network/src/commonMain/kotlin/core/network/MoneyRepository.kt
@@ -6,6 +6,7 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import model.MonthlyMoney
 import model.MonthlyMoneyStatus
+import model.MonthlyMoneyStatusUpdate
 import model.PaymentRecord
 
 interface MoneyRepository {
@@ -59,7 +60,7 @@ class MoneyRepositoryImpl(
         client
             .patch("/api/money/$month/status") {
                 contentType(ContentType.Application.Json)
-                setBody(status)
+                setBody(MonthlyMoneyStatusUpdate(status))
             }.body()
 
     override suspend fun importRecurringItems(month: String): MonthlyMoney = client.post("/api/money/$month/import-by-tag").body()

--- a/core/network/src/commonMain/kotlin/core/network/MoneyRepository.kt
+++ b/core/network/src/commonMain/kotlin/core/network/MoneyRepository.kt
@@ -6,7 +6,6 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import model.MonthlyMoney
 import model.MonthlyMoneyStatus
-import model.MonthlyMoneyStatusUpdate
 import model.PaymentRecord
 
 interface MoneyRepository {
@@ -60,7 +59,7 @@ class MoneyRepositoryImpl(
         client
             .patch("/api/money/$month/status") {
                 contentType(ContentType.Application.Json)
-                setBody(MonthlyMoneyStatusUpdate(status))
+                setBody(status)
             }.body()
 
     override suspend fun importRecurringItems(month: String): MonthlyMoney = client.post("/api/money/$month/import-by-tag").body()

--- a/core/network/src/commonMain/kotlin/core/network/MoneyRepository.kt
+++ b/core/network/src/commonMain/kotlin/core/network/MoneyRepository.kt
@@ -4,15 +4,10 @@ import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
-import kotlinx.serialization.Serializable
 import model.MonthlyMoney
 import model.MonthlyMoneyStatus
+import model.MonthlyMoneyStatusUpdate
 import model.PaymentRecord
-
-@Serializable
-private data class MonthlyMoneyStatusUpdate(
-    val status: MonthlyMoneyStatus,
-)
 
 interface MoneyRepository {
     suspend fun getMonthlyMoney(month: String): MonthlyMoney

--- a/core/network/src/commonMain/kotlin/core/network/MoneyRepository.kt
+++ b/core/network/src/commonMain/kotlin/core/network/MoneyRepository.kt
@@ -4,8 +4,15 @@ import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
+import kotlinx.serialization.Serializable
 import model.MonthlyMoney
+import model.MonthlyMoneyStatus
 import model.PaymentRecord
+
+@Serializable
+private data class MonthlyMoneyStatusUpdate(
+    val status: MonthlyMoneyStatus,
+)
 
 interface MoneyRepository {
     suspend fun getMonthlyMoney(month: String): MonthlyMoney
@@ -19,7 +26,10 @@ interface MoneyRepository {
         record: PaymentRecord,
     ): MonthlyMoney
 
-    suspend fun toggleLock(month: String): MonthlyMoney
+    suspend fun updateStatus(
+        month: String,
+        status: MonthlyMoneyStatus,
+    ): MonthlyMoney
 
     suspend fun importRecurringItems(month: String): MonthlyMoney
 }
@@ -48,7 +58,15 @@ class MoneyRepositoryImpl(
                 setBody(record)
             }.body()
 
-    override suspend fun toggleLock(month: String): MonthlyMoney = client.patch("/api/money/$month/lock").body()
+    override suspend fun updateStatus(
+        month: String,
+        status: MonthlyMoneyStatus,
+    ): MonthlyMoney =
+        client
+            .patch("/api/money/$month/status") {
+                contentType(ContentType.Application.Json)
+                setBody(MonthlyMoneyStatusUpdate(status))
+            }.body()
 
     override suspend fun importRecurringItems(month: String): MonthlyMoney = client.post("/api/money/$month/import-by-tag").body()
 }

--- a/core/ui/src/commonMain/kotlin/core/ui/extensions/MonthlyMoneyStatusUi.kt
+++ b/core/ui/src/commonMain/kotlin/core/ui/extensions/MonthlyMoneyStatusUi.kt
@@ -1,0 +1,24 @@
+package core.ui.extensions
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Block
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.PendingActions
+import androidx.compose.ui.graphics.vector.ImageVector
+import model.MonthlyMoneyStatus
+
+val MonthlyMoneyStatus.displayName: String
+    get() =
+        when (this) {
+            MonthlyMoneyStatus.PENDING -> "確定前"
+            MonthlyMoneyStatus.CONFIRMED -> "確定済み"
+            MonthlyMoneyStatus.FROZEN -> "凍結"
+        }
+
+val MonthlyMoneyStatus.icon: ImageVector
+    get() =
+        when (this) {
+            MonthlyMoneyStatus.PENDING -> Icons.Default.PendingActions
+            MonthlyMoneyStatus.CONFIRMED -> Icons.Default.CheckCircle
+            MonthlyMoneyStatus.FROZEN -> Icons.Default.Block
+        }

--- a/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
+++ b/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
@@ -11,12 +11,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Block
-import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.filled.PendingActions
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -32,6 +29,8 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import core.ui.LocalWindowSizeClass
 import core.ui.WindowSizeClass
+import core.ui.extensions.displayName
+import core.ui.extensions.icon
 import core.ui.formatYen
 import model.MoneyItem
 import model.MoneyTags
@@ -654,22 +653,6 @@ private fun MonthStatusSelector(
         }
     }
 }
-
-private val MonthlyMoneyStatus.displayName: String
-    get() =
-        when (this) {
-            MonthlyMoneyStatus.PENDING -> "確定前"
-            MonthlyMoneyStatus.CONFIRMED -> "確定済み"
-            MonthlyMoneyStatus.FROZEN -> "凍結"
-        }
-
-private val MonthlyMoneyStatus.icon: androidx.compose.ui.graphics.vector.ImageVector
-    get() =
-        when (this) {
-            MonthlyMoneyStatus.PENDING -> Icons.Default.PendingActions
-            MonthlyMoneyStatus.CONFIRMED -> Icons.Default.CheckCircle
-            MonthlyMoneyStatus.FROZEN -> Icons.Default.Block
-        }
 
 @Composable
 private fun SummaryCard(

--- a/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
+++ b/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
@@ -367,7 +367,7 @@ private fun MoneyItemForm(
     formKey: Int,
     users: List<User>,
     saving: Boolean,
-    frozen: Boolean = false,
+    frozen: Boolean,
     onSave: (String, Long, String, List<Payment>, List<String>) -> Unit,
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
@@ -791,7 +791,7 @@ private fun MoneyItemCard(
     onMovePrev: () -> Unit,
     onMoveNext: () -> Unit,
     isCompact: Boolean,
-    frozen: Boolean = false,
+    frozen: Boolean,
 ) {
     val paymentTotal = item.payments.sumOf { it.amount }
     val mismatch = paymentTotal != item.amount && item.payments.isNotEmpty()

--- a/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
+++ b/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
@@ -11,10 +11,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Block
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.filled.LockOpen
+import androidx.compose.material.icons.filled.PendingActions
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -34,6 +36,7 @@ import core.ui.formatYen
 import model.MoneyItem
 import model.MoneyTags
 import model.MonthlyMoney
+import model.MonthlyMoneyStatus
 import model.Payment
 import model.PaymentRecord
 import model.User
@@ -59,7 +62,7 @@ fun MoneyScreen(vm: MoneyViewModel = koinViewModel()) {
         onDeleteItem = vm::onDeleteItem,
         onMoveItem = vm::onMoveItem,
         onSaveItem = vm::onSaveItem,
-        onToggleLock = vm::onToggleLock,
+        onUpdateStatus = vm::onUpdateStatus,
         onImportRecurringItems = vm::onImportRecurringItems,
         windowSizeClass = windowSizeClass,
     )
@@ -82,11 +85,12 @@ internal fun MoneyContent(
     onDeleteItem: (MoneyItem) -> Unit,
     onMoveItem: (MoneyItem, Int) -> Unit,
     onSaveItem: (String, Long, String, List<Payment>, List<String>) -> Unit,
-    onToggleLock: () -> Unit,
+    onUpdateStatus: (MonthlyMoneyStatus) -> Unit,
     onImportRecurringItems: () -> Unit,
     windowSizeClass: WindowSizeClass = WindowSizeClass.Expanded,
 ) {
-    val locked = monthlyMoney.locked
+    val status = monthlyMoney.status
+    val frozen = status == MonthlyMoneyStatus.FROZEN
     val isCompact = windowSizeClass == WindowSizeClass.Compact
     // Compact 用: フォーム表示切替
     var showFormCompact by remember { mutableStateOf(false) }
@@ -125,7 +129,7 @@ internal fun MoneyContent(
                         formKey = formKey,
                         users = users,
                         saving = saving,
-                        locked = locked,
+                        frozen = frozen,
                         onSave = onSaveItem,
                         onCancel = {
                             onClearForm()
@@ -148,28 +152,16 @@ internal fun MoneyContent(
                         color = MaterialTheme.colorScheme.primary,
                     )
                     Spacer(modifier = Modifier.height(8.dp))
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        MonthSelector(
-                            month = currentMonth,
-                            onPrevious = onPreviousMonth,
-                            onNext = onNextMonth,
-                        )
-                        Spacer(modifier = Modifier.weight(1f))
-                        IconButton(onClick = onToggleLock) {
-                            Icon(
-                                if (locked) Icons.Default.Lock else Icons.Default.LockOpen,
-                                contentDescription = if (locked) "ロック解除" else "ロック",
-                                tint =
-                                    if (locked) {
-                                        MaterialTheme.colorScheme.error
-                                    } else {
-                                        MaterialTheme.colorScheme.onSurfaceVariant
-                                    },
-                            )
-                        }
-                    }
+                    MonthSelector(
+                        month = currentMonth,
+                        onPrevious = onPreviousMonth,
+                        onNext = onNextMonth,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    MonthStatusSelector(
+                        status = status,
+                        onStatusChange = onUpdateStatus,
+                    )
                     Spacer(modifier = Modifier.height(8.dp))
 
                     // 追加ボタン + インポートボタン
@@ -180,12 +172,13 @@ internal fun MoneyContent(
                                 showFormCompact = true
                             },
                             modifier = Modifier.fillMaxWidth(),
+                            enabled = !frozen,
                         ) {
                             Icon(Icons.Default.Add, contentDescription = null)
                             Spacer(modifier = Modifier.width(8.dp))
                             Text("項目を追加")
                         }
-                        if (!locked) {
+                        if (!frozen) {
                             Spacer(modifier = Modifier.height(4.dp))
                             OutlinedButton(
                                 onClick = onImportRecurringItems,
@@ -204,7 +197,7 @@ internal fun MoneyContent(
                         error = error,
                         users = users,
                         isCompact = true,
-                        locked = locked,
+                        frozen = frozen,
                         onEditItem = { item ->
                             onEditItem(item)
                             showFormCompact = true
@@ -231,27 +224,18 @@ internal fun MoneyContent(
                 Spacer(modifier = Modifier.height(16.dp))
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     MonthSelector(
                         month = currentMonth,
                         onPrevious = onPreviousMonth,
                         onNext = onNextMonth,
                     )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    IconButton(onClick = onToggleLock) {
-                        Icon(
-                            if (locked) Icons.Default.Lock else Icons.Default.LockOpen,
-                            contentDescription = if (locked) "ロック解除" else "ロック",
-                            tint =
-                                if (locked) {
-                                    MaterialTheme.colorScheme.error
-                                } else {
-                                    MaterialTheme.colorScheme.onSurfaceVariant
-                                },
-                        )
-                    }
-                    if (!locked && !loading && error == null) {
-                        Spacer(modifier = Modifier.width(8.dp))
+                    MonthStatusSelector(
+                        status = status,
+                        onStatusChange = onUpdateStatus,
+                    )
+                    if (!frozen && !loading && error == null) {
                         OutlinedButton(
                             onClick = onImportRecurringItems,
                             enabled = !saving,
@@ -270,7 +254,7 @@ internal fun MoneyContent(
                         error = error,
                         users = users,
                         isCompact = false,
-                        locked = locked,
+                        frozen = frozen,
                         onEditItem = onEditItem,
                         onDeleteItem = onDeleteItem,
                         onMoveItem = onMoveItem,
@@ -284,7 +268,7 @@ internal fun MoneyContent(
                         formKey = formKey,
                         users = users,
                         saving = saving,
-                        locked = locked,
+                        frozen = frozen,
                         onSave = onSaveItem,
                         onCancel = onClearForm,
                         modifier = Modifier.width(400.dp),
@@ -307,7 +291,7 @@ private fun MoneyListContent(
     error: String?,
     users: List<User>,
     isCompact: Boolean,
-    locked: Boolean,
+    frozen: Boolean,
     onEditItem: (MoneyItem) -> Unit,
     onDeleteItem: (MoneyItem) -> Unit,
     onMoveItem: (MoneyItem, Int) -> Unit,
@@ -370,7 +354,7 @@ private fun MoneyListContent(
                         onMovePrev = { onMoveItem(item, -1) },
                         onMoveNext = { onMoveItem(item, 1) },
                         isCompact = isCompact,
-                        locked = locked,
+                        frozen = frozen,
                     )
                 }
             }
@@ -384,7 +368,7 @@ private fun MoneyItemForm(
     formKey: Int,
     users: List<User>,
     saving: Boolean,
-    locked: Boolean = false,
+    frozen: Boolean = false,
     onSave: (String, Long, String, List<Payment>, List<String>) -> Unit,
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
@@ -577,7 +561,7 @@ private fun MoneyItemForm(
                 }
             }
 
-            if (locked) {
+            if (frozen) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -589,7 +573,7 @@ private fun MoneyItemForm(
                         modifier = Modifier.size(16.dp),
                     )
                     Text(
-                        text = "この月はロックされています",
+                        text = "この月は凍結されています",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.error,
                     )
@@ -607,7 +591,7 @@ private fun MoneyItemForm(
                 Spacer(modifier = Modifier.width(8.dp))
                 Button(
                     onClick = { onSave(name, amount, note, payments, selectedTags) },
-                    enabled = name.isNotBlank() && isAmountValid && !saving && !locked,
+                    enabled = name.isNotBlank() && isAmountValid && !saving && !frozen,
                 ) {
                     Text(if (isEditing) "保存" else "追加")
                 }
@@ -641,6 +625,51 @@ private fun MonthSelector(
         }
     }
 }
+
+@Composable
+private fun MonthStatusSelector(
+    status: MonthlyMoneyStatus,
+    onStatusChange: (MonthlyMoneyStatus) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    FlowRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        for (candidate in MonthlyMoneyStatus.entries) {
+            val selected = candidate == status
+            FilterChip(
+                selected = selected,
+                onClick = { if (!selected) onStatusChange(candidate) },
+                label = { Text(candidate.displayName, style = MaterialTheme.typography.labelMedium) },
+                leadingIcon = {
+                    Icon(
+                        candidate.icon,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                },
+            )
+        }
+    }
+}
+
+private val MonthlyMoneyStatus.displayName: String
+    get() =
+        when (this) {
+            MonthlyMoneyStatus.PENDING -> "確定前"
+            MonthlyMoneyStatus.CONFIRMED -> "確定済み"
+            MonthlyMoneyStatus.FROZEN -> "凍結"
+        }
+
+private val MonthlyMoneyStatus.icon: androidx.compose.ui.graphics.vector.ImageVector
+    get() =
+        when (this) {
+            MonthlyMoneyStatus.PENDING -> Icons.Default.PendingActions
+            MonthlyMoneyStatus.CONFIRMED -> Icons.Default.CheckCircle
+            MonthlyMoneyStatus.FROZEN -> Icons.Default.Block
+        }
 
 @Composable
 private fun SummaryCard(
@@ -779,7 +808,7 @@ private fun MoneyItemCard(
     onMovePrev: () -> Unit,
     onMoveNext: () -> Unit,
     isCompact: Boolean,
-    locked: Boolean = false,
+    frozen: Boolean = false,
 ) {
     val paymentTotal = item.payments.sumOf { it.amount }
     val mismatch = paymentTotal != item.amount && item.payments.isNotEmpty()
@@ -831,7 +860,7 @@ private fun MoneyItemCard(
                 }
 
                 Row {
-                    if (!locked) {
+                    if (!frozen) {
                         IconButton(onClick = onMovePrev) {
                             Icon(
                                 Icons.AutoMirrored.Filled.ArrowBack,

--- a/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
+++ b/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -566,7 +565,7 @@ private fun MoneyItemForm(
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
                     Icon(
-                        Icons.Default.Lock,
+                        MonthlyMoneyStatus.FROZEN.icon,
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.error,
                         modifier = Modifier.size(16.dp),

--- a/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyViewModel.kt
+++ b/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyViewModel.kt
@@ -13,6 +13,7 @@ import core.network.UserRepository
 import kotlinx.coroutines.launch
 import model.MoneyItem
 import model.MonthlyMoney
+import model.MonthlyMoneyStatus
 import model.Payment
 import model.User
 
@@ -119,10 +120,11 @@ class MoneyViewModel(
         onLoadMonth(shiftMonthJs(uiState.currentMonth.toJsString(), 1).toString())
     }
 
-    fun onToggleLock() {
+    fun onUpdateStatus(status: MonthlyMoneyStatus) {
+        if (uiState.monthlyMoney.status == status) return
         viewModelScope.launch {
             try {
-                val updated = moneyRepository.toggleLock(uiState.currentMonth)
+                val updated = moneyRepository.updateStatus(uiState.currentMonth, status)
                 uiState = uiState.copy(monthlyMoney = updated)
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)

--- a/feature/payment/src/wasmJsMain/kotlin/feature/payment/PaymentScreen.kt
+++ b/feature/payment/src/wasmJsMain/kotlin/feature/payment/PaymentScreen.kt
@@ -7,12 +7,15 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
-import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Block
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.PendingActions
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import core.ui.LocalWindowSizeClass
@@ -20,6 +23,7 @@ import core.ui.WindowSizeClass
 import core.ui.formatYen
 import model.MoneyItem
 import model.MonthlyMoney
+import model.MonthlyMoneyStatus
 import model.PaymentRecord
 import model.User
 import org.koin.compose.viewmodel.koinViewModel
@@ -73,7 +77,8 @@ internal fun PaymentContent(
     // 支払い済み合計
     val totalPaid = monthlyMoney.paymentRecords.sumOf { it.amount }
     val remaining = totalAllocated - totalPaid
-    val locked = monthlyMoney.locked
+    val status = monthlyMoney.status
+    val frozen = status == MonthlyMoneyStatus.FROZEN
 
     Box(modifier = Modifier.fillMaxSize()) {
         if (isCompact) {
@@ -118,10 +123,10 @@ internal fun PaymentContent(
                     loading = loading,
                     error = error,
                     isCompact = true,
-                    locked = locked,
+                    status = status,
                     modifier = Modifier.weight(1f),
                 )
-                if (!loading && error == null && !locked && !isViewingOther) {
+                if (!loading && error == null && !frozen && !isViewingOther) {
                     Spacer(modifier = Modifier.height(8.dp))
                     PaymentInlineForm(
                         remaining = remaining,
@@ -176,11 +181,11 @@ internal fun PaymentContent(
                         loading = loading,
                         error = error,
                         isCompact = false,
-                        locked = locked,
+                        status = status,
                         modifier = Modifier.weight(1f),
                     )
 
-                    if (!locked && !isViewingOther) {
+                    if (!frozen && !isViewingOther) {
                         Spacer(modifier = Modifier.width(24.dp))
 
                         if (!loading && error == null) {
@@ -213,7 +218,7 @@ private fun PaymentListContent(
     loading: Boolean,
     error: String?,
     isCompact: Boolean,
-    locked: Boolean = false,
+    status: MonthlyMoneyStatus = MonthlyMoneyStatus.PENDING,
     modifier: Modifier = Modifier,
 ) {
     when {
@@ -246,7 +251,7 @@ private fun PaymentListContent(
                         totalPaid = totalPaid,
                         remaining = remaining,
                         isCompact = isCompact,
-                        locked = locked,
+                        status = status,
                     )
                 }
 
@@ -440,7 +445,7 @@ private fun SummaryCard(
     totalPaid: Long,
     remaining: Long,
     isCompact: Boolean,
-    locked: Boolean = false,
+    status: MonthlyMoneyStatus = MonthlyMoneyStatus.PENDING,
 ) {
     Card(
         modifier =
@@ -463,30 +468,7 @@ private fun SummaryCard(
                     style = MaterialTheme.typography.titleMedium,
                 )
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    if (locked) {
-                        Surface(
-                            color = MaterialTheme.colorScheme.errorContainer,
-                            shape = MaterialTheme.shapes.small,
-                        ) {
-                            Row(
-                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                            ) {
-                                Icon(
-                                    Icons.Default.Lock,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(14.dp),
-                                    tint = MaterialTheme.colorScheme.onErrorContainer,
-                                )
-                                Text(
-                                    text = "ロック中",
-                                    style = MaterialTheme.typography.labelLarge,
-                                    color = MaterialTheme.colorScheme.onErrorContainer,
-                                )
-                            }
-                        }
-                    }
+                    StatusBadge(status = status)
                     if (remaining <= 0 && totalAllocated > 0) {
                         Surface(
                             color = MaterialTheme.colorScheme.primary,
@@ -640,6 +622,57 @@ private fun ItemBreakdownCard(
         }
     }
 }
+
+@Composable
+private fun StatusBadge(status: MonthlyMoneyStatus) {
+    val (container, onContainer) =
+        when (status) {
+            MonthlyMoneyStatus.PENDING ->
+                MaterialTheme.colorScheme.tertiaryContainer to
+                    MaterialTheme.colorScheme.onTertiaryContainer
+            MonthlyMoneyStatus.CONFIRMED ->
+                MaterialTheme.colorScheme.primaryContainer to
+                    MaterialTheme.colorScheme.onPrimaryContainer
+            MonthlyMoneyStatus.FROZEN ->
+                MaterialTheme.colorScheme.errorContainer to
+                    MaterialTheme.colorScheme.onErrorContainer
+        }
+    Surface(color = container, shape = MaterialTheme.shapes.small) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Icon(
+                status.icon,
+                contentDescription = null,
+                modifier = Modifier.size(14.dp),
+                tint = onContainer,
+            )
+            Text(
+                text = status.displayName,
+                style = MaterialTheme.typography.labelLarge,
+                color = onContainer,
+            )
+        }
+    }
+}
+
+private val MonthlyMoneyStatus.displayName: String
+    get() =
+        when (this) {
+            MonthlyMoneyStatus.PENDING -> "確定前"
+            MonthlyMoneyStatus.CONFIRMED -> "確定済み"
+            MonthlyMoneyStatus.FROZEN -> "凍結"
+        }
+
+private val MonthlyMoneyStatus.icon: ImageVector
+    get() =
+        when (this) {
+            MonthlyMoneyStatus.PENDING -> Icons.Default.PendingActions
+            MonthlyMoneyStatus.CONFIRMED -> Icons.Default.CheckCircle
+            MonthlyMoneyStatus.FROZEN -> Icons.Default.Block
+        }
 
 /** UTC ISO 文字列を JST (UTC+9) に変換して表示用にフォーマットする */
 private fun formatDate(isoString: String): String =

--- a/feature/payment/src/wasmJsMain/kotlin/feature/payment/PaymentScreen.kt
+++ b/feature/payment/src/wasmJsMain/kotlin/feature/payment/PaymentScreen.kt
@@ -7,19 +7,17 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
-import androidx.compose.material.icons.filled.Block
-import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.PendingActions
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import core.ui.LocalWindowSizeClass
 import core.ui.WindowSizeClass
+import core.ui.extensions.displayName
+import core.ui.extensions.icon
 import core.ui.formatYen
 import model.MoneyItem
 import model.MonthlyMoney
@@ -657,22 +655,6 @@ private fun StatusBadge(status: MonthlyMoneyStatus) {
         }
     }
 }
-
-private val MonthlyMoneyStatus.displayName: String
-    get() =
-        when (this) {
-            MonthlyMoneyStatus.PENDING -> "確定前"
-            MonthlyMoneyStatus.CONFIRMED -> "確定済み"
-            MonthlyMoneyStatus.FROZEN -> "凍結"
-        }
-
-private val MonthlyMoneyStatus.icon: ImageVector
-    get() =
-        when (this) {
-            MonthlyMoneyStatus.PENDING -> Icons.Default.PendingActions
-            MonthlyMoneyStatus.CONFIRMED -> Icons.Default.CheckCircle
-            MonthlyMoneyStatus.FROZEN -> Icons.Default.Block
-        }
 
 /** UTC ISO 文字列を JST (UTC+9) に変換して表示用にフォーマットする */
 private fun formatDate(isoString: String): String =

--- a/feature/payment/src/wasmJsMain/kotlin/feature/payment/PaymentScreen.kt
+++ b/feature/payment/src/wasmJsMain/kotlin/feature/payment/PaymentScreen.kt
@@ -216,7 +216,7 @@ private fun PaymentListContent(
     loading: Boolean,
     error: String?,
     isCompact: Boolean,
-    status: MonthlyMoneyStatus = MonthlyMoneyStatus.PENDING,
+    status: MonthlyMoneyStatus,
     modifier: Modifier = Modifier,
 ) {
     when {
@@ -443,7 +443,7 @@ private fun SummaryCard(
     totalPaid: Long,
     remaining: Long,
     isCompact: Boolean,
-    status: MonthlyMoneyStatus = MonthlyMoneyStatus.PENDING,
+    status: MonthlyMoneyStatus,
 ) {
     Card(
         modifier =

--- a/feature/payment/src/wasmJsMain/kotlin/feature/payment/PaymentScreen.kt
+++ b/feature/payment/src/wasmJsMain/kotlin/feature/payment/PaymentScreen.kt
@@ -466,7 +466,7 @@ private fun SummaryCard(
                     style = MaterialTheme.typography.titleMedium,
                 )
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    StatusBadge(status = status)
+                    MonthlyMoneyStatusBadge(status = status)
                     if (remaining <= 0 && totalAllocated > 0) {
                         Surface(
                             color = MaterialTheme.colorScheme.primary,
@@ -622,7 +622,7 @@ private fun ItemBreakdownCard(
 }
 
 @Composable
-private fun StatusBadge(status: MonthlyMoneyStatus) {
+private fun MonthlyMoneyStatusBadge(status: MonthlyMoneyStatus) {
     val (container, onContainer) =
         when (status) {
             MonthlyMoneyStatus.PENDING ->

--- a/feature/report/src/wasmJsMain/kotlin/feature/report/OverpaymentScreen.kt
+++ b/feature/report/src/wasmJsMain/kotlin/feature/report/OverpaymentScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
-import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -219,7 +219,7 @@ private fun RedemptionInlineCard(
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
                     Icon(
-                        Icons.Default.Lock,
+                        Icons.Default.Block,
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.error,
                         modifier = Modifier.size(16.dp),

--- a/feature/report/src/wasmJsMain/kotlin/feature/report/OverpaymentScreen.kt
+++ b/feature/report/src/wasmJsMain/kotlin/feature/report/OverpaymentScreen.kt
@@ -142,7 +142,7 @@ private fun RedemptionInlineCard(
     modifier: Modifier = Modifier,
 ) {
     val inputEnabled = !form.isSaving
-    val locked = form.isMonthLocked
+    val frozen = form.isMonthFrozen
 
     Card(
         modifier = modifier,
@@ -212,8 +212,8 @@ private fun RedemptionInlineCard(
                 enabled = inputEnabled,
             )
 
-            // ロック警告
-            if (locked) {
+            // 凍結警告
+            if (frozen) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -225,7 +225,7 @@ private fun RedemptionInlineCard(
                         modifier = Modifier.size(16.dp),
                     )
                     Text(
-                        text = "この月はロックされています",
+                        text = "この月は凍結されています",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.error,
                     )
@@ -243,12 +243,12 @@ private fun RedemptionInlineCard(
                     label = { Text("金額 (円)") },
                     modifier = Modifier.weight(1f),
                     singleLine = true,
-                    enabled = inputEnabled && !locked,
+                    enabled = inputEnabled && !frozen,
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 )
                 OutlinedButton(
                     onClick = onFillRemaining,
-                    enabled = inputEnabled && !locked && form.selectedUid.isNotEmpty(),
+                    enabled = inputEnabled && !frozen && form.selectedUid.isNotEmpty(),
                     contentPadding = PaddingValues(horizontal = 8.dp),
                 ) {
                     Text("残額全額", style = MaterialTheme.typography.labelSmall)
@@ -262,7 +262,7 @@ private fun RedemptionInlineCard(
                 label = { Text("備考") },
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
-                enabled = inputEnabled && !locked,
+                enabled = inputEnabled && !frozen,
             )
 
             // エラー表示

--- a/feature/report/src/wasmJsMain/kotlin/feature/report/OverpaymentViewModel.kt
+++ b/feature/report/src/wasmJsMain/kotlin/feature/report/OverpaymentViewModel.kt
@@ -12,6 +12,7 @@ import core.network.MoneyRepository
 import core.network.ReportRepository
 import kotlinx.coroutines.launch
 import model.MonthlyMoney
+import model.MonthlyMoneyStatus
 import model.OverpaymentRedemptionRequest
 import model.UserBalance
 
@@ -26,13 +27,13 @@ data class RedemptionFormState(
     val error: String? = null,
     val monthData: MonthlyMoney? = null,
 ) {
-    val isMonthLocked: Boolean get() = monthData?.locked == true
+    val isMonthFrozen: Boolean get() = monthData?.status == MonthlyMoneyStatus.FROZEN
     val canSubmit: Boolean
         get() =
             selectedUid.isNotEmpty() &&
                 (amountText.toLongOrNull() ?: 0L) > 0L &&
                 !isSaving &&
-                !isMonthLocked
+                !isMonthFrozen
 }
 
 data class OverpaymentUiState(
@@ -182,10 +183,10 @@ class OverpaymentViewModel(
                 )
             return
         }
-        if (form.isMonthLocked) {
+        if (form.isMonthFrozen) {
             uiState =
                 uiState.copy(
-                    redemptionForm = form.copy(error = "この月はロックされています"),
+                    redemptionForm = form.copy(error = "この月は凍結されています"),
                 )
             return
         }

--- a/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
+++ b/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
@@ -144,10 +144,11 @@ internal fun parseStatus(
     statusRaw: String?,
     legacyLocked: Boolean?,
 ): MonthlyMoneyStatus {
-    if (statusRaw != null) {
-        val parsed = runCatching { MonthlyMoneyStatus.valueOf(statusRaw) }.getOrNull()
+    val normalized = statusRaw?.trim()?.takeIf { it.isNotEmpty() }
+    if (normalized != null) {
+        val parsed = runCatching { MonthlyMoneyStatus.valueOf(normalized) }.getOrNull()
         if (parsed != null) return parsed
-        logger.warn("Unknown MonthlyMoneyStatus value: {} — falling back to legacy locked", statusRaw)
+        logger.warn("Unknown MonthlyMoneyStatus value: {} — falling back to legacy locked", normalized)
     }
     return if (legacyLocked == true) MonthlyMoneyStatus.FROZEN else MonthlyMoneyStatus.PENDING
 }

--- a/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
+++ b/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
@@ -76,7 +76,7 @@ class FirestoreMoneyRepository(
         firestore
             .collection(MONEY_COLLECTION)
             .document(month)
-            .set(mapOf("month" to month, "items" to items, "paymentRecords" to records, "status" to data.status.wireValue))
+            .set(mapOf("month" to month, "items" to items, "paymentRecords" to records, "status" to data.status.name))
             .await()
 
         cache[month] = data
@@ -130,7 +130,7 @@ class FirestoreMoneyRepository(
 /**
  * Firestore の生フィールドから MonthlyMoneyStatus を復元する。
  *
- * - 新形式: `status: "FROZEN"` 等の文字列。[MonthlyMoneyStatus.wireValue] 経由で復元する。
+ * - 新形式: `status: "FROZEN"` 等の文字列。enum の name で復元する。
  * - 未知の文字列: WARN ログを出した上で旧形式にフォールバックする。
  * - 旧形式 (`locked: Boolean`): `locked=true → FROZEN` に変換する。
  *
@@ -145,7 +145,7 @@ internal fun parseStatus(
     legacyLocked: Boolean?,
 ): MonthlyMoneyStatus {
     if (statusRaw != null) {
-        val parsed = MonthlyMoneyStatus.fromWireValue(statusRaw)
+        val parsed = runCatching { MonthlyMoneyStatus.valueOf(statusRaw) }.getOrNull()
         if (parsed != null) return parsed
         logger.warn("Unknown MonthlyMoneyStatus value: {} — falling back to legacy locked", statusRaw)
     }

--- a/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
+++ b/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
@@ -76,7 +76,7 @@ class FirestoreMoneyRepository(
         firestore
             .collection(MONEY_COLLECTION)
             .document(month)
-            .set(mapOf("month" to month, "items" to items, "paymentRecords" to records, "status" to data.status.name))
+            .set(mapOf("month" to month, "items" to items, "paymentRecords" to records, "status" to data.status.wireValue))
             .await()
 
         cache[month] = data
@@ -129,16 +129,23 @@ class FirestoreMoneyRepository(
 
 /**
  * Firestore の生フィールドから MonthlyMoneyStatus を復元する。
- * 新形式は `status: "FROZEN"` 等の文字列。未知の値や status 未設定の場合は
- * 旧形式（`locked: Boolean`）にフォールバックし、`locked=true → FROZEN`,
- * それ以外は PENDING として扱う。未知の status 文字列は WARN ログを出す。
+ *
+ * - 新形式: `status: "FROZEN"` 等の文字列。[MonthlyMoneyStatus.wireValue] 経由で復元する。
+ * - 未知の文字列: WARN ログを出した上で旧形式にフォールバックする。
+ * - 旧形式 (`locked: Boolean`): `locked=true → FROZEN` に変換する。
+ *
+ * それ以外（status 未設定 + locked=false または未設定）は [MonthlyMoneyStatus.PENDING] を
+ * デフォルトとして返す。旧運用では `locked=false` は単に「編集可能」を意味し、新 3 状態の
+ * 「確定済みか未確定か」という情報は存在しなかったため、安全側に倒して PENDING とする。
+ * 既に運用上確定していた月は、マイグレーション後に admin が手動で CONFIRMED に切り替える
+ * ことを想定する。
  */
 internal fun parseStatus(
     statusRaw: String?,
     legacyLocked: Boolean?,
 ): MonthlyMoneyStatus {
     if (statusRaw != null) {
-        val parsed = runCatching { MonthlyMoneyStatus.valueOf(statusRaw) }.getOrNull()
+        val parsed = MonthlyMoneyStatus.fromWireValue(statusRaw)
         if (parsed != null) return parsed
         logger.warn("Unknown MonthlyMoneyStatus value: {} — falling back to legacy locked", statusRaw)
     }

--- a/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
+++ b/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
@@ -8,6 +8,7 @@ import model.MonthlyMoney
 import model.MonthlyMoneyStatus
 import model.Payment
 import model.PaymentRecord
+import org.slf4j.LoggerFactory
 import server.cache.Cacheable
 import server.util.await
 import java.time.YearMonth
@@ -16,6 +17,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 
 private const val MONEY_COLLECTION = "money"
+private val logger = LoggerFactory.getLogger("server.money.FirestoreMoneyRepository")
 
 class FirestoreMoneyRepository(
     private val firestore: Firestore,
@@ -127,16 +129,18 @@ class FirestoreMoneyRepository(
 
 /**
  * Firestore の生フィールドから MonthlyMoneyStatus を復元する。
- * 新形式は `status: "FROZEN"` 等の文字列。旧形式（`locked: Boolean` のみ）からは
- * `locked=true → FROZEN`, `locked=false → PENDING` にフォールバックする。
+ * 新形式は `status: "FROZEN"` 等の文字列。未知の値や status 未設定の場合は
+ * 旧形式（`locked: Boolean`）にフォールバックし、`locked=true → FROZEN`,
+ * それ以外は PENDING として扱う。未知の status 文字列は WARN ログを出す。
  */
 internal fun parseStatus(
     statusRaw: String?,
     legacyLocked: Boolean?,
 ): MonthlyMoneyStatus {
     if (statusRaw != null) {
-        return runCatching { MonthlyMoneyStatus.valueOf(statusRaw) }
-            .getOrDefault(MonthlyMoneyStatus.PENDING)
+        val parsed = runCatching { MonthlyMoneyStatus.valueOf(statusRaw) }.getOrNull()
+        if (parsed != null) return parsed
+        logger.warn("Unknown MonthlyMoneyStatus value: {} — falling back to legacy locked", statusRaw)
     }
     return if (legacyLocked == true) MonthlyMoneyStatus.FROZEN else MonthlyMoneyStatus.PENDING
 }

--- a/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
+++ b/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
@@ -5,6 +5,7 @@ import com.google.cloud.firestore.Firestore
 import model.MoneyItem
 import model.MoneyTags
 import model.MonthlyMoney
+import model.MonthlyMoneyStatus
 import model.Payment
 import model.PaymentRecord
 import server.cache.Cacheable
@@ -73,7 +74,7 @@ class FirestoreMoneyRepository(
         firestore
             .collection(MONEY_COLLECTION)
             .document(month)
-            .set(mapOf("month" to month, "items" to items, "paymentRecords" to records, "locked" to data.locked))
+            .set(mapOf("month" to month, "items" to items, "paymentRecords" to records, "status" to data.status.name))
             .await()
 
         cache[month] = data
@@ -119,9 +120,25 @@ class FirestoreMoneyRepository(
     ): MonthlyMoney {
         val items = parseItems(doc.get("items"))
         val records = parsePaymentRecords(doc.get("paymentRecords"))
-        val locked = doc.getBoolean("locked") ?: false
-        return MonthlyMoney(month = month, items = items, paymentRecords = records, locked = locked)
+        val status = parseStatus(doc.getString("status"), doc.getBoolean("locked"))
+        return MonthlyMoney(month = month, items = items, paymentRecords = records, status = status)
     }
+}
+
+/**
+ * Firestore の生フィールドから MonthlyMoneyStatus を復元する。
+ * 新形式は `status: "FROZEN"` 等の文字列。旧形式（`locked: Boolean` のみ）からは
+ * `locked=true → FROZEN`, `locked=false → PENDING` にフォールバックする。
+ */
+internal fun parseStatus(
+    statusRaw: String?,
+    legacyLocked: Boolean?,
+): MonthlyMoneyStatus {
+    if (statusRaw != null) {
+        return runCatching { MonthlyMoneyStatus.valueOf(statusRaw) }
+            .getOrDefault(MonthlyMoneyStatus.PENDING)
+    }
+    return if (legacyLocked == true) MonthlyMoneyStatus.FROZEN else MonthlyMoneyStatus.PENDING
 }
 
 /** Map リストから MoneyItem リストをパースする（テスト用に internal） */

--- a/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
+++ b/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
@@ -49,6 +49,15 @@ class FirestoreMoneyRepository(
         return data
     }
 
+    /**
+     * 月次お金データを Firestore に保存する。
+     *
+     * `set(Map)` は `SetOptions.merge()` を指定しないためドキュメント全体を置換する。
+     * これにより、旧スキーマの `locked: Boolean` フィールドを持つドキュメントを保存した際に
+     * `locked` が自動で削除され、legacy フィールドが残留しない。
+     * 将来この呼び出しを `merge` に変える場合は、`"locked" to FieldValue.delete()` を明示的に
+     * 含めて legacy フィールドの除去を維持すること。
+     */
     override suspend fun saveMonthlyMoney(
         month: String,
         data: MonthlyMoney,

--- a/server/src/main/kotlin/server/money/MoneyFilters.kt
+++ b/server/src/main/kotlin/server/money/MoneyFilters.kt
@@ -5,5 +5,5 @@ import model.MonthlyMoney
 fun MonthlyMoney.filterForUser(uid: String): MonthlyMoney {
     val userItems = items.filter { item -> item.payments.any { it.uid == uid } }
     val userRecords = paymentRecords.filter { it.uid == uid }
-    return MonthlyMoney(month = month, items = userItems, paymentRecords = userRecords, locked = locked)
+    return MonthlyMoney(month = month, items = userItems, paymentRecords = userRecords, status = status)
 }

--- a/server/src/main/kotlin/server/money/MoneyRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyRoutes.kt
@@ -86,8 +86,9 @@ fun Route.moneyRoutes() {
                 }
                 val body = call.receive<MonthlyMoney>()
                 // status フィールドはこのエンドポイントでは変更しない（専用 PATCH /status で更新）
-                moneyRepository.saveMonthlyMoney(month, body.copy(status = existing.status))
-                call.respond(body.copy(status = existing.status))
+                val normalized = body.copy(status = existing.status)
+                moneyRepository.saveMonthlyMoney(month, normalized)
+                call.respond(normalized)
             }
 
             patch("status", {

--- a/server/src/main/kotlin/server/money/MoneyRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyRoutes.kt
@@ -69,7 +69,7 @@ fun Route.moneyRoutes() {
                 tags = listOf("money")
                 summary = "月次お金データ保存（admin）"
                 description =
-                    "items / paymentRecords を保存する。body.status は無視され、既存値（新規月は PENDING）が維持される。" +
+                    "items / paymentRecords を保存する。body.status は無視され、既存値（新規月は PENDING）が維持される。 " +
                     "status を変更する場合は PATCH /status を使うこと。"
                 request {
                     pathParameter<String>("month") { description = "月（YYYY-MM）" }

--- a/server/src/main/kotlin/server/money/MoneyRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyRoutes.kt
@@ -12,6 +12,7 @@ import io.ktor.server.util.getOrFail
 import model.MoneyTags
 import model.MonthlyMoney
 import model.MonthlyMoneyStatus
+import model.MonthlyMoneyStatusUpdate
 import model.PaymentRecord
 import org.koin.ktor.ext.inject
 import server.auth.adminOnly
@@ -104,7 +105,7 @@ fun Route.moneyRoutes() {
                     "含めた任意の状態遷移を admin 権限で許可する。凍結運用を admin が解除できる唯一の経路。"
                 request {
                     pathParameter<String>("month") { description = "月（YYYY-MM）" }
-                    body<MonthlyMoneyStatus>()
+                    body<MonthlyMoneyStatusUpdate>()
                 }
                 response {
                     code(HttpStatusCode.OK) {
@@ -113,10 +114,10 @@ fun Route.moneyRoutes() {
                 }
             }) {
                 val month = call.parameters.getOrFail("month")
-                val newStatus = call.receive<MonthlyMoneyStatus>()
+                val body = call.receive<MonthlyMoneyStatusUpdate>()
                 val existing = moneyRepository.getMonthlyMoney(month) ?: MonthlyMoney(month = month)
                 // FROZEN からの遷移も含めて admin に任意の状態遷移を許可する（凍結解除の唯一経路）。
-                val updated = existing.copy(status = newStatus)
+                val updated = existing.copy(status = body.status)
                 moneyRepository.saveMonthlyMoney(month, updated)
                 call.respond(updated)
             }

--- a/server/src/main/kotlin/server/money/MoneyRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyRoutes.kt
@@ -67,6 +67,9 @@ fun Route.moneyRoutes() {
             put({
                 tags = listOf("money")
                 summary = "月次お金データ保存（admin）"
+                description =
+                    "items / paymentRecords を保存する。body.status は無視され、既存値（新規月は PENDING）が維持される。" +
+                    "status を変更する場合は PATCH /status を使うこと。"
                 request {
                     pathParameter<String>("month") { description = "月（YYYY-MM）" }
                     body<MonthlyMoney>()
@@ -85,7 +88,8 @@ fun Route.moneyRoutes() {
                     return@put
                 }
                 val body = call.receive<MonthlyMoney>()
-                // status フィールドはこのエンドポイントでは変更しない（専用 PATCH /status で更新）
+                // status はこのエンドポイントでは変更しない（専用 PATCH /status で更新）。
+                // 新規月の場合 existing.status は PENDING になる点に注意。
                 val normalized = body.copy(status = existing.status)
                 moneyRepository.saveMonthlyMoney(month, normalized)
                 call.respond(normalized)

--- a/server/src/main/kotlin/server/money/MoneyRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyRoutes.kt
@@ -9,20 +9,15 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.getOrFail
-import kotlinx.serialization.Serializable
 import model.MoneyTags
 import model.MonthlyMoney
 import model.MonthlyMoneyStatus
+import model.MonthlyMoneyStatusUpdate
 import model.PaymentRecord
 import org.koin.ktor.ext.inject
 import server.auth.adminOnly
 import server.auth.authenticated
 import server.auth.firebasePrincipal
-
-@Serializable
-data class MonthlyMoneyStatusUpdate(
-    val status: MonthlyMoneyStatus,
-)
 
 fun Route.moneyRoutes() {
     val moneyRepository by inject<MoneyRepository>()

--- a/server/src/main/kotlin/server/money/MoneyRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyRoutes.kt
@@ -12,7 +12,6 @@ import io.ktor.server.util.getOrFail
 import model.MoneyTags
 import model.MonthlyMoney
 import model.MonthlyMoneyStatus
-import model.MonthlyMoneyStatusUpdate
 import model.PaymentRecord
 import org.koin.ktor.ext.inject
 import server.auth.adminOnly
@@ -96,7 +95,7 @@ fun Route.moneyRoutes() {
                 summary = "月次ステータス更新（admin）"
                 request {
                     pathParameter<String>("month") { description = "月（YYYY-MM）" }
-                    body<MonthlyMoneyStatusUpdate>()
+                    body<MonthlyMoneyStatus>()
                 }
                 response {
                     code(HttpStatusCode.OK) {
@@ -105,9 +104,9 @@ fun Route.moneyRoutes() {
                 }
             }) {
                 val month = call.parameters.getOrFail("month")
-                val body = call.receive<MonthlyMoneyStatusUpdate>()
+                val newStatus = call.receive<MonthlyMoneyStatus>()
                 val existing = moneyRepository.getMonthlyMoney(month) ?: MonthlyMoney(month = month)
-                val updated = existing.copy(status = body.status)
+                val updated = existing.copy(status = newStatus)
                 moneyRepository.saveMonthlyMoney(month, updated)
                 call.respond(updated)
             }

--- a/server/src/main/kotlin/server/money/MoneyRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyRoutes.kt
@@ -69,8 +69,8 @@ fun Route.moneyRoutes() {
                 tags = listOf("money")
                 summary = "月次お金データ保存（admin）"
                 description =
-                    "items / paymentRecords を保存する。body.status は無視され、既存値（新規月は PENDING）が維持される。 " +
-                    "status を変更する場合は PATCH /status を使うこと。"
+                    "items / paymentRecords を保存する。body.status は無視され、" +
+                    "既存値（新規月は PENDING）が維持される。status を変更する場合は PATCH /status を使うこと。"
                 request {
                     pathParameter<String>("month") { description = "月（YYYY-MM）" }
                     body<MonthlyMoney>()

--- a/server/src/main/kotlin/server/money/MoneyRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyRoutes.kt
@@ -9,13 +9,20 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.getOrFail
+import kotlinx.serialization.Serializable
 import model.MoneyTags
 import model.MonthlyMoney
+import model.MonthlyMoneyStatus
 import model.PaymentRecord
 import org.koin.ktor.ext.inject
 import server.auth.adminOnly
 import server.auth.authenticated
 import server.auth.firebasePrincipal
+
+@Serializable
+data class MonthlyMoneyStatusUpdate(
+    val status: MonthlyMoneyStatus,
+)
 
 fun Route.moneyRoutes() {
     val moneyRepository by inject<MoneyRepository>()
@@ -50,13 +57,13 @@ fun Route.moneyRoutes() {
                     code(HttpStatusCode.OK) {
                         body<MonthlyMoney>()
                     }
-                    code(HttpStatusCode.Conflict) { description = "ロック中" }
+                    code(HttpStatusCode.Conflict) { description = "凍結中" }
                 }
             }) {
                 val month = call.parameters.getOrFail("month")
                 val existing = moneyRepository.getMonthlyMoney(month)
-                if (existing?.locked == true) {
-                    call.respond(HttpStatusCode.Conflict, mapOf("error" to "Month is locked"))
+                if (existing?.status == MonthlyMoneyStatus.FROZEN) {
+                    call.respond(HttpStatusCode.Conflict, mapOf("error" to "Month is frozen"))
                     return@post
                 }
                 val updated = moneyRepository.importItemsByTag(month, MoneyTags.RECURRING)
@@ -74,25 +81,27 @@ fun Route.moneyRoutes() {
                     code(HttpStatusCode.OK) {
                         body<MonthlyMoney>()
                     }
-                    code(HttpStatusCode.Conflict) { description = "ロック中" }
+                    code(HttpStatusCode.Conflict) { description = "凍結中" }
                 }
             }) {
                 val month = call.parameters.getOrFail("month")
                 val existing = moneyRepository.getMonthlyMoney(month) ?: MonthlyMoney(month = month)
-                if (existing.locked) {
-                    call.respond(HttpStatusCode.Conflict, mapOf("error" to "Month is locked"))
+                if (existing.status == MonthlyMoneyStatus.FROZEN) {
+                    call.respond(HttpStatusCode.Conflict, mapOf("error" to "Month is frozen"))
                     return@put
                 }
                 val body = call.receive<MonthlyMoney>()
-                moneyRepository.saveMonthlyMoney(month, body)
-                call.respond(body)
+                // status フィールドはこのエンドポイントでは変更しない（専用 PATCH /status で更新）
+                moneyRepository.saveMonthlyMoney(month, body.copy(status = existing.status))
+                call.respond(body.copy(status = existing.status))
             }
 
-            patch("lock", {
+            patch("status", {
                 tags = listOf("money")
-                summary = "月次ロック切り替え（admin）"
+                summary = "月次ステータス更新（admin）"
                 request {
                     pathParameter<String>("month") { description = "月（YYYY-MM）" }
+                    body<MonthlyMoneyStatusUpdate>()
                 }
                 response {
                     code(HttpStatusCode.OK) {
@@ -101,8 +110,9 @@ fun Route.moneyRoutes() {
                 }
             }) {
                 val month = call.parameters.getOrFail("month")
+                val body = call.receive<MonthlyMoneyStatusUpdate>()
                 val existing = moneyRepository.getMonthlyMoney(month) ?: MonthlyMoney(month = month)
-                val updated = existing.copy(locked = !existing.locked)
+                val updated = existing.copy(status = body.status)
                 moneyRepository.saveMonthlyMoney(month, updated)
                 call.respond(updated)
             }
@@ -149,7 +159,7 @@ fun Route.moneyRoutes() {
                         body<MonthlyMoney>()
                     }
                     code(HttpStatusCode.NotFound) { description = "月データ未作成" }
-                    code(HttpStatusCode.Conflict) { description = "ロック中" }
+                    code(HttpStatusCode.Conflict) { description = "凍結中" }
                 }
             }) {
                 val month = call.parameters.getOrFail("month")
@@ -164,8 +174,8 @@ fun Route.moneyRoutes() {
                     return@post
                 }
 
-                if (data.locked) {
-                    call.respond(HttpStatusCode.Conflict, mapOf("error" to "Month is locked"))
+                if (data.status == MonthlyMoneyStatus.FROZEN) {
+                    call.respond(HttpStatusCode.Conflict, mapOf("error" to "Month is frozen"))
                     return@post
                 }
                 val updated = data.copy(paymentRecords = data.paymentRecords + safeRecord)

--- a/server/src/main/kotlin/server/money/MoneyRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyRoutes.kt
@@ -98,6 +98,10 @@ fun Route.moneyRoutes() {
             patch("status", {
                 tags = listOf("money")
                 summary = "月次ステータス更新（admin）"
+                description =
+                    "月次の MonthlyMoneyStatus を更新する。他エンドポイント（PUT / pay / redemption 等）が " +
+                    "FROZEN の月を 409 で拒否するのに対し、このエンドポイントは FROZEN からの遷移（凍結解除）も " +
+                    "含めた任意の状態遷移を admin 権限で許可する。凍結運用を admin が解除できる唯一の経路。"
                 request {
                     pathParameter<String>("month") { description = "月（YYYY-MM）" }
                     body<MonthlyMoneyStatus>()
@@ -111,6 +115,7 @@ fun Route.moneyRoutes() {
                 val month = call.parameters.getOrFail("month")
                 val newStatus = call.receive<MonthlyMoneyStatus>()
                 val existing = moneyRepository.getMonthlyMoney(month) ?: MonthlyMoney(month = month)
+                // FROZEN からの遷移も含めて admin に任意の状態遷移を許可する（凍結解除の唯一経路）。
                 val updated = existing.copy(status = newStatus)
                 moneyRepository.saveMonthlyMoney(month, updated)
                 call.respond(updated)

--- a/server/src/main/kotlin/server/report/ReportRoutes.kt
+++ b/server/src/main/kotlin/server/report/ReportRoutes.kt
@@ -13,6 +13,7 @@ import model.ExpenseReport
 import model.MoneyTags
 import model.MonthlyExpenseSummary
 import model.MonthlyMoney
+import model.MonthlyMoneyStatus
 import model.OverpaymentRedemptionRequest
 import model.PaymentRecord
 import model.UserBalance
@@ -118,7 +119,7 @@ fun Route.reportRoutes() {
                     body<Map<String, String>>()
                 }
                 code(HttpStatusCode.BadRequest) { description = "不正なリクエスト" }
-                code(HttpStatusCode.Conflict) { description = "ロック中" }
+                code(HttpStatusCode.Conflict) { description = "凍結中" }
             }
         }) {
             val req = call.receive<OverpaymentRedemptionRequest>()
@@ -133,8 +134,8 @@ fun Route.reportRoutes() {
             }
 
             val data = moneyRepository.getMonthlyMoney(req.month) ?: MonthlyMoney(month = req.month)
-            if (data.locked) {
-                call.respond(HttpStatusCode.Conflict, mapOf("error" to "Month is locked"))
+            if (data.status == MonthlyMoneyStatus.FROZEN) {
+                call.respond(HttpStatusCode.Conflict, mapOf("error" to "Month is frozen"))
                 return@post
             }
             val record =

--- a/server/src/test/kotlin/server/money/MoneyFiltersTest.kt
+++ b/server/src/test/kotlin/server/money/MoneyFiltersTest.kt
@@ -2,6 +2,7 @@ package server.money
 
 import model.MoneyItem
 import model.MonthlyMoney
+import model.MonthlyMoneyStatus
 import model.Payment
 import model.PaymentRecord
 import kotlin.test.Test
@@ -48,16 +49,18 @@ class MoneyFiltersTest {
     }
 
     @Test
-    fun filterPreservesLockedState() {
-        val data =
-            MonthlyMoney(
-                month = "2024-06",
-                items = emptyList(),
-                paymentRecords = emptyList(),
-                locked = true,
-            )
-        val filtered = data.filterForUser("u1")
-        assertEquals(true, filtered.locked)
+    fun filterPreservesStatus() {
+        for (status in MonthlyMoneyStatus.entries) {
+            val data =
+                MonthlyMoney(
+                    month = "2024-06",
+                    items = emptyList(),
+                    paymentRecords = emptyList(),
+                    status = status,
+                )
+            val filtered = data.filterForUser("u1")
+            assertEquals(status, filtered.status)
+        }
     }
 
     @Test

--- a/server/src/test/kotlin/server/money/MoneyParsingTest.kt
+++ b/server/src/test/kotlin/server/money/MoneyParsingTest.kt
@@ -129,9 +129,9 @@ class MoneyParsingTest {
     }
 
     @Test
-    fun parseStatusFromExplicitWireValue() {
+    fun parseStatusFromExplicitString() {
         for (status in MonthlyMoneyStatus.entries) {
-            assertEquals(status, parseStatus(status.wireValue, null))
+            assertEquals(status, parseStatus(status.name, null))
         }
     }
 

--- a/server/src/test/kotlin/server/money/MoneyParsingTest.kt
+++ b/server/src/test/kotlin/server/money/MoneyParsingTest.kt
@@ -156,7 +156,17 @@ class MoneyParsingTest {
     }
 
     @Test
-    fun parseStatusFallsBackToPendingForUnknownString() {
-        assertEquals(MonthlyMoneyStatus.PENDING, parseStatus("UNKNOWN_VALUE", true))
+    fun parseStatusFallsBackToFrozenForUnknownStringWhenLegacyLocked() {
+        assertEquals(MonthlyMoneyStatus.FROZEN, parseStatus("UNKNOWN_VALUE", true))
+    }
+
+    @Test
+    fun parseStatusFallsBackToPendingForUnknownStringWhenLegacyUnlocked() {
+        assertEquals(MonthlyMoneyStatus.PENDING, parseStatus("UNKNOWN_VALUE", false))
+    }
+
+    @Test
+    fun parseStatusFallsBackToPendingForUnknownStringWhenLegacyAbsent() {
+        assertEquals(MonthlyMoneyStatus.PENDING, parseStatus("UNKNOWN_VALUE", null))
     }
 }

--- a/server/src/test/kotlin/server/money/MoneyParsingTest.kt
+++ b/server/src/test/kotlin/server/money/MoneyParsingTest.kt
@@ -129,9 +129,9 @@ class MoneyParsingTest {
     }
 
     @Test
-    fun parseStatusFromExplicitString() {
+    fun parseStatusFromExplicitWireValue() {
         for (status in MonthlyMoneyStatus.entries) {
-            assertEquals(status, parseStatus(status.name, null))
+            assertEquals(status, parseStatus(status.wireValue, null))
         }
     }
 

--- a/server/src/test/kotlin/server/money/MoneyParsingTest.kt
+++ b/server/src/test/kotlin/server/money/MoneyParsingTest.kt
@@ -169,4 +169,17 @@ class MoneyParsingTest {
     fun parseStatusFallsBackToPendingForUnknownStringWhenLegacyAbsent() {
         assertEquals(MonthlyMoneyStatus.PENDING, parseStatus("UNKNOWN_VALUE", null))
     }
+
+    @Test
+    fun parseStatusTreatsBlankStringAsAbsent() {
+        assertEquals(MonthlyMoneyStatus.PENDING, parseStatus("", null))
+        assertEquals(MonthlyMoneyStatus.PENDING, parseStatus("   ", null))
+        assertEquals(MonthlyMoneyStatus.FROZEN, parseStatus("", true))
+    }
+
+    @Test
+    fun parseStatusTrimsSurroundingWhitespace() {
+        assertEquals(MonthlyMoneyStatus.CONFIRMED, parseStatus(" CONFIRMED ", null))
+        assertEquals(MonthlyMoneyStatus.FROZEN, parseStatus("\tFROZEN\n", null))
+    }
 }

--- a/server/src/test/kotlin/server/money/MoneyParsingTest.kt
+++ b/server/src/test/kotlin/server/money/MoneyParsingTest.kt
@@ -1,6 +1,7 @@
 package server.money
 
 import model.MoneyTags
+import model.MonthlyMoneyStatus
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -125,5 +126,37 @@ class MoneyParsingTest {
     @Test
     fun parsePaymentRecordsReturnsEmptyForNull() {
         assertEquals(emptyList(), parsePaymentRecords(null))
+    }
+
+    @Test
+    fun parseStatusFromExplicitString() {
+        for (status in MonthlyMoneyStatus.entries) {
+            assertEquals(status, parseStatus(status.name, null))
+        }
+    }
+
+    @Test
+    fun parseStatusFallsBackToLegacyLockedTrue() {
+        assertEquals(MonthlyMoneyStatus.FROZEN, parseStatus(null, true))
+    }
+
+    @Test
+    fun parseStatusFallsBackToLegacyLockedFalse() {
+        assertEquals(MonthlyMoneyStatus.PENDING, parseStatus(null, false))
+    }
+
+    @Test
+    fun parseStatusDefaultsToPendingWhenAbsent() {
+        assertEquals(MonthlyMoneyStatus.PENDING, parseStatus(null, null))
+    }
+
+    @Test
+    fun parseStatusStringTakesPrecedenceOverLegacyLocked() {
+        assertEquals(MonthlyMoneyStatus.CONFIRMED, parseStatus("CONFIRMED", true))
+    }
+
+    @Test
+    fun parseStatusFallsBackToPendingForUnknownString() {
+        assertEquals(MonthlyMoneyStatus.PENDING, parseStatus("UNKNOWN_VALUE", true))
     }
 }

--- a/shared/src/commonMain/kotlin/model/MoneyModels.kt
+++ b/shared/src/commonMain/kotlin/model/MoneyModels.kt
@@ -51,3 +51,8 @@ data class MonthlyMoney(
     val paymentRecords: List<PaymentRecord> = emptyList(),
     val status: MonthlyMoneyStatus = MonthlyMoneyStatus.PENDING,
 )
+
+@Serializable
+data class MonthlyMoneyStatusUpdate(
+    val status: MonthlyMoneyStatus,
+)

--- a/shared/src/commonMain/kotlin/model/MoneyModels.kt
+++ b/shared/src/commonMain/kotlin/model/MoneyModels.kt
@@ -52,11 +52,6 @@ data class MonthlyMoney(
     val status: MonthlyMoneyStatus = MonthlyMoneyStatus.PENDING,
 )
 
-/**
- * PATCH /api/money/{month}/status の body。
- * 単一フィールドでも DTO としてラップすることで、API の body 構造を
- * `{ "status": "..." }` に統一する（プロジェクト方針: CLAUDE.md 参照）。
- */
 @Serializable
 data class MonthlyMoneyStatusUpdate(
     val status: MonthlyMoneyStatus,

--- a/shared/src/commonMain/kotlin/model/MoneyModels.kt
+++ b/shared/src/commonMain/kotlin/model/MoneyModels.kt
@@ -51,8 +51,3 @@ data class MonthlyMoney(
     val paymentRecords: List<PaymentRecord> = emptyList(),
     val status: MonthlyMoneyStatus = MonthlyMoneyStatus.PENDING,
 )
-
-@Serializable
-data class MonthlyMoneyStatusUpdate(
-    val status: MonthlyMoneyStatus,
-)

--- a/shared/src/commonMain/kotlin/model/MoneyModels.kt
+++ b/shared/src/commonMain/kotlin/model/MoneyModels.kt
@@ -71,3 +71,13 @@ data class MonthlyMoney(
     val paymentRecords: List<PaymentRecord> = emptyList(),
     val status: MonthlyMoneyStatus = MonthlyMoneyStatus.PENDING,
 )
+
+/**
+ * PATCH /api/money/{month}/status の body。
+ * 単一フィールドでも DTO としてラップすることで、API の body 構造を
+ * \`{ "status": "..." }\` に統一する（プロジェクト方針: CLAUDE.md 参照）。
+ */
+@Serializable
+data class MonthlyMoneyStatusUpdate(
+    val status: MonthlyMoneyStatus,
+)

--- a/shared/src/commonMain/kotlin/model/MoneyModels.kt
+++ b/shared/src/commonMain/kotlin/model/MoneyModels.kt
@@ -1,6 +1,5 @@
 package model
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -33,35 +32,16 @@ object MoneyTags {
     const val CARRY_OVER = "繰越"
 }
 
-/**
- * 月次支払いの状態。
- *
- * 各 enum 値には Firestore / JSON 保存時に使うワイヤ値 [wireValue] を持たせている。
- * Kotlin 側の enum 名称を将来リネームしても [wireValue] を保持すれば既存データは
- * 壊れない。JSON シリアライズも [SerialName] で [wireValue] に揃えているため、
- * Firestore / API / 保存形式の 3 つで表現を一元管理できる。
- */
 @Serializable
-enum class MonthlyMoneyStatus(
-    val wireValue: String,
-) {
+enum class MonthlyMoneyStatus {
     /** 支払い内容を組み立て中。ユーザーには「確定前」として表示する。 */
-    @SerialName("PENDING")
-    PENDING("PENDING"),
+    PENDING,
 
     /** 支払い内容が確定済み。ユーザーへの告知目的のみで、操作制約は掛からない。 */
-    @SerialName("CONFIRMED")
-    CONFIRMED("CONFIRMED"),
+    CONFIRMED,
 
     /** 月跨ぎ等で凍結済み。項目編集・支払い記録のすべてを拒否する。 */
-    @SerialName("FROZEN")
-    FROZEN("FROZEN"),
-    ;
-
-    companion object {
-        /** ワイヤ値から enum を復元する。未知の値は null を返す。 */
-        fun fromWireValue(value: String): MonthlyMoneyStatus? = entries.firstOrNull { it.wireValue == value }
-    }
+    FROZEN,
 }
 
 @Serializable
@@ -75,7 +55,7 @@ data class MonthlyMoney(
 /**
  * PATCH /api/money/{month}/status の body。
  * 単一フィールドでも DTO としてラップすることで、API の body 構造を
- * \`{ "status": "..." }\` に統一する（プロジェクト方針: CLAUDE.md 参照）。
+ * `{ "status": "..." }` に統一する（プロジェクト方針: CLAUDE.md 参照）。
  */
 @Serializable
 data class MonthlyMoneyStatusUpdate(

--- a/shared/src/commonMain/kotlin/model/MoneyModels.kt
+++ b/shared/src/commonMain/kotlin/model/MoneyModels.kt
@@ -33,9 +33,21 @@ object MoneyTags {
 }
 
 @Serializable
+enum class MonthlyMoneyStatus {
+    /** 支払い内容を組み立て中。ユーザーには「確定前」として表示する。 */
+    PENDING,
+
+    /** 支払い内容が確定済み。ユーザーへの告知目的のみで、操作制約は掛からない。 */
+    CONFIRMED,
+
+    /** 月跨ぎ等で凍結済み。項目編集・支払い記録のすべてを拒否する。 */
+    FROZEN,
+}
+
+@Serializable
 data class MonthlyMoney(
     val month: String,
     val items: List<MoneyItem> = emptyList(),
     val paymentRecords: List<PaymentRecord> = emptyList(),
-    val locked: Boolean = false,
+    val status: MonthlyMoneyStatus = MonthlyMoneyStatus.PENDING,
 )

--- a/shared/src/commonMain/kotlin/model/MoneyModels.kt
+++ b/shared/src/commonMain/kotlin/model/MoneyModels.kt
@@ -1,5 +1,6 @@
 package model
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -32,16 +33,35 @@ object MoneyTags {
     const val CARRY_OVER = "繰越"
 }
 
+/**
+ * 月次支払いの状態。
+ *
+ * 各 enum 値には Firestore / JSON 保存時に使うワイヤ値 [wireValue] を持たせている。
+ * Kotlin 側の enum 名称を将来リネームしても [wireValue] を保持すれば既存データは
+ * 壊れない。JSON シリアライズも [SerialName] で [wireValue] に揃えているため、
+ * Firestore / API / 保存形式の 3 つで表現を一元管理できる。
+ */
 @Serializable
-enum class MonthlyMoneyStatus {
+enum class MonthlyMoneyStatus(
+    val wireValue: String,
+) {
     /** 支払い内容を組み立て中。ユーザーには「確定前」として表示する。 */
-    PENDING,
+    @SerialName("PENDING")
+    PENDING("PENDING"),
 
     /** 支払い内容が確定済み。ユーザーへの告知目的のみで、操作制約は掛からない。 */
-    CONFIRMED,
+    @SerialName("CONFIRMED")
+    CONFIRMED("CONFIRMED"),
 
     /** 月跨ぎ等で凍結済み。項目編集・支払い記録のすべてを拒否する。 */
-    FROZEN,
+    @SerialName("FROZEN")
+    FROZEN("FROZEN"),
+    ;
+
+    companion object {
+        /** ワイヤ値から enum を復元する。未知の値は null を返す。 */
+        fun fromWireValue(value: String): MonthlyMoneyStatus? = entries.firstOrNull { it.wireValue == value }
+    }
 }
 
 @Serializable

--- a/shared/src/commonTest/kotlin/model/MoneyModelsTest.kt
+++ b/shared/src/commonTest/kotlin/model/MoneyModelsTest.kt
@@ -99,17 +99,19 @@ class MoneyModelsTest {
     }
 
     @Test
-    fun monthlyMoneyLockedDefault() {
+    fun monthlyMoneyStatusDefault() {
         val jsonStr = """{"month":"2024-07"}"""
         val decoded = json.decodeFromString(MonthlyMoney.serializer(), jsonStr)
-        assertEquals(false, decoded.locked)
+        assertEquals(MonthlyMoneyStatus.PENDING, decoded.status)
     }
 
     @Test
-    fun monthlyMoneyLockedRoundTrip() {
-        val monthly = MonthlyMoney(month = "2024-07", locked = true)
-        val encoded = json.encodeToString(MonthlyMoney.serializer(), monthly)
-        val decoded = json.decodeFromString(MonthlyMoney.serializer(), encoded)
-        assertEquals(true, decoded.locked)
+    fun monthlyMoneyStatusRoundTrip() {
+        for (status in MonthlyMoneyStatus.entries) {
+            val monthly = MonthlyMoney(month = "2024-07", status = status)
+            val encoded = json.encodeToString(MonthlyMoney.serializer(), monthly)
+            val decoded = json.decodeFromString(MonthlyMoney.serializer(), encoded)
+            assertEquals(status, decoded.status)
+        }
     }
 }

--- a/shared/src/commonTest/kotlin/model/MoneyModelsTest.kt
+++ b/shared/src/commonTest/kotlin/model/MoneyModelsTest.kt
@@ -6,7 +6,6 @@ import kotlin.test.assertEquals
 
 class MoneyModelsTest {
     private val json = Json
-    private val jsonWithDefaults = Json { encodeDefaults = true }
 
     @Test
     fun paymentRoundTrip() {
@@ -114,22 +113,5 @@ class MoneyModelsTest {
             val decoded = json.decodeFromString(MonthlyMoney.serializer(), encoded)
             assertEquals(status, decoded.status)
         }
-    }
-
-    @Test
-    fun monthlyMoneyStatusWireValueMatchesJsonRepresentation() {
-        for (status in MonthlyMoneyStatus.entries) {
-            val monthly = MonthlyMoney(month = "2024-07", status = status)
-            val encoded = jsonWithDefaults.encodeToString(MonthlyMoney.serializer(), monthly)
-            assertEquals(true, encoded.contains("\"status\":\"${status.wireValue}\""))
-        }
-    }
-
-    @Test
-    fun monthlyMoneyStatusFromWireValue() {
-        for (status in MonthlyMoneyStatus.entries) {
-            assertEquals(status, MonthlyMoneyStatus.fromWireValue(status.wireValue))
-        }
-        assertEquals(null, MonthlyMoneyStatus.fromWireValue("UNKNOWN"))
     }
 }

--- a/shared/src/commonTest/kotlin/model/MoneyModelsTest.kt
+++ b/shared/src/commonTest/kotlin/model/MoneyModelsTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertEquals
 
 class MoneyModelsTest {
     private val json = Json
+    private val jsonWithDefaults = Json { encodeDefaults = true }
 
     @Test
     fun paymentRoundTrip() {
@@ -113,5 +114,22 @@ class MoneyModelsTest {
             val decoded = json.decodeFromString(MonthlyMoney.serializer(), encoded)
             assertEquals(status, decoded.status)
         }
+    }
+
+    @Test
+    fun monthlyMoneyStatusWireValueMatchesJsonRepresentation() {
+        for (status in MonthlyMoneyStatus.entries) {
+            val monthly = MonthlyMoney(month = "2024-07", status = status)
+            val encoded = jsonWithDefaults.encodeToString(MonthlyMoney.serializer(), monthly)
+            assertEquals(true, encoded.contains("\"status\":\"${status.wireValue}\""))
+        }
+    }
+
+    @Test
+    fun monthlyMoneyStatusFromWireValue() {
+        for (status in MonthlyMoneyStatus.entries) {
+            assertEquals(status, MonthlyMoneyStatus.fromWireValue(status.wireValue))
+        }
+        assertEquals(null, MonthlyMoneyStatus.fromWireValue("UNKNOWN"))
     }
 }


### PR DESCRIPTION
## 概要

月次支払いの状態表現を `locked: Boolean` から `MonthlyMoneyStatus` enum に差し替え、
以下の 3 段階で管理する。

| ステータス | 意味 | 操作制約 |
|----|----|----|
| `PENDING` | 支払いデータ追加中（確定前） | なし（UI 表示用） |
| `CONFIRMED` | 支払内容確定済み | なし（UI 表示用） |
| `FROZEN` | 月跨ぎ等で凍結 | 項目編集・支払い記録・過払い金精算を全て拒否 |

`PENDING` と `CONFIRMED` は一般ユーザー向けの告知目的のみで、API の操作制約は掛けない。
凍結 (`FROZEN`) は従来の `locked=true` と同じ挙動。

## 主な変更点

- **shared**:
  - `MonthlyMoneyStatus` enum 追加。`MonthlyMoney.locked` → `status`。
  - `MonthlyMoneyStatusUpdate(status)` DTO を追加し、PATCH /status の body を
    `{ "status": "..." }` 形式に統一。
- **サーバー**:
  - `PATCH /api/money/{month}/lock` → `PATCH /api/money/{month}/status` に差し替え
    （body は `MonthlyMoneyStatusUpdate` DTO）。OpenAPI description で「FROZEN からの
    凍結解除を含む任意の遷移を admin 権限で許可する唯一の経路」と意図を明記。
  - `PUT /api/money/{month}`: OpenAPI description に「body.status は無視され既存値が
    維持される」挙動を明記。`body.copy(status = existing.status)` はローカル変数に束ねて整理。
  - 各ガードは `status == FROZEN` のみ拒否。
  - `FirestoreMoneyRepository`:
    - 旧 `locked` フィールドを自動マイグレーション（`locked=true → FROZEN`）。enum 値は `.name` 経由で保存・復元。
    - `saveMonthlyMoney` の `set(Map)` が全置換モードで旧 `locked` フィールドを自動除去する挙動を KDoc に明記。
  - `parseStatus` を純関数に切り出してユニットテスト化。未知 status 値 + `locked=true`
    の場合は FROZEN にフォールバック、未知値検知時は WARN ログを出力。空白・空文字列は
    null 扱いにして WARN ノイズを抑制。KDoc で旧 `locked=false` / 未設定が PENDING
    にフォールバックされる妥協点と admin 手動切替前提を明記。
- **core/ui**:
  - `MonthlyMoneyStatus.displayName` / `icon` を `core/ui/extensions/MonthlyMoneyStatusUi.kt`
    に集約（`GarbageTypeUi` などの既存パターンに整合）。
- **フロントエンド**:
  - MoneyScreen のロック切替アイコンを 3 状態 `FilterChip` に置き換え。
  - PaymentScreen の SummaryCard に `MonthlyMoneyStatusBadge`（確定前／確定済み／凍結）を常時表示。
  - `MoneyRepository.toggleLock` → `updateStatus(month, status)`。
  - 内部 Composable の冗長なデフォルト引数（`status`, `frozen`）は撤廃して呼び出し明示を強制。
  - 凍結警告の Row 内アイコンを `MonthlyMoneyStatus.FROZEN.icon`（= `Icons.Default.Block`）に統一。
- **ドキュメント**:
  - README.md に "API 設計" セクションを追加し、「リクエスト body は 1 フィールドでも
    必ず DTO でラップする」方針を明文化。
  - CLAUDE.md の Architecture セクションから README の「API 設計」へのポインタを追加。

## フォローアップ Issue

- #188 — `month: String = "YYYY-MM"` の命名を `yearMonth` に統一するリファクタ
  （本 PR では既存命名を踏襲しているが、英語的に正しくないため別途対応）。
- #189 — 月次ステータス切替の連打防止（`isSaving` インジケーター追加）。

## Test plan

- [x] `./gradlew :shared:jvmTest :server:test -PskipFrontend`
  - parseStatus の未知値 × legacy locked の組み合わせ網羅、空白・前後スペース正規化、
    `MonthlyMoney` の legacy `locked` フォールバック、enum の JSON ラウンドトリップ等
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew :feature:money:compileKotlinWasmJs :feature:payment:compileKotlinWasmJs :feature:report:compileKotlinWasmJs :core:network:compileKotlinWasmJs :core:ui:compileKotlinWasmJs`
- [ ] 手動確認: 旧 `locked` フィールドのみ保存されている月を開いたとき、適切に
      `FROZEN` / `PENDING` に復元されること
- [ ] 手動確認: 3 状態を切り替えたとき、支払い画面の表示バッジと操作可否が期待通りに変わること

🤖 Generated with [Claude Code](https://claude.com/claude-code)