### PR TITLE
CD の OOM 修正と Discord 成否通知の追加

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,3 +25,46 @@ jobs:
             -t ghcr.io/ptknktq/crabshell:${{ github.ref_name }} .
           docker push ghcr.io/ptknktq/crabshell:latest
           docker push ghcr.io/ptknktq/crabshell:${{ github.ref_name }}
+      - name: Notify Discord
+        if: always()
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          STATUS: ${{ job.status }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          if [ -z "$WEBHOOK_URL" ]; then
+            echo "DISCORD_WEBHOOK_URL is not set; skipping notification."
+            exit 0
+          fi
+          if [ "$STATUS" = "success" ]; then
+            title="CD 成功"
+            color=3066993
+          else
+            title="CD 失敗"
+            color=15158332
+          fi
+          short_sha="${SHA:0:7}"
+          payload=$(jq -n \
+            --arg title "$title" \
+            --argjson color "$color" \
+            --arg ref "$REF_NAME" \
+            --arg sha "$short_sha" \
+            --arg commit_url "$SERVER_URL/$REPO/commit/$SHA" \
+            --arg run_url "$SERVER_URL/$REPO/actions/runs/$RUN_ID" \
+            '{
+              embeds: [{
+                title: $title,
+                color: $color,
+                fields: [
+                  {name: "タグ", value: $ref, inline: true},
+                  {name: "コミット", value: ("[`" + $sha + "`](" + $commit_url + ")"), inline: true},
+                  {name: "ワークフロー", value: ("[実行ログを開く](" + $run_url + ")"), inline: false}
+                ],
+                timestamp: (now | todate)
+              }]
+            }')
+          curl -sSf -H "Content-Type: application/json" -d "$payload" "$WEBHOOK_URL"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,4 +67,5 @@ jobs:
                 timestamp: (now | todate)
               }]
             }')
-          curl -sSf -H "Content-Type: application/json" -d "$payload" "$WEBHOOK_URL"
+          curl -sS -H "Content-Type: application/json" -d "$payload" "$WEBHOOK_URL" \
+            || echo "::warning::Discord notification failed"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,8 @@ git tag v1.x.x && git push origin v1.x.x
 
 Dockerfile はマルチステージビルド（Gradle でビルド → JRE Alpine で実行）。ビルドステージで WASM フロントエンド + fat JAR を生成し、実行ステージは `eclipse-temurin:21-jre-alpine` 上で `app.jar` を起動する。ポート 8080 を公開。GHCR 経由で本番デプロイする（リバースプロキシ前提）。HEALTHCHECK 付き。詳細は README.md の「Docker」セクションを参照。
 
+ビルドステージでは CI runner の OOM 回避のため Gradle daemon `-Xmx2g` + Kotlin compiler daemon `-Xmx4g` + `parallel=false` で起動する。`compileProductionExecutableKotlinWasmJs` は別プロセス（Kotlin compiler daemon）で動くため、`org.gradle.jvmargs` ではなく `kotlin.daemon.jvmargs` を増やす必要がある。
+
 ```bash
 # 手動ビルド & push（通常は CD ワークフローが自動実行するため不要）
 docker build --build-arg COMMIT_HASH=$(git rev-parse --short HEAD) \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ The `server/build.gradle.kts` has a `copyWasmFrontend` task that copies the fron
 GitHub Actions で CI/CD を構成。
 
 - **CI** (`.github/workflows/ci.yml`): PR・main push 時に lint / test / build を実行。Renovate の patch auto-merge は `platformAutomerge: false` により CI pass 後に Renovate 自身がマージする。
-- **CD** (`.github/workflows/cd.yml`): `v*` タグ push 時に Docker イメージをビルドし GHCR に push。`:latest` と `:v1.x.x` の2タグ。
+- **CD** (`.github/workflows/cd.yml`): `v*` タグ push 時に Docker イメージをビルドし GHCR に push。`:latest` と `:v1.x.x` の2タグ。完了後に Discord へ成否通知（GitHub Secret `DISCORD_WEBHOOK_URL` が必要。未設定時は通知をスキップ）。
 
 ### デプロイフロー
 
@@ -217,6 +217,7 @@ PR マージ → main 更新（CI 検証済み）
   ↓ 任意のタイミングでタグ push
 git tag v1.x.x && git push origin v1.x.x
   ↓ CD が GHCR にイメージ push
+  ↓ Discord に成否通知
   ↓ 本番サーバーが定期的に pull → 自動反映
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ COPY core/ core/
 COPY feature/ feature/
 RUN gradle :server:buildFatJar --no-daemon \
     -Dorg.gradle.jvmargs="-Xmx2g -Dfile.encoding=UTF-8" \
-    -Dorg.gradle.parallel=false
+    -Dorg.gradle.parallel=false \
+    -Dkotlin.daemon.jvmargs="-Xmx4g"
 
 FROM eclipse-temurin:21.0.10_7-jre-noble
 WORKDIR /app


### PR DESCRIPTION
## Summary
- `:app:compileProductionExecutableKotlinWasmJs` の OOM (`v0.0.24` で再発) を Kotlin compiler daemon の heap 拡張で解消
- CD 完了時に Discord webhook で成否を通知
- 通知失敗で CD ジョブが赤くならないようにエラーハンドリング

## Changes
### fix: Kotlin compiler daemon heap 拡張
- `Dockerfile` の `RUN gradle :server:buildFatJar` に `-Dkotlin.daemon.jvmargs="-Xmx4g"` を追加
- 過去の対策（PR #174 の Gradle daemon `-Xmx2g`、PR #184 の `parallel=false`）は維持

### feat: Discord 通知
- `.github/workflows/cd.yml` に `Notify Discord` ステップを追加（`if: always()`）
- `DISCORD_WEBHOOK_URL` secret から URL を読み込み、未設定時はスキップ
- 成功は緑、失敗は赤の embed でタグ・コミット・実行ログリンクを送信

### fix: 通知失敗で CD を失敗扱いにしない
- `curl -sSf` → `curl -sS` に変更し、失敗時は `::warning::` ログのみ出力
- イメージ push 済みなのに通知側の不調でジョブが赤くなるのを防ぐ

## 背景: なぜまた OOM したのか
| PR | 症状 | 原因 | 対策 |
|---|---|---|---|
| #174 | runner lost communication | Gradle daemon `-Xmx4g` + worker JVM が runner RAM 上限超過 | Docker 内で `-Xmx2g` |
| #184 | OOM (`compileProductionExecutableKotlinWasmJs`) | `parallel=true` でモジュール並列コンパイル | `parallel=false` |
| **今回 (#187/v0.0.24)** | OOM (同タスク) | parallel=false でも wasmJs production 単体が 2GB heap を超過。発生箇所は **Kotlin compiler daemon** で `org.gradle.jvmargs` の対象外 | `kotlin.daemon.jvmargs=-Xmx4g` |

Gradle ログ自体が `kotlin.daemon.jvmargs=-Xmx<size>` を増やせと提案しており、これが今回の真因。

## 設定が必要な Secret
- `DISCORD_WEBHOOK_URL`: Discord チャンネルの incoming webhook URL（未設定時は通知スキップして CD は通る）

## Test plan
- [ ] secret `DISCORD_WEBHOOK_URL` を登録
- [ ] マージ後にタグ push → CD が完走すること（OOM が再発しないこと）
- [ ] Discord に成功通知が届くこと
- [ ] 検証用に `workflow_dispatch` で feature ブランチを手動実行し、通知が来ることを先に確認してもよい
- [ ] webhook URL を一時的に不正値にして CD を流し、ジョブが緑のまま warning だけ出ることを確認（任意）

🤖 Generated with [Claude Code](https://claude.com/claude-code)