### PR TITLE
kotlin.daemon.jvmargs を gradle.properties で指定して CD の OOM を解消

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,7 @@ git tag v1.x.x && git push origin v1.x.x
 
 Dockerfile はマルチステージビルド（Gradle でビルド → JRE Alpine で実行）。ビルドステージで WASM フロントエンド + fat JAR を生成し、実行ステージは `eclipse-temurin:21-jre-alpine` 上で `app.jar` を起動する。ポート 8080 を公開。GHCR 経由で本番デプロイする（リバースプロキシ前提）。HEALTHCHECK 付き。詳細は README.md の「Docker」セクションを参照。
 
-ビルドステージでは CI runner の OOM 回避のため Gradle daemon `-Xmx2g` + Kotlin compiler daemon `-Xmx4g` + `parallel=false` で起動する。`compileProductionExecutableKotlinWasmJs` は別プロセス（Kotlin compiler daemon）で動くため、`org.gradle.jvmargs` ではなく `kotlin.daemon.jvmargs` を増やす必要がある。
+ビルドステージでは CI runner の OOM 回避のため Gradle daemon `-Xmx2g`（Dockerfile 側で指定） + `parallel=false`（Dockerfile 側で指定）で起動する。`compileProductionExecutableKotlinWasmJs` は別プロセス（Kotlin compiler daemon）で動くため、heap は `gradle.properties` の `kotlin.daemon.jvmargs=-Xmx4096M` で指定する必要がある（`-D` のシステムプロパティでは Kotlin Gradle Plugin が拾わない）。
 
 ```bash
 # 手動ビルド & push（通常は CD ワークフローが自動実行するため不要）

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,7 @@ COPY core/ core/
 COPY feature/ feature/
 RUN gradle :server:buildFatJar --no-daemon \
     -Dorg.gradle.jvmargs="-Xmx2g -Dfile.encoding=UTF-8" \
-    -Dorg.gradle.parallel=false \
-    -Dkotlin.daemon.jvmargs="-Xmx4g"
+    -Dorg.gradle.parallel=false
 
 FROM eclipse-temurin:21.0.10_7-jre-noble
 WORKDIR /app

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8
+kotlin.daemon.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
 kotlin.code.style=official


### PR DESCRIPTION
## Summary
PR #190 のフォローアップ。`v0.0.25` で再び CD が OOM 失敗した問題を解消する。

## 何が起きたか
PR #190 で `Dockerfile` の `RUN gradle ...` に `-Dkotlin.daemon.jvmargs=\"-Xmx4g\"` を追加したが、実際には反映されていなかった。`v0.0.25` の CD ログでも Gradle が再び `kotlin.daemon.jvmargs=-Xmx<size>` を増やせと提案しており、Kotlin compiler daemon はデフォルト heap のまま動いていた。

## 原因
Kotlin Gradle Plugin は `kotlin.daemon.jvmargs` を **Gradle project property** として読む。コマンドライン `-D`（JVM システムプロパティ）経由では拾われない。`gradle.properties` に宣言するか `-P` で渡す必要があった。

## Changes
- `gradle.properties`: `kotlin.daemon.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8` を追加
- `Dockerfile`: 効いていなかった `-Dkotlin.daemon.jvmargs=\"-Xmx4g\"` を削除
- `CLAUDE.md`: Docker セクションの記述を実態に合わせて訂正

## ローカル開発への影響
`gradle.properties` に書いたことで、ローカル開発でも Kotlin compiler daemon の heap が 4GB になる。現代の開発マシンで問題になることはないはずだが、ユーザー環境の RAM が厳しい場合は Gradle 起動時のメモリ予約が増える点に注意。

## Test plan
- [ ] マージ後にタグ push → CD が完走すること
- [ ] Discord に成功通知が届くこと（`DISCORD_WEBHOOK_URL` 設定済みであれば）

🤖 Generated with [Claude Code](https://claude.com/claude-code)