### PR TITLE
feat: Discord 通知タイトルに DISCORD_WEBHOOK_PREFIX を前置

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,6 +29,7 @@ jobs:
         if: always()
         env:
           WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          PREFIX: ${{ secrets.DISCORD_WEBHOOK_PREFIX }}
           STATUS: ${{ job.status }}
           REF_NAME: ${{ github.ref_name }}
           SHA: ${{ github.sha }}
@@ -46,6 +47,9 @@ jobs:
           else
             title="CD 失敗"
             color=15158332
+          fi
+          if [ -n "$PREFIX" ]; then
+            title="$PREFIX $title"
           fi
           short_sha="${SHA:0:7}"
           payload=$(jq -n \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,7 @@ The `server/build.gradle.kts` has a `copyWasmFrontend` task that copies the fron
 GitHub Actions で CI/CD を構成。
 
 - **CI** (`.github/workflows/ci.yml`): PR・main push 時に lint / test / build を実行。Renovate の patch auto-merge は `platformAutomerge: false` により CI pass 後に Renovate 自身がマージする。
-- **CD** (`.github/workflows/cd.yml`): `v*` タグ push 時に Docker イメージをビルドし GHCR に push。`:latest` と `:v1.x.x` の2タグ。完了後に Discord へ成否通知（GitHub Secret `DISCORD_WEBHOOK_URL` が必要。未設定時は通知をスキップ）。
+- **CD** (`.github/workflows/cd.yml`): `v*` タグ push 時に Docker イメージをビルドし GHCR に push。`:latest` と `:v1.x.x` の2タグ。完了後に Discord へ成否通知（GitHub Secret `DISCORD_WEBHOOK_URL` が必要。未設定時は通知をスキップ）。`DISCORD_WEBHOOK_PREFIX` を設定するとタイトルに prefix を前置できる（例: `[PROD]` → `[PROD] CD 成功`）。複数環境の通知を同一 Discord チャンネルで区別する用途向け。
 
 ### デプロイフロー
 


### PR DESCRIPTION
## Summary
- CD の Discord 通知タイトルに GitHub Secret `DISCORD_WEBHOOK_PREFIX` を prefix として前置できるようにした
- prefix 未設定時は従来通り `CD 成功` / `CD 失敗`、設定時は `[PROD] CD 成功` のような表示になる
- CLAUDE.md の CI/CD 節に新 secret の説明を追記

## 用途
複数環境（prod / staging 等）の CD 通知を同一 Discord チャンネルへ投げる場合、環境ごとに prefix を変えて一目で区別できるようにする。

## Test plan
- [ ] リポジトリ Settings > Secrets に `DISCORD_WEBHOOK_PREFIX`（例: `[PROD]`）を追加
- [ ] `v*` タグを push し、Discord 通知タイトルが `[PROD] CD 成功` になることを確認
- [ ] `DISCORD_WEBHOOK_PREFIX` 未設定のリポジトリで従来通り `CD 成功` と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)