### PR TITLE
refactor: 年月文字列の命名を month → yearMonth に統一 (#188)

### DIFF
--- a/core/network/src/commonMain/kotlin/core/network/MoneyRepository.kt
+++ b/core/network/src/commonMain/kotlin/core/network/MoneyRepository.kt
@@ -10,58 +10,58 @@ import model.MonthlyMoneyStatusUpdate
 import model.PaymentRecord
 
 interface MoneyRepository {
-    suspend fun getMonthlyMoney(month: String): MonthlyMoney
+    suspend fun getMonthlyMoney(yearMonth: String): MonthlyMoney
 
-    suspend fun getMyMonthlyMoney(month: String): MonthlyMoney
+    suspend fun getMyMonthlyMoney(yearMonth: String): MonthlyMoney
 
     suspend fun saveMonthlyMoney(data: MonthlyMoney)
 
     suspend fun recordPayment(
-        month: String,
+        yearMonth: String,
         record: PaymentRecord,
     ): MonthlyMoney
 
     suspend fun updateStatus(
-        month: String,
+        yearMonth: String,
         status: MonthlyMoneyStatus,
     ): MonthlyMoney
 
-    suspend fun importRecurringItems(month: String): MonthlyMoney
+    suspend fun importRecurringItems(yearMonth: String): MonthlyMoney
 }
 
 class MoneyRepositoryImpl(
     private val client: HttpClient,
 ) : MoneyRepository {
-    override suspend fun getMonthlyMoney(month: String): MonthlyMoney = client.get("/api/money/$month").body()
+    override suspend fun getMonthlyMoney(yearMonth: String): MonthlyMoney = client.get("/api/money/$yearMonth").body()
 
-    override suspend fun getMyMonthlyMoney(month: String): MonthlyMoney = client.get("/api/money/$month/my").body()
+    override suspend fun getMyMonthlyMoney(yearMonth: String): MonthlyMoney = client.get("/api/money/$yearMonth/my").body()
 
     override suspend fun saveMonthlyMoney(data: MonthlyMoney) {
-        client.put("/api/money/${data.month}") {
+        client.put("/api/money/${data.yearMonth}") {
             contentType(ContentType.Application.Json)
             setBody(data)
         }
     }
 
     override suspend fun recordPayment(
-        month: String,
+        yearMonth: String,
         record: PaymentRecord,
     ): MonthlyMoney =
         client
-            .post("/api/money/$month/pay") {
+            .post("/api/money/$yearMonth/pay") {
                 contentType(ContentType.Application.Json)
                 setBody(record)
             }.body()
 
     override suspend fun updateStatus(
-        month: String,
+        yearMonth: String,
         status: MonthlyMoneyStatus,
     ): MonthlyMoney =
         client
-            .patch("/api/money/$month/status") {
+            .patch("/api/money/$yearMonth/status") {
                 contentType(ContentType.Application.Json)
                 setBody(MonthlyMoneyStatusUpdate(status))
             }.body()
 
-    override suspend fun importRecurringItems(month: String): MonthlyMoney = client.post("/api/money/$month/import-by-tag").body()
+    override suspend fun importRecurringItems(yearMonth: String): MonthlyMoney = client.post("/api/money/$yearMonth/import-by-tag").body()
 }

--- a/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
+++ b/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
@@ -46,7 +46,7 @@ fun MoneyScreen(vm: MoneyViewModel = koinViewModel()) {
 
     MoneyContent(
         monthlyMoney = vm.uiState.monthlyMoney,
-        currentMonth = vm.uiState.currentMonth,
+        currentYearMonth = vm.uiState.currentYearMonth,
         loading = vm.uiState.isLoading,
         saving = vm.uiState.isSaving,
         error = vm.uiState.error,
@@ -69,7 +69,7 @@ fun MoneyScreen(vm: MoneyViewModel = koinViewModel()) {
 @Composable
 internal fun MoneyContent(
     monthlyMoney: MonthlyMoney,
-    currentMonth: String,
+    currentYearMonth: String,
     loading: Boolean,
     saving: Boolean,
     error: String?,
@@ -151,7 +151,7 @@ internal fun MoneyContent(
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     MonthSelector(
-                        month = currentMonth,
+                        yearMonth = currentYearMonth,
                         onPrevious = onPreviousMonth,
                         onNext = onNextMonth,
                     )
@@ -225,7 +225,7 @@ internal fun MoneyContent(
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     MonthSelector(
-                        month = currentMonth,
+                        yearMonth = currentYearMonth,
                         onPrevious = onPreviousMonth,
                         onNext = onNextMonth,
                     )
@@ -600,11 +600,11 @@ private fun MoneyItemForm(
 
 @Composable
 private fun MonthSelector(
-    month: String,
+    yearMonth: String,
     onPrevious: () -> Unit,
     onNext: () -> Unit,
 ) {
-    val parts = month.split("-")
+    val parts = yearMonth.split("-")
     val displayText = "${parts[0]}年${parts[1].toInt()}月"
 
     Row(

--- a/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyViewModel.kt
+++ b/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyViewModel.kt
@@ -26,20 +26,20 @@ import model.User
     return y + '-' + m;
 }""",
 )
-external fun currentMonthJs(): JsString
+external fun currentYearMonthJs(): JsString
 
-/** 月を offset 分ずらす (例: "2026-02", 1 → "2026-03") */
+/** 年月を offset 月分ずらす (例: "2026-02", 1 → "2026-03") */
 @JsFun(
-    """(monthStr, offset) => {
-    const [y, m] = monthStr.split('-').map(Number);
+    """(yearMonthStr, offset) => {
+    const [y, m] = yearMonthStr.split('-').map(Number);
     const d = new Date(y, m - 1 + offset, 1);
     const ny = d.getFullYear();
     const nm = String(d.getMonth() + 1).padStart(2, '0');
     return ny + '-' + nm;
 }""",
 )
-external fun shiftMonthJs(
-    monthStr: JsString,
+external fun shiftYearMonthJs(
+    yearMonthStr: JsString,
     offset: Int,
 ): JsString
 
@@ -48,8 +48,8 @@ external fun shiftMonthJs(
 external fun randomUUID(): JsString
 
 data class MoneyUiState(
-    val monthlyMoney: MonthlyMoney = MonthlyMoney(month = ""),
-    val currentMonth: String = "",
+    val monthlyMoney: MonthlyMoney = MonthlyMoney(yearMonth = ""),
+    val currentYearMonth: String = "",
     val isLoading: Boolean = true,
     val isSaving: Boolean = false,
     val error: String? = null,
@@ -64,8 +64,8 @@ class MoneyViewModel(
 ) : ViewModel() {
     var uiState by mutableStateOf(
         MoneyUiState(
-            currentMonth = currentMonthJs().toString(),
-            monthlyMoney = MonthlyMoney(month = currentMonthJs().toString()),
+            currentYearMonth = currentYearMonthJs().toString(),
+            monthlyMoney = MonthlyMoney(yearMonth = currentYearMonthJs().toString()),
         ),
     )
         private set
@@ -84,7 +84,7 @@ class MoneyViewModel(
                     emptyList()
                 }
             try {
-                val monthly = moneyRepository.getMonthlyMoney(uiState.currentMonth)
+                val monthly = moneyRepository.getMonthlyMoney(uiState.currentYearMonth)
                 uiState =
                     uiState.copy(
                         users = users,
@@ -97,13 +97,13 @@ class MoneyViewModel(
         }
     }
 
-    fun onLoadMonth(month: String) {
-        uiState = uiState.copy(currentMonth = month, isLoading = true, error = null)
+    fun onLoadYearMonth(yearMonth: String) {
+        uiState = uiState.copy(currentYearMonth = yearMonth, isLoading = true, error = null)
         viewModelScope.launch {
             try {
                 uiState =
                     uiState.copy(
-                        monthlyMoney = moneyRepository.getMonthlyMoney(month),
+                        monthlyMoney = moneyRepository.getMonthlyMoney(yearMonth),
                         isLoading = false,
                     )
             } catch (e: Exception) {
@@ -113,18 +113,18 @@ class MoneyViewModel(
     }
 
     fun onGoToPreviousMonth() {
-        onLoadMonth(shiftMonthJs(uiState.currentMonth.toJsString(), -1).toString())
+        onLoadYearMonth(shiftYearMonthJs(uiState.currentYearMonth.toJsString(), -1).toString())
     }
 
     fun onGoToNextMonth() {
-        onLoadMonth(shiftMonthJs(uiState.currentMonth.toJsString(), 1).toString())
+        onLoadYearMonth(shiftYearMonthJs(uiState.currentYearMonth.toJsString(), 1).toString())
     }
 
     fun onUpdateStatus(status: MonthlyMoneyStatus) {
         if (uiState.monthlyMoney.status == status) return
         viewModelScope.launch {
             try {
-                val updated = moneyRepository.updateStatus(uiState.currentMonth, status)
+                val updated = moneyRepository.updateStatus(uiState.currentYearMonth, status)
                 uiState = uiState.copy(monthlyMoney = updated)
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
@@ -186,7 +186,7 @@ class MoneyViewModel(
         uiState = uiState.copy(isSaving = true)
         viewModelScope.launch {
             try {
-                val updated = moneyRepository.importRecurringItems(uiState.currentMonth)
+                val updated = moneyRepository.importRecurringItems(uiState.currentYearMonth)
                 uiState = uiState.copy(monthlyMoney = updated)
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
@@ -201,12 +201,12 @@ class MoneyViewModel(
         item: MoneyItem,
         offset: Int,
     ) {
-        val targetMonth = shiftMonthJs(uiState.currentMonth.toJsString(), offset).toString()
+        val targetYearMonth = shiftYearMonthJs(uiState.currentYearMonth.toJsString(), offset).toString()
         uiState = uiState.copy(isSaving = true)
         viewModelScope.launch {
             try {
                 // 移動先の月データを取得して項目を追加
-                val targetData = moneyRepository.getMonthlyMoney(targetMonth)
+                val targetData = moneyRepository.getMonthlyMoney(targetYearMonth)
                 val updatedTarget = targetData.copy(items = targetData.items + item)
                 moneyRepository.saveMonthlyMoney(updatedTarget)
                 // 現在の月から項目を削除

--- a/feature/payment/src/wasmJsMain/kotlin/feature/payment/PaymentScreen.kt
+++ b/feature/payment/src/wasmJsMain/kotlin/feature/payment/PaymentScreen.kt
@@ -32,7 +32,7 @@ fun PaymentScreen(vm: PaymentViewModel = koinViewModel()) {
 
     PaymentContent(
         monthlyMoney = vm.uiState.monthlyMoney,
-        currentMonth = vm.uiState.currentMonth,
+        currentYearMonth = vm.uiState.currentYearMonth,
         currentUid = vm.uiState.viewingUid,
         loading = vm.uiState.isLoading,
         saving = vm.uiState.isSaving,
@@ -51,7 +51,7 @@ fun PaymentScreen(vm: PaymentViewModel = koinViewModel()) {
 @Composable
 internal fun PaymentContent(
     monthlyMoney: MonthlyMoney,
-    currentMonth: String,
+    currentYearMonth: String,
     currentUid: String,
     loading: Boolean,
     saving: Boolean,
@@ -107,7 +107,7 @@ internal fun PaymentContent(
                 }
                 Spacer(modifier = Modifier.height(8.dp))
                 MonthSelector(
-                    month = currentMonth,
+                    yearMonth = currentYearMonth,
                     onPrevious = onPreviousMonth,
                     onNext = onNextMonth,
                 )
@@ -162,7 +162,7 @@ internal fun PaymentContent(
                 }
                 Spacer(modifier = Modifier.height(16.dp))
                 MonthSelector(
-                    month = currentMonth,
+                    yearMonth = currentYearMonth,
                     onPrevious = onPreviousMonth,
                     onNext = onNextMonth,
                 )
@@ -413,11 +413,11 @@ private fun UserSwitcher(
 
 @Composable
 private fun MonthSelector(
-    month: String,
+    yearMonth: String,
     onPrevious: () -> Unit,
     onNext: () -> Unit,
 ) {
-    val parts = month.split("-")
+    val parts = yearMonth.split("-")
     val displayText = "${parts[0]}年${parts[1].toInt()}月"
 
     Row(

--- a/feature/payment/src/wasmJsMain/kotlin/feature/payment/PaymentViewModel.kt
+++ b/feature/payment/src/wasmJsMain/kotlin/feature/payment/PaymentViewModel.kt
@@ -25,20 +25,20 @@ import model.User
     return y + '-' + m;
 }""",
 )
-external fun currentMonthJs(): JsString
+external fun currentYearMonthJs(): JsString
 
-/** 月を offset 分ずらす */
+/** 年月を offset 月分ずらす */
 @JsFun(
-    """(monthStr, offset) => {
-    const [y, m] = monthStr.split('-').map(Number);
+    """(yearMonthStr, offset) => {
+    const [y, m] = yearMonthStr.split('-').map(Number);
     const d = new Date(y, m - 1 + offset, 1);
     const ny = d.getFullYear();
     const nm = String(d.getMonth() + 1).padStart(2, '0');
     return ny + '-' + nm;
 }""",
 )
-external fun shiftMonthJs(
-    monthStr: JsString,
+external fun shiftYearMonthJs(
+    yearMonthStr: JsString,
     offset: Int,
 ): JsString
 
@@ -47,8 +47,8 @@ external fun shiftMonthJs(
 external fun nowIsoJs(): JsString
 
 data class PaymentUiState(
-    val monthlyMoney: MonthlyMoney = MonthlyMoney(month = ""),
-    val currentMonth: String = "",
+    val monthlyMoney: MonthlyMoney = MonthlyMoney(yearMonth = ""),
+    val currentYearMonth: String = "",
     val currentUid: String = "",
     val viewingUid: String = "",
     val isAdmin: Boolean = false,
@@ -69,8 +69,8 @@ class PaymentViewModel(
 
     var uiState by mutableStateOf(
         PaymentUiState(
-            currentMonth = currentMonthJs().toString(),
-            monthlyMoney = MonthlyMoney(month = currentMonthJs().toString()),
+            currentYearMonth = currentYearMonthJs().toString(),
+            monthlyMoney = MonthlyMoney(yearMonth = currentYearMonthJs().toString()),
             currentUid = authUser?.uid ?: "",
             viewingUid = authUser?.uid ?: "",
             isAdmin = authUser?.isAdmin ?: false,
@@ -95,31 +95,31 @@ class PaymentViewModel(
                     emptyList()
                 }
             uiState = uiState.copy(users = users)
-            loadMonth(uiState.currentMonth)
+            loadYearMonth(uiState.currentYearMonth)
         }
     }
 
-    fun onLoadMonth(month: String) {
-        uiState = uiState.copy(currentMonth = month, isLoading = true, error = null)
-        viewModelScope.launch { loadMonth(month) }
+    fun onLoadYearMonth(yearMonth: String) {
+        uiState = uiState.copy(currentYearMonth = yearMonth, isLoading = true, error = null)
+        viewModelScope.launch { loadYearMonth(yearMonth) }
     }
 
     fun onSwitchUser(uid: String) {
         uiState = uiState.copy(viewingUid = uid, isLoading = true, error = null)
-        viewModelScope.launch { loadMonth(uiState.currentMonth) }
+        viewModelScope.launch { loadYearMonth(uiState.currentYearMonth) }
     }
 
-    private suspend fun loadMonth(month: String) {
+    private suspend fun loadYearMonth(yearMonth: String) {
         try {
             val monthly =
                 if (uiState.isViewingOther) {
-                    val full = moneyRepository.getMonthlyMoney(month)
+                    val full = moneyRepository.getMonthlyMoney(yearMonth)
                     val uid = uiState.viewingUid
                     val myItems = full.items.filter { item -> item.payments.any { it.uid == uid } }
                     val myRecords = full.paymentRecords.filter { it.uid == uid }
                     full.copy(items = myItems, paymentRecords = myRecords)
                 } else {
-                    moneyRepository.getMyMonthlyMoney(month)
+                    moneyRepository.getMyMonthlyMoney(yearMonth)
                 }
             uiState = uiState.copy(monthlyMoney = monthly, isLoading = false)
         } catch (e: Exception) {
@@ -128,11 +128,11 @@ class PaymentViewModel(
     }
 
     fun onGoToPreviousMonth() {
-        onLoadMonth(shiftMonthJs(uiState.currentMonth.toJsString(), -1).toString())
+        onLoadYearMonth(shiftYearMonthJs(uiState.currentYearMonth.toJsString(), -1).toString())
     }
 
     fun onGoToNextMonth() {
-        onLoadMonth(shiftMonthJs(uiState.currentMonth.toJsString(), 1).toString())
+        onLoadYearMonth(shiftYearMonthJs(uiState.currentYearMonth.toJsString(), 1).toString())
     }
 
     fun onRecordPayment(amount: Long) {
@@ -147,7 +147,7 @@ class PaymentViewModel(
                     )
                 uiState =
                     uiState.copy(
-                        monthlyMoney = moneyRepository.recordPayment(uiState.currentMonth, record),
+                        monthlyMoney = moneyRepository.recordPayment(uiState.currentYearMonth, record),
                     )
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)

--- a/feature/report/src/commonMain/kotlin/feature/report/components/MonthlyBarChart.kt
+++ b/feature/report/src/commonMain/kotlin/feature/report/components/MonthlyBarChart.kt
@@ -28,10 +28,10 @@ private val BarSpacing = 12.dp
 @Composable
 fun MonthlyBarChart(
     months: List<MonthlyExpenseSummary>,
-    selectedMonth: String,
+    selectedYearMonth: String,
     primaryColor: Color = MaterialTheme.colorScheme.primary,
     onSurfaceVariantColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
-    onMonthClick: (String) -> Unit,
+    onYearMonthClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val textMeasurer = rememberTextMeasurer()
@@ -48,7 +48,7 @@ fun MonthlyBarChart(
             textAlign = TextAlign.Center,
         )
 
-    val currentOnMonthClick by rememberUpdatedState(onMonthClick)
+    val currentOnYearMonthClick by rememberUpdatedState(onYearMonthClick)
 
     val density = LocalDensity.current
     val horizontalPaddingPx = remember(density) { with(density) { HorizontalPadding.toPx() } }
@@ -68,7 +68,7 @@ fun MonthlyBarChart(
                         months.forEachIndexed { index, summary ->
                             val x = horizontalPaddingPx + index * (barWidth + barSpacingPx)
                             if (offset.x in x..(x + barWidth)) {
-                                currentOnMonthClick(summary.month)
+                                currentOnYearMonthClick(summary.yearMonth)
                                 return@detectTapGestures
                             }
                         }
@@ -96,7 +96,7 @@ fun MonthlyBarChart(
             val x = horizontalPaddingPx + index * (barWidth + barSpacingPx)
             val y = topPadding + chartHeight - barHeight
 
-            val isSelected = summary.month == selectedMonth
+            val isSelected = summary.yearMonth == selectedYearMonth
             val barColor = if (isSelected) primaryColor else primaryColor.copy(alpha = 0.4f)
 
             // 棒グラフ
@@ -128,7 +128,7 @@ fun MonthlyBarChart(
             }
 
             // 月名ラベル（下部）
-            val monthLabel = formatMonthLabel(summary.month)
+            val monthLabel = formatMonthLabel(summary.yearMonth)
             val monthLayout =
                 textMeasurer.measure(
                     text = monthLabel,
@@ -153,7 +153,7 @@ private fun formatChartAmount(amount: Long): String =
         "¥$amount"
     }
 
-private fun formatMonthLabel(month: String): String {
-    val parts = month.split("-")
-    return if (parts.size == 2) "${parts[1].toInt()}月" else month
+private fun formatMonthLabel(yearMonth: String): String {
+    val parts = yearMonth.split("-")
+    return if (parts.size == 2) "${parts[1].toInt()}月" else yearMonth
 }

--- a/feature/report/src/wasmJsMain/kotlin/feature/report/OverpaymentScreen.kt
+++ b/feature/report/src/wasmJsMain/kotlin/feature/report/OverpaymentScreen.kt
@@ -206,7 +206,7 @@ private fun RedemptionInlineCard(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             RedemptionMonthSelector(
-                month = form.selectedMonth,
+                yearMonth = form.selectedYearMonth,
                 onPrevious = onMonthPrevious,
                 onNext = onMonthNext,
                 enabled = inputEnabled,
@@ -300,12 +300,12 @@ private fun RedemptionInlineCard(
 
 @Composable
 private fun RedemptionMonthSelector(
-    month: String,
+    yearMonth: String,
     onPrevious: () -> Unit,
     onNext: () -> Unit,
     enabled: Boolean = true,
 ) {
-    val parts = month.split("-")
+    val parts = yearMonth.split("-")
     val displayText = "${parts[0]}年${parts[1].toInt()}月"
 
     Row(

--- a/feature/report/src/wasmJsMain/kotlin/feature/report/OverpaymentViewModel.kt
+++ b/feature/report/src/wasmJsMain/kotlin/feature/report/OverpaymentViewModel.kt
@@ -20,7 +20,7 @@ private const val DEFAULT_REDEMPTION_NOTE = "過払い金から支払い"
 
 data class RedemptionFormState(
     val selectedUid: String = "",
-    val selectedMonth: String = "",
+    val selectedYearMonth: String = "",
     val amountText: String = "",
     val noteText: String = DEFAULT_REDEMPTION_NOTE,
     val isSaving: Boolean = false,
@@ -49,7 +49,7 @@ class OverpaymentViewModel(
 ) : ViewModel() {
     var uiState by mutableStateOf(
         OverpaymentUiState(
-            redemptionForm = RedemptionFormState(selectedMonth = currentMonthJs().toString()),
+            redemptionForm = RedemptionFormState(selectedYearMonth = currentYearMonthJs().toString()),
         ),
     )
         private set
@@ -83,10 +83,10 @@ class OverpaymentViewModel(
     }
 
     private fun loadMonthData() {
-        val month = uiState.redemptionForm.selectedMonth
+        val yearMonth = uiState.redemptionForm.selectedYearMonth
         viewModelScope.launch {
             try {
-                val data = moneyRepository.getMonthlyMoney(month)
+                val data = moneyRepository.getMonthlyMoney(yearMonth)
                 uiState =
                     uiState.copy(
                         redemptionForm = uiState.redemptionForm.copy(monthData = data),
@@ -108,10 +108,10 @@ class OverpaymentViewModel(
     }
 
     fun onClearForm() {
-        val month = currentMonthJs().toString()
+        val yearMonth = currentYearMonthJs().toString()
         uiState =
             uiState.copy(
-                redemptionForm = RedemptionFormState(selectedMonth = month),
+                redemptionForm = RedemptionFormState(selectedYearMonth = yearMonth),
             )
         loadMonthData()
     }
@@ -131,19 +131,19 @@ class OverpaymentViewModel(
     }
 
     fun onRedemptionMonthPrevious() {
-        val newMonth = shiftMonthJs(uiState.redemptionForm.selectedMonth.toJsString(), -1).toString()
+        val newYearMonth = shiftYearMonthJs(uiState.redemptionForm.selectedYearMonth.toJsString(), -1).toString()
         uiState =
             uiState.copy(
-                redemptionForm = uiState.redemptionForm.copy(selectedMonth = newMonth, monthData = null),
+                redemptionForm = uiState.redemptionForm.copy(selectedYearMonth = newYearMonth, monthData = null),
             )
         loadMonthData()
     }
 
     fun onRedemptionMonthNext() {
-        val newMonth = shiftMonthJs(uiState.redemptionForm.selectedMonth.toJsString(), 1).toString()
+        val newYearMonth = shiftYearMonthJs(uiState.redemptionForm.selectedYearMonth.toJsString(), 1).toString()
         uiState =
             uiState.copy(
-                redemptionForm = uiState.redemptionForm.copy(selectedMonth = newMonth, monthData = null),
+                redemptionForm = uiState.redemptionForm.copy(selectedYearMonth = newYearMonth, monthData = null),
             )
         loadMonthData()
     }
@@ -200,7 +200,7 @@ class OverpaymentViewModel(
                 reportRepository.redeemOverpayment(
                     OverpaymentRedemptionRequest(
                         uid = form.selectedUid,
-                        month = form.selectedMonth,
+                        yearMonth = form.selectedYearMonth,
                         amount = amount,
                         note = form.noteText,
                     ),

--- a/feature/report/src/wasmJsMain/kotlin/feature/report/ReportScreen.kt
+++ b/feature/report/src/wasmJsMain/kotlin/feature/report/ReportScreen.kt
@@ -49,7 +49,7 @@ fun ReportScreen(vm: ReportViewModel = koinViewModel()) {
 
     ReportContent(
         report = vm.uiState.report,
-        selectedMonth = vm.uiState.selectedMonth,
+        selectedYearMonth = vm.uiState.selectedYearMonth,
         selectedSummary = vm.uiState.selectedSummary,
         averageAmount = vm.uiState.averageAmount,
         previousMonthDiff = vm.uiState.previousMonthDiff,
@@ -57,7 +57,7 @@ fun ReportScreen(vm: ReportViewModel = koinViewModel()) {
         error = vm.uiState.error,
         onPreviousMonth = vm::onGoToPreviousMonth,
         onNextMonth = vm::onGoToNextMonth,
-        onSelectMonth = vm::onSelectMonth,
+        onSelectYearMonth = vm::onSelectYearMonth,
         windowSizeClass = windowSizeClass,
     )
 }
@@ -65,7 +65,7 @@ fun ReportScreen(vm: ReportViewModel = koinViewModel()) {
 @Composable
 internal fun ReportContent(
     report: ExpenseReport,
-    selectedMonth: String,
+    selectedYearMonth: String,
     selectedSummary: MonthlyExpenseSummary?,
     averageAmount: Long,
     previousMonthDiff: Long?,
@@ -73,7 +73,7 @@ internal fun ReportContent(
     error: String?,
     onPreviousMonth: () -> Unit,
     onNextMonth: () -> Unit,
-    onSelectMonth: (String) -> Unit,
+    onSelectYearMonth: (String) -> Unit,
     windowSizeClass: WindowSizeClass = WindowSizeClass.Expanded,
 ) {
     val isCompact = windowSizeClass == WindowSizeClass.Compact
@@ -118,7 +118,7 @@ internal fun ReportContent(
         Spacer(modifier = Modifier.height(if (isCompact) 8.dp else 16.dp))
 
         MonthSelector(
-            month = selectedMonth,
+            yearMonth = selectedYearMonth,
             onPrevious = onPreviousMonth,
             onNext = onNextMonth,
         )
@@ -126,13 +126,13 @@ internal fun ReportContent(
 
         ReportMainContent(
             report = report,
-            selectedMonth = selectedMonth,
+            selectedYearMonth = selectedYearMonth,
             selectedSummary = selectedSummary,
             averageAmount = averageAmount,
             previousMonthDiff = previousMonthDiff,
             isLoading = isLoading,
             error = error,
-            onSelectMonth = onSelectMonth,
+            onSelectYearMonth = onSelectYearMonth,
             isCompact = isCompact,
             modifier = Modifier.weight(1f),
         )
@@ -142,13 +142,13 @@ internal fun ReportContent(
 @Composable
 private fun ReportMainContent(
     report: ExpenseReport,
-    selectedMonth: String,
+    selectedYearMonth: String,
     selectedSummary: MonthlyExpenseSummary?,
     averageAmount: Long,
     previousMonthDiff: Long?,
     isLoading: Boolean,
     error: String?,
-    onSelectMonth: (String) -> Unit,
+    onSelectYearMonth: (String) -> Unit,
     isCompact: Boolean,
     modifier: Modifier = Modifier,
 ) {
@@ -187,8 +187,8 @@ private fun ReportMainContent(
                 item(key = "chart") {
                     MonthlyBarChart(
                         months = report.months,
-                        selectedMonth = selectedMonth,
-                        onMonthClick = onSelectMonth,
+                        selectedYearMonth = selectedYearMonth,
+                        onYearMonthClick = onSelectYearMonth,
                         modifier = Modifier.widthIn(max = 600.dp),
                     )
                 }
@@ -207,13 +207,13 @@ private fun ReportMainContent(
 
 @Composable
 private fun MonthSelector(
-    month: String,
+    yearMonth: String,
     onPrevious: () -> Unit,
     onNext: () -> Unit,
 ) {
-    val parts = month.split("-")
+    val parts = yearMonth.split("-")
     val displayText =
-        if (parts.size == 2) "${parts[0]}年${parts[1].toInt()}月" else month
+        if (parts.size == 2) "${parts[0]}年${parts[1].toInt()}月" else yearMonth
 
     Row(
         verticalAlignment = Alignment.CenterVertically,

--- a/feature/report/src/wasmJsMain/kotlin/feature/report/ReportViewModel.kt
+++ b/feature/report/src/wasmJsMain/kotlin/feature/report/ReportViewModel.kt
@@ -22,31 +22,31 @@ import model.MonthlyExpenseSummary
     return y + '-' + m;
 }""",
 )
-external fun currentMonthJs(): JsString
+external fun currentYearMonthJs(): JsString
 
-/** 月を offset 分ずらす */
+/** 年月を offset 月分ずらす */
 @JsFun(
-    """(monthStr, offset) => {
-    const [y, m] = monthStr.split('-').map(Number);
+    """(yearMonthStr, offset) => {
+    const [y, m] = yearMonthStr.split('-').map(Number);
     const d = new Date(y, m - 1 + offset, 1);
     const ny = d.getFullYear();
     const nm = String(d.getMonth() + 1).padStart(2, '0');
     return ny + '-' + nm;
 }""",
 )
-external fun shiftMonthJs(
-    monthStr: JsString,
+external fun shiftYearMonthJs(
+    yearMonthStr: JsString,
     offset: Int,
 ): JsString
 
 data class ReportUiState(
     val report: ExpenseReport = ExpenseReport(),
-    val selectedMonth: String = "",
+    val selectedYearMonth: String = "",
     val isLoading: Boolean = true,
     val error: String? = null,
 ) {
     val selectedSummary: MonthlyExpenseSummary?
-        get() = report.months.find { it.month == selectedMonth }
+        get() = report.months.find { it.yearMonth == selectedYearMonth }
 
     val averageAmount: Long
         get() {
@@ -57,8 +57,8 @@ data class ReportUiState(
     val previousMonthDiff: Long?
         get() {
             val current = selectedSummary ?: return null
-            val prevMonth = shiftMonthJs(selectedMonth.toJsString(), -1).toString()
-            val prev = report.months.find { it.month == prevMonth } ?: return null
+            val prevYearMonth = shiftYearMonthJs(selectedYearMonth.toJsString(), -1).toString()
+            val prev = report.months.find { it.yearMonth == prevYearMonth } ?: return null
             return current.totalAmount - prev.totalAmount
         }
 }
@@ -67,12 +67,12 @@ class ReportViewModel(
     private val reportRepository: ReportRepository,
 ) : ViewModel() {
     var uiState by mutableStateOf(
-        ReportUiState(selectedMonth = currentMonthJs().toString()),
+        ReportUiState(selectedYearMonth = currentYearMonthJs().toString()),
     )
         private set
 
     init {
-        loadReport(uiState.selectedMonth)
+        loadReport(uiState.selectedYearMonth)
     }
 
     private fun loadReport(center: String) {
@@ -88,21 +88,21 @@ class ReportViewModel(
     }
 
     fun onGoToPreviousMonth() {
-        val newMonth = shiftMonthJs(uiState.selectedMonth.toJsString(), -1).toString()
-        uiState = uiState.copy(selectedMonth = newMonth)
-        loadReport(newMonth)
+        val newYearMonth = shiftYearMonthJs(uiState.selectedYearMonth.toJsString(), -1).toString()
+        uiState = uiState.copy(selectedYearMonth = newYearMonth)
+        loadReport(newYearMonth)
     }
 
     fun onGoToNextMonth() {
-        val newMonth = shiftMonthJs(uiState.selectedMonth.toJsString(), 1).toString()
-        uiState = uiState.copy(selectedMonth = newMonth)
-        loadReport(newMonth)
+        val newYearMonth = shiftYearMonthJs(uiState.selectedYearMonth.toJsString(), 1).toString()
+        uiState = uiState.copy(selectedYearMonth = newYearMonth)
+        loadReport(newYearMonth)
     }
 
-    fun onSelectMonth(month: String) {
-        if (month != uiState.selectedMonth) {
-            uiState = uiState.copy(selectedMonth = month)
-            loadReport(month)
+    fun onSelectYearMonth(yearMonth: String) {
+        if (yearMonth != uiState.selectedYearMonth) {
+            uiState = uiState.copy(selectedYearMonth = yearMonth)
+            loadReport(yearMonth)
         }
     }
 }

--- a/server/src/main/kotlin/server/Application.kt
+++ b/server/src/main/kotlin/server/Application.kt
@@ -42,6 +42,7 @@ import server.feeding.feedingRoutes
 import server.garbage.GarbageNotificationService
 import server.garbage.garbageRoutes
 import server.loginhistory.loginHistoryRoutes
+import server.migration.FirestoreMigrations
 import server.money.moneyRoutes
 import server.passkey.PasskeyDatabase
 import server.passkey.passkeyRoutes
@@ -76,6 +77,9 @@ fun Application.module() {
     PasskeyDatabase.initialize()
 
     install(Koin) { modules(serverModule) }
+
+    val firestoreMigrations by inject<FirestoreMigrations>()
+    launch { firestoreMigrations.runAll() }
 
     val petRepository by inject<PetRepository>()
     petRepository.seedDefaultPet()

--- a/server/src/main/kotlin/server/Application.kt
+++ b/server/src/main/kotlin/server/Application.kt
@@ -25,6 +25,7 @@ import io.ktor.server.request.path
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.SerializationException
 import org.koin.ktor.ext.inject
 import org.koin.ktor.plugin.Koin
@@ -78,8 +79,10 @@ fun Application.module() {
 
     install(Koin) { modules(serverModule) }
 
+    // 同期実行: マイグレーション完了前に HTTP リクエストを受け付けないようにする。
+    // 失敗時は例外を伝播させてサーバー起動自体を中断し、未移行のまま運用を開始しない。
     val firestoreMigrations by inject<FirestoreMigrations>()
-    launch { firestoreMigrations.runAll() }
+    runBlocking { firestoreMigrations.runAll() }
 
     val petRepository by inject<PetRepository>()
     petRepository.seedDefaultPet()

--- a/server/src/main/kotlin/server/Application.kt
+++ b/server/src/main/kotlin/server/Application.kt
@@ -26,6 +26,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.SerializationException
 import org.koin.ktor.ext.inject
 import org.koin.ktor.plugin.Koin
@@ -65,6 +66,11 @@ fun main() {
 
 private val logger = LoggerFactory.getLogger("server.Application")
 
+// Firestore マイグレーションの最大待ち時間。
+// Dockerfile の HEALTHCHECK start-period=15s 以下に収める必要があるため、初回実行時間 + 余裕分を確保。
+// 大量データで収まらなくなった場合は HEALTHCHECK 側と併せて再調整すること。
+private val MIGRATION_TIMEOUT = 60.seconds
+
 fun Application.module() {
     // dotenv-java の値を Logback に反映（logback.xml は OS 環境変数のみ参照するため）
     EnvConfig["LOG_LEVEL"]?.let { level ->
@@ -81,8 +87,11 @@ fun Application.module() {
 
     // 同期実行: マイグレーション完了前に HTTP リクエストを受け付けないようにする。
     // 失敗時は例外を伝播させてサーバー起動自体を中断し、未移行のまま運用を開始しない。
+    // Firestore のネットワーク不通・認証失敗で無期限ブロックしないよう withTimeout で守る。
     val firestoreMigrations by inject<FirestoreMigrations>()
-    runBlocking { firestoreMigrations.runAll() }
+    runBlocking {
+        withTimeout(MIGRATION_TIMEOUT) { firestoreMigrations.runAll() }
+    }
 
     val petRepository by inject<PetRepository>()
     petRepository.seedDefaultPet()

--- a/server/src/main/kotlin/server/di/ServerModule.kt
+++ b/server/src/main/kotlin/server/di/ServerModule.kt
@@ -15,6 +15,7 @@ import server.garbage.GarbageNotificationService
 import server.garbage.GarbageRepository
 import server.loginhistory.FirestoreLoginHistoryRepository
 import server.loginhistory.LoginHistoryRepository
+import server.migration.FirestoreMigrations
 import server.money.FirestoreMoneyRepository
 import server.money.MoneyRepository
 import server.pet.FirestorePetRepository
@@ -43,6 +44,7 @@ val serverModule =
         single { FeedingReminderService(get(), get(), get()) }
         single { GarbageNotificationService(get()) }
         single { BalanceCalculationService() }
+        single { FirestoreMigrations(get()) }
         single {
             CacheManager(
                 listOf(

--- a/server/src/main/kotlin/server/migration/FirestoreMigrations.kt
+++ b/server/src/main/kotlin/server/migration/FirestoreMigrations.kt
@@ -15,29 +15,6 @@ private const val FIRESTORE_BATCH_LIMIT = 500
 
 private val logger = LoggerFactory.getLogger("server.migration.FirestoreMigrations")
 
-/** money.month → yearMonth マイグレーションにおける 1 ドキュメントの扱い。 */
-internal enum class MoneyMigrationAction {
-    /** 対象外。新フィールドのみ保持済み、または両方未設定。 */
-    SKIP,
-
-    /** 新旧両方保持しているため、旧 `month` フィールドのみ削除する。 */
-    DELETE_LEGACY,
-
-    /** 旧 `month` フィールドのみ保持しているため、`yearMonth` を `doc.id` からセット & 旧 `month` を削除する。 */
-    SET_NEW_AND_DELETE_LEGACY,
-}
-
-/** money ドキュメントの旧/新スキーマ保有状況から、必要なマイグレーション操作を判定する。 */
-internal fun classifyMoneyMigration(
-    hasLegacyMonth: Boolean,
-    hasYearMonth: Boolean,
-): MoneyMigrationAction =
-    when {
-        !hasLegacyMonth -> MoneyMigrationAction.SKIP
-        hasYearMonth -> MoneyMigrationAction.DELETE_LEGACY
-        else -> MoneyMigrationAction.SET_NEW_AND_DELETE_LEGACY
-    }
-
 /**
  * Firestore の一回きりマイグレーションをサーバー起動時に実行する。
  *
@@ -51,6 +28,18 @@ internal fun classifyMoneyMigration(
 class FirestoreMigrations(
     private val firestore: Firestore,
 ) {
+    /** money.month → yearMonth マイグレーションにおける 1 ドキュメントの扱い。 */
+    internal enum class MoneyMigrationAction {
+        /** 対象外。新フィールドのみ保持済み、または両方未設定。 */
+        SKIP,
+
+        /** 新旧両方保持しているため、旧 `month` フィールドのみ削除する。 */
+        DELETE_LEGACY,
+
+        /** 旧 `month` フィールドのみ保持しているため、`yearMonth` を `doc.id` からセット & 旧 `month` を削除する。 */
+        SET_NEW_AND_DELETE_LEGACY,
+    }
+
     suspend fun runAll() {
         runIfNeeded("money-month-to-year-month") { migrateMoneyMonthToYearMonth() }
     }
@@ -119,6 +108,17 @@ class FirestoreMigrations(
             }
         }
     }
+
+    /** money ドキュメントの旧/新スキーマ保有状況から、必要なマイグレーション操作を判定する。 */
+    internal fun classifyMoneyMigration(
+        hasLegacyMonth: Boolean,
+        hasYearMonth: Boolean,
+    ): MoneyMigrationAction =
+        when {
+            !hasLegacyMonth -> MoneyMigrationAction.SKIP
+            hasYearMonth -> MoneyMigrationAction.DELETE_LEGACY
+            else -> MoneyMigrationAction.SET_NEW_AND_DELETE_LEGACY
+        }
 
     /**
      * [docs] に対して [buildUpdate] が返す更新内容を [FIRESTORE_BATCH_LIMIT] 件ずつ WriteBatch でコミットする。

--- a/server/src/main/kotlin/server/migration/FirestoreMigrations.kt
+++ b/server/src/main/kotlin/server/migration/FirestoreMigrations.kt
@@ -1,0 +1,87 @@
+package server.migration
+
+import com.google.cloud.firestore.FieldValue
+import com.google.cloud.firestore.Firestore
+import org.slf4j.LoggerFactory
+import server.util.await
+
+private const val MIGRATIONS_COLLECTION = "_migrations"
+private const val MONEY_COLLECTION = "money"
+
+private val logger = LoggerFactory.getLogger("server.migration.FirestoreMigrations")
+
+/**
+ * Firestore の一回きりマイグレーションをサーバー起動時に実行する。
+ *
+ * 完了フラグは [MIGRATIONS_COLLECTION] の各マイグレーション名ドキュメントに保存する。
+ * 2 回目以降の起動では完了フラグを 1 回読むだけで O(1) で skip する。
+ */
+class FirestoreMigrations(
+    private val firestore: Firestore,
+) {
+    suspend fun runAll() {
+        runIfNeeded("money-month-to-year-month") { migrateMoneyMonthToYearMonth() }
+    }
+
+    private suspend fun runIfNeeded(
+        name: String,
+        block: suspend () -> Int,
+    ) {
+        val flagRef = firestore.collection(MIGRATIONS_COLLECTION).document(name)
+        if (flagRef.get().await().exists()) return
+
+        logger.info("Running Firestore migration: {}", name)
+        val affected =
+            runCatching { block() }
+                .onFailure { logger.error("Firestore migration {} failed", name, it) }
+                .getOrThrow()
+        flagRef
+            .set(
+                mapOf(
+                    "completedAt" to FieldValue.serverTimestamp(),
+                    "affected" to affected,
+                ),
+            ).await()
+        logger.info("Firestore migration {} complete: {} document(s) updated", name, affected)
+    }
+
+    /**
+     * money コレクションの旧 `month` フィールドを `yearMonth` にリネームする。
+     *
+     * doc.id が年月文字列と一致する不変条件を利用し、`yearMonth` は `doc.id` から設定する。
+     * 既に `yearMonth` が存在するドキュメントは旧 `month` フィールドのみ削除する。
+     */
+    private suspend fun migrateMoneyMonthToYearMonth(): Int {
+        val docs =
+            firestore
+                .collection(MONEY_COLLECTION)
+                .get()
+                .await()
+                .documents
+        var migrated = 0
+        for (doc in docs) {
+            val data = doc.data
+            val hasLegacy = data.containsKey("month")
+            val hasNew = data.containsKey("yearMonth")
+            when {
+                !hasLegacy && hasNew -> continue
+                hasNew -> {
+                    doc.reference.update(mapOf("month" to FieldValue.delete())).await()
+                    migrated++
+                }
+                hasLegacy -> {
+                    doc.reference
+                        .update(
+                            mapOf(
+                                "yearMonth" to doc.id,
+                                "month" to FieldValue.delete(),
+                            ),
+                        ).await()
+                    migrated++
+                }
+                else -> continue
+            }
+        }
+        return migrated
+    }
+}

--- a/server/src/main/kotlin/server/migration/FirestoreMigrations.kt
+++ b/server/src/main/kotlin/server/migration/FirestoreMigrations.kt
@@ -27,10 +27,7 @@ internal enum class MoneyMigrationAction {
     SET_NEW_AND_DELETE_LEGACY,
 }
 
-/**
- * money ドキュメントの旧/新スキーマ保有状況から、必要なマイグレーション操作を判定する純粋関数。
- * Firestore I/O を伴わないためユニットテスト可能。
- */
+/** money ドキュメントの旧/新スキーマ保有状況から、必要なマイグレーション操作を判定する。 */
 internal fun classifyMoneyMigration(
     hasLegacyMonth: Boolean,
     hasYearMonth: Boolean,

--- a/server/src/main/kotlin/server/migration/FirestoreMigrations.kt
+++ b/server/src/main/kotlin/server/migration/FirestoreMigrations.kt
@@ -2,19 +2,54 @@ package server.migration
 
 import com.google.cloud.firestore.FieldValue
 import com.google.cloud.firestore.Firestore
+import com.google.cloud.firestore.QueryDocumentSnapshot
 import org.slf4j.LoggerFactory
 import server.util.await
 
 private const val MIGRATIONS_COLLECTION = "_migrations"
 private const val MONEY_COLLECTION = "money"
 
+// Firestore の WriteBatch 1 コミットあたりの最大オペレーション数。
+// https://firebase.google.com/docs/firestore/manage-data/transactions#batched-writes
+private const val FIRESTORE_BATCH_LIMIT = 500
+
 private val logger = LoggerFactory.getLogger("server.migration.FirestoreMigrations")
+
+/** money.month → yearMonth マイグレーションにおける 1 ドキュメントの扱い。 */
+internal enum class MoneyMigrationAction {
+    /** 対象外。新フィールドのみ保持済み、または両方未設定。 */
+    SKIP,
+
+    /** 新旧両方保持しているため、旧 `month` フィールドのみ削除する。 */
+    DELETE_LEGACY,
+
+    /** 旧 `month` フィールドのみ保持しているため、`yearMonth` を `doc.id` からセット & 旧 `month` を削除する。 */
+    SET_NEW_AND_DELETE_LEGACY,
+}
+
+/**
+ * money ドキュメントの旧/新スキーマ保有状況から、必要なマイグレーション操作を判定する純粋関数。
+ * Firestore I/O を伴わないためユニットテスト可能。
+ */
+internal fun classifyMoneyMigration(
+    hasLegacyMonth: Boolean,
+    hasYearMonth: Boolean,
+): MoneyMigrationAction =
+    when {
+        !hasLegacyMonth -> MoneyMigrationAction.SKIP
+        hasYearMonth -> MoneyMigrationAction.DELETE_LEGACY
+        else -> MoneyMigrationAction.SET_NEW_AND_DELETE_LEGACY
+    }
 
 /**
  * Firestore の一回きりマイグレーションをサーバー起動時に実行する。
  *
  * 完了フラグは [MIGRATIONS_COLLECTION] の各マイグレーション名ドキュメントに保存する。
  * 2 回目以降の起動では完了フラグを 1 回読むだけで O(1) で skip する。
+ *
+ * 並走防止: 完了フラグの書き込みには [com.google.cloud.firestore.DocumentReference.create] を使い、
+ * Precondition.documentNotExists() 相当の CAS で保護する。複数インスタンスが同時起動した場合でも
+ * 完了フラグ書き込みは 1 回に収まり、冪等なマイグレーション本体の並走は許容する。
  */
 class FirestoreMigrations(
     private val firestore: Firestore,
@@ -35,21 +70,32 @@ class FirestoreMigrations(
             runCatching { block() }
                 .onFailure { logger.error("Firestore migration {} failed", name, it) }
                 .getOrThrow()
-        flagRef
-            .set(
-                mapOf(
-                    "completedAt" to FieldValue.serverTimestamp(),
-                    "affected" to affected,
-                ),
-            ).await()
-        logger.info("Firestore migration {} complete: {} document(s) updated", name, affected)
+
+        try {
+            flagRef
+                .create(
+                    mapOf(
+                        "completedAt" to FieldValue.serverTimestamp(),
+                        "affected" to affected,
+                    ),
+                ).await()
+            logger.info("Firestore migration {} complete: {} document(s) updated", name, affected)
+        } catch (e: Exception) {
+            // 別インスタンスが先にフラグを書き込んだケース（ALREADY_EXISTS）。本体は冪等なので問題なし。
+            logger.info(
+                "Firestore migration {} flag write skipped (likely completed by another instance): {}",
+                name,
+                e.message,
+            )
+        }
     }
 
     /**
      * money コレクションの旧 `month` フィールドを `yearMonth` にリネームする。
      *
-     * doc.id が年月文字列と一致する不変条件を利用し、`yearMonth` は `doc.id` から設定する。
-     * 既に `yearMonth` が存在するドキュメントは旧 `month` フィールドのみ削除する。
+     * `doc.id` が年月文字列と一致する不変条件を利用し、`yearMonth` は `doc.id` から設定する。
+     * 更新は WriteBatch で [FIRESTORE_BATCH_LIMIT] 件ずつまとめてコミットし、N ドキュメントに対する
+     * Firestore RTT を N 回から ⌈N / 500⌉ 回に削減する。
      */
     private suspend fun migrateMoneyMonthToYearMonth(): Int {
         val docs =
@@ -58,30 +104,48 @@ class FirestoreMigrations(
                 .get()
                 .await()
                 .documents
-        var migrated = 0
-        for (doc in docs) {
+        return commitInBatches(docs) { doc ->
             val data = doc.data
-            val hasLegacy = data.containsKey("month")
-            val hasNew = data.containsKey("yearMonth")
-            when {
-                !hasLegacy && hasNew -> continue
-                hasNew -> {
-                    doc.reference.update(mapOf("month" to FieldValue.delete())).await()
-                    migrated++
-                }
-                hasLegacy -> {
-                    doc.reference
-                        .update(
-                            mapOf(
-                                "yearMonth" to doc.id,
-                                "month" to FieldValue.delete(),
-                            ),
-                        ).await()
-                    migrated++
-                }
-                else -> continue
+            val action =
+                classifyMoneyMigration(
+                    hasLegacyMonth = data.containsKey("month"),
+                    hasYearMonth = data.containsKey("yearMonth"),
+                )
+            when (action) {
+                MoneyMigrationAction.SKIP -> null
+                MoneyMigrationAction.DELETE_LEGACY -> mapOf("month" to FieldValue.delete())
+                MoneyMigrationAction.SET_NEW_AND_DELETE_LEGACY ->
+                    mapOf(
+                        "yearMonth" to doc.id,
+                        "month" to FieldValue.delete(),
+                    )
             }
         }
-        return migrated
+    }
+
+    /**
+     * [docs] に対して [buildUpdate] が返す更新内容を [FIRESTORE_BATCH_LIMIT] 件ずつ WriteBatch でコミットする。
+     * [buildUpdate] が null を返したドキュメントは更新対象外。戻り値は更新されたドキュメント数。
+     */
+    private suspend fun commitInBatches(
+        docs: List<QueryDocumentSnapshot>,
+        buildUpdate: (QueryDocumentSnapshot) -> Map<String, Any>?,
+    ): Int {
+        var batch = firestore.batch()
+        var pending = 0
+        var affected = 0
+        for (doc in docs) {
+            val update = buildUpdate(doc) ?: continue
+            batch.update(doc.reference, update)
+            pending++
+            affected++
+            if (pending >= FIRESTORE_BATCH_LIMIT) {
+                batch.commit().await()
+                batch = firestore.batch()
+                pending = 0
+            }
+        }
+        if (pending > 0) batch.commit().await()
+        return affected
     }
 }

--- a/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
+++ b/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
@@ -125,6 +125,14 @@ class FirestoreMoneyRepository(
         return months
     }
 
+    /**
+     * Firestore ドキュメントから [MonthlyMoney] を組み立てる。
+     *
+     * 本リポジトリの不変条件として「ドキュメント ID == `yearMonth` フィールド値」を維持しており、
+     * 呼び出し側は必ず `doc.id`（または同値の引数）を [yearMonth] に渡す。ドキュメント内に保存された
+     * `"yearMonth"` フィールドは本関数では読まない（冗長保存だが、[saveMonthlyMoney] の `set` 全置換時に
+     * スキーマとして一貫させるために書き込んでいる）。
+     */
     private fun parseMonthlyMoney(
         yearMonth: String,
         doc: DocumentSnapshot,

--- a/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
+++ b/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
@@ -33,19 +33,19 @@ class FirestoreMoneyRepository(
     private val cache = ConcurrentHashMap<String, MonthlyMoney>()
     private val allMonthsLoaded = AtomicBoolean(false)
 
-    override suspend fun getMonthlyMoney(month: String): MonthlyMoney? {
-        cache[month]?.let { return it }
+    override suspend fun getMonthlyMoney(yearMonth: String): MonthlyMoney? {
+        cache[yearMonth]?.let { return it }
 
         val doc =
             firestore
                 .collection(MONEY_COLLECTION)
-                .document(month)
+                .document(yearMonth)
                 .get()
                 .await()
         if (!doc.exists()) return null
 
-        val data = parseMonthlyMoney(month, doc)
-        cache[month] = data
+        val data = parseMonthlyMoney(yearMonth, doc)
+        cache[yearMonth] = data
         return data
     }
 
@@ -53,13 +53,13 @@ class FirestoreMoneyRepository(
      * 月次お金データを Firestore に保存する。
      *
      * `set(Map)` は `SetOptions.merge()` を指定しないためドキュメント全体を置換する。
-     * これにより、旧スキーマの `locked: Boolean` フィールドを持つドキュメントを保存した際に
-     * `locked` が自動で削除され、legacy フィールドが残留しない。
-     * 将来この呼び出しを `merge` に変える場合は、`"locked" to FieldValue.delete()` を明示的に
+     * これにより、旧スキーマの `locked: Boolean` や `month` フィールドを持つドキュメントを保存した際に
+     * 自動で削除され、legacy フィールドが残留しない。
+     * 将来この呼び出しを `merge` に変える場合は、`"locked" to FieldValue.delete()` などを明示的に
      * 含めて legacy フィールドの除去を維持すること。
      */
     override suspend fun saveMonthlyMoney(
-        month: String,
+        yearMonth: String,
         data: MonthlyMoney,
     ) {
         val items =
@@ -84,27 +84,27 @@ class FirestoreMoneyRepository(
 
         firestore
             .collection(MONEY_COLLECTION)
-            .document(month)
-            .set(mapOf("month" to month, "items" to items, "paymentRecords" to records, "status" to data.status.name))
+            .document(yearMonth)
+            .set(mapOf("yearMonth" to yearMonth, "items" to items, "paymentRecords" to records, "status" to data.status.name))
             .await()
 
-        cache[month] = data
+        cache[yearMonth] = data
     }
 
     override suspend fun importItemsByTag(
-        targetMonth: String,
+        targetYearMonth: String,
         tag: String,
     ): MonthlyMoney {
-        val previousMonth = YearMonth.parse(targetMonth).minusMonths(1).toString()
-        val prevData = getMonthlyMoney(previousMonth)
+        val previousYearMonth = YearMonth.parse(targetYearMonth).minusMonths(1).toString()
+        val prevData = getMonthlyMoney(previousYearMonth)
         val taggedItems =
             (prevData?.items ?: emptyList())
                 .filter { tag in it.tags }
                 .map { item -> item.copy(id = UUID.randomUUID().toString()) }
 
-        val existing = getMonthlyMoney(targetMonth) ?: MonthlyMoney(month = targetMonth)
+        val existing = getMonthlyMoney(targetYearMonth) ?: MonthlyMoney(yearMonth = targetYearMonth)
         val merged = existing.copy(items = existing.items + taggedItems)
-        saveMonthlyMoney(targetMonth, merged)
+        saveMonthlyMoney(targetYearMonth, merged)
         return merged
     }
 
@@ -120,19 +120,19 @@ class FirestoreMoneyRepository(
                 .await()
                 .documents
         val months = docs.map { doc -> parseMonthlyMoney(doc.id, doc) }
-        months.forEach { cache[it.month] = it }
+        months.forEach { cache[it.yearMonth] = it }
         allMonthsLoaded.set(true)
         return months
     }
 
     private fun parseMonthlyMoney(
-        month: String,
+        yearMonth: String,
         doc: DocumentSnapshot,
     ): MonthlyMoney {
         val items = parseItems(doc.get("items"))
         val records = parsePaymentRecords(doc.get("paymentRecords"))
         val status = parseStatus(doc.getString("status"), doc.getBoolean("locked"))
-        return MonthlyMoney(month = month, items = items, paymentRecords = records, status = status)
+        return MonthlyMoney(yearMonth = yearMonth, items = items, paymentRecords = records, status = status)
     }
 }
 

--- a/server/src/main/kotlin/server/money/MoneyFilters.kt
+++ b/server/src/main/kotlin/server/money/MoneyFilters.kt
@@ -5,5 +5,5 @@ import model.MonthlyMoney
 fun MonthlyMoney.filterForUser(uid: String): MonthlyMoney {
     val userItems = items.filter { item -> item.payments.any { it.uid == uid } }
     val userRecords = paymentRecords.filter { it.uid == uid }
-    return MonthlyMoney(month = month, items = userItems, paymentRecords = userRecords, status = status)
+    return MonthlyMoney(yearMonth = yearMonth, items = userItems, paymentRecords = userRecords, status = status)
 }

--- a/server/src/main/kotlin/server/money/MoneyRepository.kt
+++ b/server/src/main/kotlin/server/money/MoneyRepository.kt
@@ -5,16 +5,16 @@ import model.MonthlyMoney
 /** Money データのリポジトリインターフェース */
 interface MoneyRepository {
     /** 月データを取得。ドキュメントが存在しない場合は null */
-    suspend fun getMonthlyMoney(month: String): MonthlyMoney?
+    suspend fun getMonthlyMoney(yearMonth: String): MonthlyMoney?
 
     suspend fun saveMonthlyMoney(
-        month: String,
+        yearMonth: String,
         data: MonthlyMoney,
     )
 
-    /** targetMonth の前月から指定タグ付き項目を targetMonth にインポート（マージ）して返す */
+    /** targetYearMonth の前月から指定タグ付き項目を targetYearMonth にインポート（マージ）して返す */
     suspend fun importItemsByTag(
-        targetMonth: String,
+        targetYearMonth: String,
         tag: String,
     ): MonthlyMoney
 

--- a/server/src/main/kotlin/server/money/MoneyRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyRoutes.kt
@@ -22,14 +22,14 @@ import server.auth.firebasePrincipal
 fun Route.moneyRoutes() {
     val moneyRepository by inject<MoneyRepository>()
 
-    route("/money/{month}") {
+    route("/money/{yearMonth}") {
         // 管理者: データ取得・全体保存
         adminOnly {
             get({
                 tags = listOf("money")
                 summary = "月次お金データ取得（admin）"
                 request {
-                    pathParameter<String>("month") { description = "月（YYYY-MM）" }
+                    pathParameter<String>("yearMonth") { description = "年月（YYYY-MM）" }
                 }
                 response {
                     code(HttpStatusCode.OK) {
@@ -37,16 +37,16 @@ fun Route.moneyRoutes() {
                     }
                 }
             }) {
-                val month = call.parameters.getOrFail("month")
-                val data = moneyRepository.getMonthlyMoney(month)
-                call.respond(data ?: MonthlyMoney(month = month))
+                val yearMonth = call.parameters.getOrFail("yearMonth")
+                val data = moneyRepository.getMonthlyMoney(yearMonth)
+                call.respond(data ?: MonthlyMoney(yearMonth = yearMonth))
             }
 
             post("import-by-tag", {
                 tags = listOf("money")
                 summary = "前月からタグ付き項目をインポート（admin）"
                 request {
-                    pathParameter<String>("month") { description = "月（YYYY-MM）" }
+                    pathParameter<String>("yearMonth") { description = "年月（YYYY-MM）" }
                 }
                 response {
                     code(HttpStatusCode.OK) {
@@ -55,13 +55,13 @@ fun Route.moneyRoutes() {
                     code(HttpStatusCode.Conflict) { description = "凍結中" }
                 }
             }) {
-                val month = call.parameters.getOrFail("month")
-                val existing = moneyRepository.getMonthlyMoney(month)
+                val yearMonth = call.parameters.getOrFail("yearMonth")
+                val existing = moneyRepository.getMonthlyMoney(yearMonth)
                 if (existing?.status == MonthlyMoneyStatus.FROZEN) {
                     call.respond(HttpStatusCode.Conflict, mapOf("error" to "Month is frozen"))
                     return@post
                 }
-                val updated = moneyRepository.importItemsByTag(month, MoneyTags.RECURRING)
+                val updated = moneyRepository.importItemsByTag(yearMonth, MoneyTags.RECURRING)
                 call.respond(updated)
             }
 
@@ -72,7 +72,7 @@ fun Route.moneyRoutes() {
                     "items / paymentRecords を保存する。body.status は無視され、" +
                     "既存値（新規月は PENDING）が維持される。status を変更する場合は PATCH /status を使うこと。"
                 request {
-                    pathParameter<String>("month") { description = "月（YYYY-MM）" }
+                    pathParameter<String>("yearMonth") { description = "年月（YYYY-MM）" }
                     body<MonthlyMoney>()
                 }
                 response {
@@ -82,8 +82,8 @@ fun Route.moneyRoutes() {
                     code(HttpStatusCode.Conflict) { description = "凍結中" }
                 }
             }) {
-                val month = call.parameters.getOrFail("month")
-                val existing = moneyRepository.getMonthlyMoney(month) ?: MonthlyMoney(month = month)
+                val yearMonth = call.parameters.getOrFail("yearMonth")
+                val existing = moneyRepository.getMonthlyMoney(yearMonth) ?: MonthlyMoney(yearMonth = yearMonth)
                 if (existing.status == MonthlyMoneyStatus.FROZEN) {
                     call.respond(HttpStatusCode.Conflict, mapOf("error" to "Month is frozen"))
                     return@put
@@ -92,7 +92,7 @@ fun Route.moneyRoutes() {
                 // status はこのエンドポイントでは変更しない（専用 PATCH /status で更新）。
                 // 新規月の場合 existing.status は PENDING になる点に注意。
                 val normalized = body.copy(status = existing.status)
-                moneyRepository.saveMonthlyMoney(month, normalized)
+                moneyRepository.saveMonthlyMoney(yearMonth, normalized)
                 call.respond(normalized)
             }
 
@@ -104,7 +104,7 @@ fun Route.moneyRoutes() {
                     "FROZEN の月を 409 で拒否するのに対し、このエンドポイントは FROZEN からの遷移（凍結解除）も " +
                     "含めた任意の状態遷移を admin 権限で許可する。凍結運用を admin が解除できる唯一の経路。"
                 request {
-                    pathParameter<String>("month") { description = "月（YYYY-MM）" }
+                    pathParameter<String>("yearMonth") { description = "年月（YYYY-MM）" }
                     body<MonthlyMoneyStatusUpdate>()
                 }
                 response {
@@ -113,12 +113,12 @@ fun Route.moneyRoutes() {
                     }
                 }
             }) {
-                val month = call.parameters.getOrFail("month")
+                val yearMonth = call.parameters.getOrFail("yearMonth")
                 val body = call.receive<MonthlyMoneyStatusUpdate>()
-                val existing = moneyRepository.getMonthlyMoney(month) ?: MonthlyMoney(month = month)
+                val existing = moneyRepository.getMonthlyMoney(yearMonth) ?: MonthlyMoney(yearMonth = yearMonth)
                 // FROZEN からの遷移も含めて admin に任意の状態遷移を許可する（凍結解除の唯一経路）。
                 val updated = existing.copy(status = body.status)
-                moneyRepository.saveMonthlyMoney(month, updated)
+                moneyRepository.saveMonthlyMoney(yearMonth, updated)
                 call.respond(updated)
             }
         }
@@ -129,7 +129,7 @@ fun Route.moneyRoutes() {
                 tags = listOf("money")
                 summary = "自分の月次お金データ取得"
                 request {
-                    pathParameter<String>("month") { description = "月（YYYY-MM）" }
+                    pathParameter<String>("yearMonth") { description = "年月（YYYY-MM）" }
                 }
                 response {
                     code(HttpStatusCode.OK) {
@@ -137,12 +137,12 @@ fun Route.moneyRoutes() {
                     }
                 }
             }) {
-                val month = call.parameters.getOrFail("month")
+                val yearMonth = call.parameters.getOrFail("yearMonth")
                 val uid = call.firebasePrincipal.uid
 
-                val data = moneyRepository.getMonthlyMoney(month)
+                val data = moneyRepository.getMonthlyMoney(yearMonth)
                 if (data == null) {
-                    call.respond(MonthlyMoney(month = month))
+                    call.respond(MonthlyMoney(yearMonth = yearMonth))
                     return@get
                 }
 
@@ -156,7 +156,7 @@ fun Route.moneyRoutes() {
                 tags = listOf("money")
                 summary = "支払い記録追加"
                 request {
-                    pathParameter<String>("month") { description = "月（YYYY-MM）" }
+                    pathParameter<String>("yearMonth") { description = "年月（YYYY-MM）" }
                     body<PaymentRecord>()
                 }
                 response {
@@ -167,13 +167,13 @@ fun Route.moneyRoutes() {
                     code(HttpStatusCode.Conflict) { description = "凍結中" }
                 }
             }) {
-                val month = call.parameters.getOrFail("month")
+                val yearMonth = call.parameters.getOrFail("yearMonth")
                 val uid = call.firebasePrincipal.uid
                 val record = call.receive<PaymentRecord>()
                 // uid をサーバー側で上書き（改ざん防止）
                 val safeRecord = record.copy(uid = uid)
 
-                val data = moneyRepository.getMonthlyMoney(month)
+                val data = moneyRepository.getMonthlyMoney(yearMonth)
                 if (data == null) {
                     call.respond(HttpStatusCode.NotFound, mapOf("error" to "Month not found"))
                     return@post
@@ -184,7 +184,7 @@ fun Route.moneyRoutes() {
                     return@post
                 }
                 val updated = data.copy(paymentRecords = data.paymentRecords + safeRecord)
-                moneyRepository.saveMonthlyMoney(month, updated)
+                moneyRepository.saveMonthlyMoney(yearMonth, updated)
 
                 call.respond(updated.filterForUser(uid))
             }

--- a/server/src/main/kotlin/server/report/BalanceCalculationService.kt
+++ b/server/src/main/kotlin/server/report/BalanceCalculationService.kt
@@ -11,18 +11,18 @@ data class UserOverpayment(
 }
 
 data class BalanceResult(
-    val months: List<String>,
+    val yearMonths: List<String>,
     val overpayments: List<UserOverpayment>,
 )
 
 class BalanceCalculationService {
     fun calculateOverpayments(allMonths: List<MonthlyMoney>): BalanceResult {
-        val months = mutableListOf<String>()
+        val yearMonths = mutableListOf<String>()
         val overpaidByUser = mutableMapOf<String, Long>()
         val redeemedByUser = mutableMapOf<String, Long>()
 
         for (monthData in allMonths) {
-            months.add(monthData.month)
+            yearMonths.add(monthData.yearMonth)
 
             val monthAllocated = mutableMapOf<String, Long>()
             for (item in monthData.items) {
@@ -52,10 +52,10 @@ class BalanceCalculationService {
             }
         }
 
-        months.sort()
+        yearMonths.sort()
 
         return BalanceResult(
-            months = months,
+            yearMonths = yearMonths,
             overpayments =
                 overpaidByUser.map { (uid, overpaid) ->
                     UserOverpayment(

--- a/server/src/main/kotlin/server/report/ReportRoutes.kt
+++ b/server/src/main/kotlin/server/report/ReportRoutes.kt
@@ -34,7 +34,7 @@ fun Route.reportRoutes() {
             summary = "支出レポート取得"
             request {
                 queryParameter<String>("center") {
-                    description = "中心月（YYYY-MM）"
+                    description = "中心となる年月（YYYY-MM）"
                     required = false
                 }
                 queryParameter<Int>("range") {
@@ -63,10 +63,10 @@ fun Route.reportRoutes() {
             val summaries =
                 (-range..range).map { offset ->
                     val ym = center.plusMonths(offset.toLong())
-                    val monthStr = ym.toString()
-                    val data = moneyRepository.getMonthlyMoney(monthStr)
+                    val yearMonthStr = ym.toString()
+                    val data = moneyRepository.getMonthlyMoney(yearMonthStr)
 
-                    buildExpenseSummary(monthStr, data)
+                    buildExpenseSummary(yearMonthStr, data)
                 }
 
             call.respond(ExpenseReport(months = summaries))
@@ -102,8 +102,8 @@ fun Route.reportRoutes() {
             call.respond(
                 BalanceSummary(
                     balances = balances,
-                    periodStart = result.months.firstOrNull() ?: "",
-                    periodEnd = result.months.lastOrNull() ?: "",
+                    periodStart = result.yearMonths.firstOrNull() ?: "",
+                    periodEnd = result.yearMonths.lastOrNull() ?: "",
                 ),
             )
         }
@@ -128,12 +128,12 @@ fun Route.reportRoutes() {
                 call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Amount must be positive"))
                 return@post
             }
-            runCatching { YearMonth.parse(req.month) }.getOrElse {
-                call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid month format"))
+            runCatching { YearMonth.parse(req.yearMonth) }.getOrElse {
+                call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid yearMonth format"))
                 return@post
             }
 
-            val data = moneyRepository.getMonthlyMoney(req.month) ?: MonthlyMoney(month = req.month)
+            val data = moneyRepository.getMonthlyMoney(req.yearMonth) ?: MonthlyMoney(yearMonth = req.yearMonth)
             if (data.status == MonthlyMoneyStatus.FROZEN) {
                 call.respond(HttpStatusCode.Conflict, mapOf("error" to "Month is frozen"))
                 return@post
@@ -147,7 +147,7 @@ fun Route.reportRoutes() {
                     isRedemption = true,
                 )
             val updated = data.copy(paymentRecords = data.paymentRecords + record)
-            moneyRepository.saveMonthlyMoney(req.month, updated)
+            moneyRepository.saveMonthlyMoney(req.yearMonth, updated)
 
             call.respond(mapOf("status" to "ok"))
         }
@@ -156,13 +156,13 @@ fun Route.reportRoutes() {
 
 /** MonthlyMoney から繰越タグ付き項目を除外して MonthlyExpenseSummary を構築する */
 internal fun buildExpenseSummary(
-    month: String,
+    yearMonth: String,
     data: MonthlyMoney?,
 ): MonthlyExpenseSummary {
-    if (data == null) return MonthlyExpenseSummary(month = month, totalAmount = 0L)
+    if (data == null) return MonthlyExpenseSummary(yearMonth = yearMonth, totalAmount = 0L)
     val reportItems = data.items.filter { MoneyTags.CARRY_OVER !in it.tags }
     return MonthlyExpenseSummary(
-        month = month,
+        yearMonth = yearMonth,
         totalAmount = reportItems.sumOf { it.amount },
         items = reportItems.map { ExpenseItem(name = it.name, amount = it.amount, note = it.note) },
     )

--- a/server/src/test/kotlin/server/migration/FirestoreMigrationsTest.kt
+++ b/server/src/test/kotlin/server/migration/FirestoreMigrationsTest.kt
@@ -1,38 +1,45 @@
 package server.migration
 
+import com.google.cloud.firestore.Firestore
+import io.mockk.mockk
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class FirestoreMigrationsTest {
+    // classifyMoneyMigration は Firestore に触れない純粋関数だが、メンバ関数なので
+    // FirestoreMigrations を instance 化する必要がある。relaxed = true で未使用メソッド呼び出しが
+    // 起きても no-op を返すダミー Firestore を用意する。
+    private val firestoreMigrations = FirestoreMigrations(mockk<Firestore>(relaxed = true))
+
     @Test
     fun legacyOnlySetsNewAndDeletesLegacy() {
         assertEquals(
-            MoneyMigrationAction.SET_NEW_AND_DELETE_LEGACY,
-            classifyMoneyMigration(hasLegacyMonth = true, hasYearMonth = false),
+            FirestoreMigrations.MoneyMigrationAction.SET_NEW_AND_DELETE_LEGACY,
+            firestoreMigrations.classifyMoneyMigration(hasLegacyMonth = true, hasYearMonth = false),
         )
     }
 
     @Test
     fun bothFieldsDeletesLegacyOnly() {
         assertEquals(
-            MoneyMigrationAction.DELETE_LEGACY,
-            classifyMoneyMigration(hasLegacyMonth = true, hasYearMonth = true),
+            FirestoreMigrations.MoneyMigrationAction.DELETE_LEGACY,
+            firestoreMigrations.classifyMoneyMigration(hasLegacyMonth = true, hasYearMonth = true),
         )
     }
 
     @Test
     fun newOnlySkips() {
         assertEquals(
-            MoneyMigrationAction.SKIP,
-            classifyMoneyMigration(hasLegacyMonth = false, hasYearMonth = true),
+            FirestoreMigrations.MoneyMigrationAction.SKIP,
+            firestoreMigrations.classifyMoneyMigration(hasLegacyMonth = false, hasYearMonth = true),
         )
     }
 
     @Test
     fun neitherFieldSkips() {
         assertEquals(
-            MoneyMigrationAction.SKIP,
-            classifyMoneyMigration(hasLegacyMonth = false, hasYearMonth = false),
+            FirestoreMigrations.MoneyMigrationAction.SKIP,
+            firestoreMigrations.classifyMoneyMigration(hasLegacyMonth = false, hasYearMonth = false),
         )
     }
 }

--- a/server/src/test/kotlin/server/migration/FirestoreMigrationsTest.kt
+++ b/server/src/test/kotlin/server/migration/FirestoreMigrationsTest.kt
@@ -1,0 +1,38 @@
+package server.migration
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FirestoreMigrationsTest {
+    @Test
+    fun legacyOnlySetsNewAndDeletesLegacy() {
+        assertEquals(
+            MoneyMigrationAction.SET_NEW_AND_DELETE_LEGACY,
+            classifyMoneyMigration(hasLegacyMonth = true, hasYearMonth = false),
+        )
+    }
+
+    @Test
+    fun bothFieldsDeletesLegacyOnly() {
+        assertEquals(
+            MoneyMigrationAction.DELETE_LEGACY,
+            classifyMoneyMigration(hasLegacyMonth = true, hasYearMonth = true),
+        )
+    }
+
+    @Test
+    fun newOnlySkips() {
+        assertEquals(
+            MoneyMigrationAction.SKIP,
+            classifyMoneyMigration(hasLegacyMonth = false, hasYearMonth = true),
+        )
+    }
+
+    @Test
+    fun neitherFieldSkips() {
+        assertEquals(
+            MoneyMigrationAction.SKIP,
+            classifyMoneyMigration(hasLegacyMonth = false, hasYearMonth = false),
+        )
+    }
+}

--- a/server/src/test/kotlin/server/money/MoneyFiltersTest.kt
+++ b/server/src/test/kotlin/server/money/MoneyFiltersTest.kt
@@ -13,7 +13,7 @@ class MoneyFiltersTest {
     fun filterKeepsOnlyUserItems() {
         val data =
             MonthlyMoney(
-                month = "2024-06",
+                yearMonth = "2024-06",
                 items =
                     listOf(
                         MoneyItem(
@@ -41,7 +41,7 @@ class MoneyFiltersTest {
             )
 
         val filtered = data.filterForUser("u1")
-        assertEquals("2024-06", filtered.month)
+        assertEquals("2024-06", filtered.yearMonth)
         assertEquals(1, filtered.items.size)
         assertEquals("item1", filtered.items[0].id)
         assertEquals(1, filtered.paymentRecords.size)
@@ -53,7 +53,7 @@ class MoneyFiltersTest {
         for (status in MonthlyMoneyStatus.entries) {
             val data =
                 MonthlyMoney(
-                    month = "2024-06",
+                    yearMonth = "2024-06",
                     items = emptyList(),
                     paymentRecords = emptyList(),
                     status = status,
@@ -67,7 +67,7 @@ class MoneyFiltersTest {
     fun filterReturnsEmptyForUnknownUser() {
         val data =
             MonthlyMoney(
-                month = "2024-06",
+                yearMonth = "2024-06",
                 items =
                     listOf(
                         MoneyItem(
@@ -91,7 +91,7 @@ class MoneyFiltersTest {
     fun filterKeepsItemIfUserHasAnyPayment() {
         val data =
             MonthlyMoney(
-                month = "2024-06",
+                yearMonth = "2024-06",
                 items =
                     listOf(
                         MoneyItem(
@@ -117,7 +117,7 @@ class MoneyFiltersTest {
         // isRedemption=true の精算レコードも uid ベースで正しくフィルタされる
         val data =
             MonthlyMoney(
-                month = "2024-06",
+                yearMonth = "2024-06",
                 paymentRecords =
                     listOf(
                         PaymentRecord(uid = "u1", amount = 5000L, paidAt = "2024-06-01"),

--- a/server/src/test/kotlin/server/report/BalanceCalculationServiceTest.kt
+++ b/server/src/test/kotlin/server/report/BalanceCalculationServiceTest.kt
@@ -13,7 +13,7 @@ class BalanceCalculationServiceTest {
     @Test
     fun emptyDataReturnsEmptyResult() {
         val result = service.calculateOverpayments(emptyList())
-        assertEquals(emptyList(), result.months)
+        assertEquals(emptyList(), result.yearMonths)
         assertEquals(emptyList(), result.overpayments)
     }
 
@@ -22,7 +22,7 @@ class BalanceCalculationServiceTest {
         val data =
             listOf(
                 MonthlyMoney(
-                    month = "2024-06",
+                    yearMonth = "2024-06",
                     items =
                         listOf(
                             MoneyItem(
@@ -39,7 +39,7 @@ class BalanceCalculationServiceTest {
                 ),
             )
         val result = service.calculateOverpayments(data)
-        assertEquals(listOf("2024-06"), result.months)
+        assertEquals(listOf("2024-06"), result.yearMonths)
         assertEquals(0, result.overpayments.size)
     }
 
@@ -48,7 +48,7 @@ class BalanceCalculationServiceTest {
         val data =
             listOf(
                 MonthlyMoney(
-                    month = "2024-06",
+                    yearMonth = "2024-06",
                     items =
                         listOf(
                             MoneyItem(
@@ -78,7 +78,7 @@ class BalanceCalculationServiceTest {
         val data =
             listOf(
                 MonthlyMoney(
-                    month = "2024-06",
+                    yearMonth = "2024-06",
                     items =
                         listOf(
                             MoneyItem(
@@ -99,7 +99,7 @@ class BalanceCalculationServiceTest {
                         ),
                 ),
                 MonthlyMoney(
-                    month = "2024-07",
+                    yearMonth = "2024-07",
                     items =
                         listOf(
                             MoneyItem(
@@ -121,7 +121,7 @@ class BalanceCalculationServiceTest {
                 ),
             )
         val result = service.calculateOverpayments(data)
-        assertEquals(listOf("2024-06", "2024-07"), result.months)
+        assertEquals(listOf("2024-06", "2024-07"), result.yearMonths)
 
         val u1 = result.overpayments.find { it.uid == "u1" }!!
         assertEquals(3000L, u1.overpaid) // 6月: 7000 - 4000 = 3000 過払い
@@ -137,7 +137,7 @@ class BalanceCalculationServiceTest {
         val data =
             listOf(
                 MonthlyMoney(
-                    month = "2024-06",
+                    yearMonth = "2024-06",
                     items =
                         listOf(
                             MoneyItem(
@@ -166,7 +166,7 @@ class BalanceCalculationServiceTest {
         val data =
             listOf(
                 MonthlyMoney(
-                    month = "2024-06",
+                    yearMonth = "2024-06",
                     items =
                         listOf(
                             MoneyItem(
@@ -191,15 +191,15 @@ class BalanceCalculationServiceTest {
     }
 
     @Test
-    fun monthsAreSorted() {
+    fun yearMonthsAreSorted() {
         val data =
             listOf(
-                MonthlyMoney(month = "2024-08"),
-                MonthlyMoney(month = "2024-06"),
-                MonthlyMoney(month = "2024-07"),
+                MonthlyMoney(yearMonth = "2024-08"),
+                MonthlyMoney(yearMonth = "2024-06"),
+                MonthlyMoney(yearMonth = "2024-07"),
             )
         val result = service.calculateOverpayments(data)
-        assertEquals(listOf("2024-06", "2024-07", "2024-08"), result.months)
+        assertEquals(listOf("2024-06", "2024-07", "2024-08"), result.yearMonths)
     }
 
     @Test
@@ -207,7 +207,7 @@ class BalanceCalculationServiceTest {
         val data =
             listOf(
                 MonthlyMoney(
-                    month = "2024-06",
+                    yearMonth = "2024-06",
                     items =
                         listOf(
                             MoneyItem(
@@ -233,7 +233,7 @@ class BalanceCalculationServiceTest {
         val data =
             listOf(
                 MonthlyMoney(
-                    month = "2024-06",
+                    yearMonth = "2024-06",
                     items =
                         listOf(
                             MoneyItem(
@@ -262,7 +262,7 @@ class BalanceCalculationServiceTest {
         val data =
             listOf(
                 MonthlyMoney(
-                    month = "2024-06",
+                    yearMonth = "2024-06",
                     items =
                         listOf(
                             MoneyItem(

--- a/server/src/test/kotlin/server/report/BuildExpenseSummaryTest.kt
+++ b/server/src/test/kotlin/server/report/BuildExpenseSummaryTest.kt
@@ -10,7 +10,7 @@ class BuildExpenseSummaryTest {
     @Test
     fun nullDataReturnsZeroSummary() {
         val result = buildExpenseSummary("2024-06", null)
-        assertEquals("2024-06", result.month)
+        assertEquals("2024-06", result.yearMonth)
         assertEquals(0L, result.totalAmount)
         assertEquals(emptyList(), result.items)
     }
@@ -19,7 +19,7 @@ class BuildExpenseSummaryTest {
     fun normalItemsAreIncluded() {
         val data =
             MonthlyMoney(
-                month = "2024-06",
+                yearMonth = "2024-06",
                 items =
                     listOf(
                         MoneyItem(id = "i1", name = "Rent", amount = 80000L),
@@ -35,7 +35,7 @@ class BuildExpenseSummaryTest {
     fun carryOverItemsAreExcluded() {
         val data =
             MonthlyMoney(
-                month = "2024-06",
+                yearMonth = "2024-06",
                 items =
                     listOf(
                         MoneyItem(id = "i1", name = "Rent", amount = 80000L),
@@ -57,7 +57,7 @@ class BuildExpenseSummaryTest {
     fun carryOverWithRecurringTagIsExcluded() {
         val data =
             MonthlyMoney(
-                month = "2024-06",
+                yearMonth = "2024-06",
                 items =
                     listOf(
                         MoneyItem(
@@ -77,7 +77,7 @@ class BuildExpenseSummaryTest {
     fun recurringOnlyItemsAreIncluded() {
         val data =
             MonthlyMoney(
-                month = "2024-06",
+                yearMonth = "2024-06",
                 items =
                     listOf(
                         MoneyItem(
@@ -97,7 +97,7 @@ class BuildExpenseSummaryTest {
     fun allCarryOverReturnsZero() {
         val data =
             MonthlyMoney(
-                month = "2024-06",
+                yearMonth = "2024-06",
                 items =
                     listOf(
                         MoneyItem(

--- a/shared/src/commonMain/kotlin/model/MoneyModels.kt
+++ b/shared/src/commonMain/kotlin/model/MoneyModels.kt
@@ -46,7 +46,7 @@ enum class MonthlyMoneyStatus {
 
 @Serializable
 data class MonthlyMoney(
-    val month: String,
+    val yearMonth: String,
     val items: List<MoneyItem> = emptyList(),
     val paymentRecords: List<PaymentRecord> = emptyList(),
     val status: MonthlyMoneyStatus = MonthlyMoneyStatus.PENDING,

--- a/shared/src/commonMain/kotlin/model/ReportModels.kt
+++ b/shared/src/commonMain/kotlin/model/ReportModels.kt
@@ -11,7 +11,7 @@ data class ExpenseItem(
 
 @Serializable
 data class MonthlyExpenseSummary(
-    val month: String,
+    val yearMonth: String,
     val totalAmount: Long,
     val items: List<ExpenseItem> = emptyList(),
 )
@@ -40,7 +40,7 @@ data class BalanceSummary(
 @Serializable
 data class OverpaymentRedemptionRequest(
     val uid: String,
-    val month: String,
+    val yearMonth: String,
     val amount: Long,
     val note: String = "",
 )

--- a/shared/src/commonTest/kotlin/model/MoneyModelsTest.kt
+++ b/shared/src/commonTest/kotlin/model/MoneyModelsTest.kt
@@ -53,7 +53,7 @@ class MoneyModelsTest {
     fun monthlyMoneyNestedRoundTrip() {
         val monthly =
             MonthlyMoney(
-                month = "2024-06",
+                yearMonth = "2024-06",
                 items =
                     listOf(
                         MoneyItem(id = "i1", name = "Water", amount = 3000L),
@@ -100,7 +100,7 @@ class MoneyModelsTest {
 
     @Test
     fun monthlyMoneyStatusDefault() {
-        val jsonStr = """{"month":"2024-07"}"""
+        val jsonStr = """{"yearMonth":"2024-07"}"""
         val decoded = json.decodeFromString(MonthlyMoney.serializer(), jsonStr)
         assertEquals(MonthlyMoneyStatus.PENDING, decoded.status)
     }
@@ -108,7 +108,7 @@ class MoneyModelsTest {
     @Test
     fun monthlyMoneyStatusRoundTrip() {
         for (status in MonthlyMoneyStatus.entries) {
-            val monthly = MonthlyMoney(month = "2024-07", status = status)
+            val monthly = MonthlyMoney(yearMonth = "2024-07", status = status)
             val encoded = json.encodeToString(MonthlyMoney.serializer(), monthly)
             val decoded = json.decodeFromString(MonthlyMoney.serializer(), encoded)
             assertEquals(status, decoded.status)

--- a/shared/src/commonTest/kotlin/model/ReportModelsTest.kt
+++ b/shared/src/commonTest/kotlin/model/ReportModelsTest.kt
@@ -26,7 +26,7 @@ class ReportModelsTest {
     fun monthlyExpenseSummaryRoundTrip() {
         val summary =
             MonthlyExpenseSummary(
-                month = "2025-01",
+                yearMonth = "2025-01",
                 totalAmount = 150000L,
                 items =
                     listOf(
@@ -41,9 +41,9 @@ class ReportModelsTest {
 
     @Test
     fun monthlyExpenseSummaryDefaultItems() {
-        val jsonStr = """{"month":"2025-02","totalAmount":50000}"""
+        val jsonStr = """{"yearMonth":"2025-02","totalAmount":50000}"""
         val decoded = json.decodeFromString(MonthlyExpenseSummary.serializer(), jsonStr)
-        assertEquals("2025-02", decoded.month)
+        assertEquals("2025-02", decoded.yearMonth)
         assertEquals(50000L, decoded.totalAmount)
         assertEquals(emptyList(), decoded.items)
     }
@@ -55,12 +55,12 @@ class ReportModelsTest {
                 months =
                     listOf(
                         MonthlyExpenseSummary(
-                            month = "2025-01",
+                            yearMonth = "2025-01",
                             totalAmount = 100000L,
                             items = listOf(ExpenseItem(name = "食費", amount = 40000L)),
                         ),
                         MonthlyExpenseSummary(
-                            month = "2025-02",
+                            yearMonth = "2025-02",
                             totalAmount = 120000L,
                         ),
                     ),


### PR DESCRIPTION
Closes #188

## Summary

YYYY-MM 形式の年月文字列を扱うフィールド・パラメーター・API パスを ISO 8601 / `java.time.YearMonth` の慣行に合わせて `yearMonth` に統一。1-12 の月番号を扱う変数（`CalendarView` 等）は対象外として維持。

### 主な変更点

- **shared モデル**: `MonthlyMoney.month`, `MonthlyExpenseSummary.month`, `OverpaymentRedemptionRequest.month` → `yearMonth`
- **API パス**: `/api/money/{month}` → `/api/money/{yearMonth}`
- **Firestore フィールド**: `\"month\"` → `\"yearMonth\"`
- **サーバー/クライアント**: `currentMonth`, `selectedMonth`, `monthStr`, `newMonth`, `targetMonth`, `currentMonthJs`, `shiftMonthJs` 等を `yearMonth` 系に統一

### Firestore マイグレーション機構

- サーバー起動時に `runBlocking { withTimeout(60.seconds) { ... } }` で **同期実行**（マイグレーション完了前に HTTP を受け付けず、失敗時は起動自体を中断）
- `_migrations` コレクションに完了フラグを保存し、2 回目以降はフラグ 1 件の読み込みで ms 単位 skip
- 完了フラグ書き込みは `DocumentReference.create`（Precondition.documentNotExists() 相当）で **CAS 保護**し、複数インスタンス並走時の無駄な書き込みを抑止
- `money` ドキュメント更新は **WriteBatch**（500 ops/バッチ）でまとめて RTT を ⌈N/500⌉ 回に圧縮
- 対象判定ロジックを `classifyMoneyMigration` 純粋関数に切り出してユニットテスト化（4 分岐網羅）

### 対象外（実態が 1-12 の月番号または UI 文言）

- `CalendarView.kt`, `DateUtils.kt` の `month: Int`
- `PaymentScreen.kt` formatDate 内の `month` ローカル変数
- UI 文言の「月」「前月」「翌月」表記

## Test plan

- [x] \`./gradlew :shared:jvmTest :server:test -PskipFrontend\` 成功（`FirestoreMigrationsTest` 4/4 含む）
- [x] \`./gradlew :app:compileDevelopmentExecutableKotlinWasmJs\` 成功
- [x] \`./gradlew ktlintCheck\` 成功
- [x] ローカル dev サーバー起動時に 2 ドキュメントのマイグレーションが約 0.6 秒で完了することを確認
- [ ] デプロイ後: Firebase コンソールで `money` ドキュメントに `yearMonth` フィールドが存在し `month` フィールドが削除されていることを確認
- [ ] デプロイ後: `/api/money/2026-04` 等で取得・保存が正常動作することを確認
- [ ] 再起動時にマイグレーションが skip されることを確認（`Running Firestore migration` ログが出ない）