### PR TITLE
feat: お金ステータス確定時の Webhook 通知機能を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ shared/              → Kotlin Multiplatform library
 
 server/              → Ktor server (Netty, JVM)
                        Depends on :shared
-                       Routes: /api/{firebase-config,users,pets,feeding,garbage,money,report,quest,point,quest-webhook,cache,login-history,passkey}
+                       Routes: /api/{firebase-config,users,pets,feeding,garbage,money,money-webhook,report,quest,point,quest-webhook,cache,login-history,passkey}
                        Firebase Auth verification
                        Koin DI でリポジトリ注入（ServerModule）
                        Repository 層: interface + Firestore 実装 class

--- a/core/network/src/commonMain/kotlin/core/network/MoneyWebhookRepository.kt
+++ b/core/network/src/commonMain/kotlin/core/network/MoneyWebhookRepository.kt
@@ -1,0 +1,29 @@
+package core.network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import model.MoneyWebhookSettings
+
+interface MoneyWebhookRepository {
+    suspend fun getSettings(): MoneyWebhookSettings
+
+    suspend fun updateSettings(settings: MoneyWebhookSettings): MoneyWebhookSettings
+}
+
+class MoneyWebhookRepositoryImpl(
+    private val client: HttpClient,
+) : MoneyWebhookRepository {
+    override suspend fun getSettings(): MoneyWebhookSettings = client.get("/api/settings/money-webhook").body()
+
+    override suspend fun updateSettings(settings: MoneyWebhookSettings): MoneyWebhookSettings =
+        client
+            .put("/api/settings/money-webhook") {
+                contentType(ContentType.Application.Json)
+                setBody(settings)
+            }.body()
+}

--- a/core/network/src/wasmJsMain/kotlin/core/network/di/NetworkModule.kt
+++ b/core/network/src/wasmJsMain/kotlin/core/network/di/NetworkModule.kt
@@ -12,6 +12,8 @@ import core.network.LoginHistoryRepository
 import core.network.LoginHistoryRepositoryImpl
 import core.network.MoneyRepository
 import core.network.MoneyRepositoryImpl
+import core.network.MoneyWebhookRepository
+import core.network.MoneyWebhookRepositoryImpl
 import core.network.PasskeyRepository
 import core.network.PasskeyRepositoryImpl
 import core.network.PetRepository
@@ -47,6 +49,7 @@ val networkModule =
         single<UserRepository> { UserRepositoryImpl(get()) }
         single<PasskeyRepository> { PasskeyRepositoryImpl(get()) }
         single<QuestWebhookRepository> { QuestWebhookRepositoryImpl(get()) }
+        single<MoneyWebhookRepository> { MoneyWebhookRepositoryImpl(get()) }
         single<CacheRepository> { CacheRepositoryImpl(get()) }
         single<LoginHistoryRepository> { LoginHistoryRepositoryImpl(get()) }
     }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/MoneyWebhookViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/MoneyWebhookViewModel.kt
@@ -31,7 +31,13 @@ class MoneyWebhookViewModel(
     }
 
     fun loadSettings() {
-        uiState = uiState.copy(isLoading = true, loadError = false, statusMessage = null)
+        uiState =
+            uiState.copy(
+                isLoading = true,
+                loadError = false,
+                loadErrorMessage = null,
+                statusMessage = null,
+            )
         viewModelScope.launch {
             try {
                 val settings = moneyWebhookRepository.getSettings()

--- a/feature/settings/src/commonMain/kotlin/feature/settings/MoneyWebhookViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/MoneyWebhookViewModel.kt
@@ -1,0 +1,80 @@
+package feature.settings
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import core.network.MoneyWebhookRepository
+import kotlinx.coroutines.launch
+import model.MoneyWebhookSettings
+
+data class MoneyWebhookUiState(
+    val url: String = "",
+    val enabled: Boolean = false,
+    val message: String = "",
+    val isLoading: Boolean = true,
+    val loadError: Boolean = false,
+    val loadErrorMessage: String? = null,
+    val isSaving: Boolean = false,
+    val statusMessage: String? = null,
+)
+
+class MoneyWebhookViewModel(
+    private val moneyWebhookRepository: MoneyWebhookRepository,
+) : ViewModel() {
+    var uiState by mutableStateOf(MoneyWebhookUiState())
+        private set
+
+    init {
+        loadSettings()
+    }
+
+    fun loadSettings() {
+        uiState = uiState.copy(isLoading = true, loadError = false, statusMessage = null)
+        viewModelScope.launch {
+            try {
+                val settings = moneyWebhookRepository.getSettings()
+                uiState =
+                    uiState.copy(
+                        url = settings.url,
+                        enabled = settings.enabled,
+                        message = settings.message,
+                        isLoading = false,
+                    )
+            } catch (e: Exception) {
+                uiState = uiState.copy(isLoading = false, loadError = true, loadErrorMessage = e.message)
+            }
+        }
+    }
+
+    fun onUrlChanged(url: String) {
+        uiState = uiState.copy(url = url, statusMessage = null)
+    }
+
+    fun onEnabledChanged(enabled: Boolean) {
+        uiState = uiState.copy(enabled = enabled, statusMessage = null)
+    }
+
+    fun onMessageChanged(message: String) {
+        uiState = uiState.copy(message = message, statusMessage = null)
+    }
+
+    fun onSave() {
+        uiState = uiState.copy(isSaving = true, statusMessage = null)
+        viewModelScope.launch {
+            try {
+                val settings =
+                    MoneyWebhookSettings(
+                        url = uiState.url,
+                        enabled = uiState.enabled,
+                        message = uiState.message,
+                    )
+                moneyWebhookRepository.updateSettings(settings)
+                uiState = uiState.copy(isSaving = false, statusMessage = "保存しました")
+            } catch (e: Exception) {
+                uiState = uiState.copy(isSaving = false, statusMessage = "保存失敗: ${e.message}")
+            }
+        }
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -1304,6 +1304,7 @@ private fun MoneyWebhookSettingsCard(
                     Switch(
                         checked = enabled,
                         onCheckedChange = onEnabledChanged,
+                        enabled = !isSaving,
                     )
                 }
 

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AccountBalance
 import androidx.compose.material.icons.filled.Cached
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.DeleteSweep
@@ -72,6 +73,7 @@ internal enum class SettingsCategory(
     Pet("ペット", Icons.Default.Pets, adminOnly = true),
     Garbage("ゴミ出し", Icons.Default.DeleteSweep, adminOnly = true),
     Quest("クエスト", Icons.Default.Star, adminOnly = true),
+    Money("お金", Icons.Default.AccountBalance, adminOnly = true),
     Cache("サーバーキャッシュ", Icons.Default.Cached, adminOnly = true),
 }
 
@@ -87,6 +89,7 @@ fun SettingsScreen(
     val userNameVm = remember(isAdmin) { if (isAdmin) koin.get<UserNameViewModel>() else null }
     val garbageVm = remember(isAdmin) { if (isAdmin) koin.get<GarbageScheduleViewModel>() else null }
     val questWebhookVm = remember(isAdmin) { if (isAdmin) koin.get<QuestWebhookViewModel>() else null }
+    val moneyWebhookVm = remember(isAdmin) { if (isAdmin) koin.get<MoneyWebhookViewModel>() else null }
     val cacheVm = remember(isAdmin) { if (isAdmin) koin.get<CacheRefreshViewModel>() else null }
     val petSettingsVm = remember(isAdmin) { if (isAdmin) koin.get<PetSettingsViewModel>() else null }
     val windowSizeClass = LocalWindowSizeClass.current
@@ -161,6 +164,19 @@ fun SettingsScreen(
         onQuestWebhookToggleEvent = { questWebhookVm?.onToggleEvent(it) },
         onSaveQuestWebhook = { questWebhookVm?.onSave() },
         onRetryQuestWebhook = { questWebhookVm?.loadSettings() },
+        moneyWebhookLoading = moneyWebhookVm?.uiState?.isLoading ?: false,
+        moneyWebhookLoadError = moneyWebhookVm?.uiState?.loadError ?: false,
+        moneyWebhookLoadErrorMessage = moneyWebhookVm?.uiState?.loadErrorMessage,
+        moneyWebhookUrl = moneyWebhookVm?.uiState?.url ?: "",
+        moneyWebhookEnabled = moneyWebhookVm?.uiState?.enabled ?: false,
+        moneyWebhookMessage = moneyWebhookVm?.uiState?.message ?: "",
+        moneyWebhookSaving = moneyWebhookVm?.uiState?.isSaving ?: false,
+        moneyWebhookStatusMessage = moneyWebhookVm?.uiState?.statusMessage,
+        onMoneyWebhookUrlChanged = { moneyWebhookVm?.onUrlChanged(it) },
+        onMoneyWebhookEnabledChanged = { moneyWebhookVm?.onEnabledChanged(it) },
+        onMoneyWebhookMessageChanged = { moneyWebhookVm?.onMessageChanged(it) },
+        onSaveMoneyWebhook = { moneyWebhookVm?.onSave() },
+        onRetryMoneyWebhook = { moneyWebhookVm?.loadSettings() },
         cacheClearing = cacheVm?.uiState?.isClearing ?: false,
         cacheMessage = cacheVm?.uiState?.message,
         onClearCache = { cacheVm?.onClearCache() },
@@ -261,6 +277,19 @@ internal fun SettingsContent(
     onQuestWebhookToggleEvent: (String) -> Unit = {},
     onSaveQuestWebhook: () -> Unit = {},
     onRetryQuestWebhook: () -> Unit = {},
+    moneyWebhookLoading: Boolean = false,
+    moneyWebhookLoadError: Boolean = false,
+    moneyWebhookLoadErrorMessage: String? = null,
+    moneyWebhookUrl: String = "",
+    moneyWebhookEnabled: Boolean = false,
+    moneyWebhookMessage: String = "",
+    moneyWebhookSaving: Boolean = false,
+    moneyWebhookStatusMessage: String? = null,
+    onMoneyWebhookUrlChanged: (String) -> Unit = {},
+    onMoneyWebhookEnabledChanged: (Boolean) -> Unit = {},
+    onMoneyWebhookMessageChanged: (String) -> Unit = {},
+    onSaveMoneyWebhook: () -> Unit = {},
+    onRetryMoneyWebhook: () -> Unit = {},
     cacheClearing: Boolean = false,
     cacheMessage: String? = null,
     onClearCache: () -> Unit = {},
@@ -439,6 +468,24 @@ internal fun SettingsContent(
                     onToggleEvent = onQuestWebhookToggleEvent,
                     onSave = onSaveQuestWebhook,
                     onRetry = onRetryQuestWebhook,
+                    modifier = cardModifier,
+                )
+            }
+            SettingsCategory.Money -> {
+                MoneyWebhookSettingsCard(
+                    isLoading = moneyWebhookLoading,
+                    loadError = moneyWebhookLoadError,
+                    loadErrorMessage = moneyWebhookLoadErrorMessage,
+                    url = moneyWebhookUrl,
+                    enabled = moneyWebhookEnabled,
+                    message = moneyWebhookMessage,
+                    isSaving = moneyWebhookSaving,
+                    statusMessage = moneyWebhookStatusMessage,
+                    onUrlChanged = onMoneyWebhookUrlChanged,
+                    onEnabledChanged = onMoneyWebhookEnabledChanged,
+                    onMessageChanged = onMoneyWebhookMessageChanged,
+                    onSave = onSaveMoneyWebhook,
+                    onRetry = onRetryMoneyWebhook,
                     modifier = cardModifier,
                 )
             }
@@ -1189,6 +1236,106 @@ private fun QuestWebhookSettingsCard(
                 if (message != null) {
                     Text(
                         text = message,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+
+                Button(
+                    onClick = onSave,
+                    modifier = Modifier.height(48.dp),
+                    enabled = !isSaving,
+                ) {
+                    if (isSaving) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                        )
+                    } else {
+                        Text("保存する")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MoneyWebhookSettingsCard(
+    isLoading: Boolean,
+    loadError: Boolean = false,
+    loadErrorMessage: String? = null,
+    url: String,
+    enabled: Boolean,
+    message: String,
+    isSaving: Boolean,
+    statusMessage: String?,
+    onUrlChanged: (String) -> Unit,
+    onEnabledChanged: (Boolean) -> Unit,
+    onMessageChanged: (String) -> Unit,
+    onSave: () -> Unit,
+    onRetry: () -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier,
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            ),
+    ) {
+        LoadableCardContent(
+            isLoading = isLoading,
+            loadError = loadError,
+            loadErrorMessage = loadErrorMessage,
+            onRetry = onRetry,
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp).fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text("ステータス確定通知", style = MaterialTheme.typography.titleSmall)
+                    Switch(
+                        checked = enabled,
+                        onCheckedChange = onEnabledChanged,
+                    )
+                }
+
+                Text(
+                    text = "月のお金ステータスを「確定済み」に切り替えた際に Webhook で通知します。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                OutlinedTextField(
+                    value = url,
+                    onValueChange = onUrlChanged,
+                    label = { Text("Webhook URL") },
+                    placeholder = { Text("https://discord.com/api/webhooks/...") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = !isSaving,
+                )
+
+                OutlinedTextField(
+                    value = message,
+                    onValueChange = onMessageChanged,
+                    label = { Text("通知テキスト") },
+                    placeholder = { Text("@everyone") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = !isSaving,
+                )
+
+                if (statusMessage != null) {
+                    Text(
+                        text = statusMessage,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.primary,
                     )

--- a/feature/settings/src/commonMain/kotlin/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/di/SettingsModule.kt
@@ -3,6 +3,7 @@ package feature.settings.di
 import feature.settings.CacheRefreshViewModel
 import feature.settings.GarbageScheduleViewModel
 import feature.settings.LoginHistoryViewModel
+import feature.settings.MoneyWebhookViewModel
 import feature.settings.PasskeyManagementViewModel
 import feature.settings.PasswordChangeViewModel
 import feature.settings.PetSettingsViewModel
@@ -20,6 +21,7 @@ val settingsModule =
         factory { UserNameViewModel(get()) }
         factory { GarbageScheduleViewModel(get()) }
         factory { QuestWebhookViewModel(get()) }
+        factory { MoneyWebhookViewModel(get()) }
         factory { CacheRefreshViewModel(get()) }
         factory { PetSettingsViewModel(get(), get(), get()) }
     }

--- a/feature/settings/src/jvmTest/kotlin/feature/settings/MoneyWebhookViewModelTest.kt
+++ b/feature/settings/src/jvmTest/kotlin/feature/settings/MoneyWebhookViewModelTest.kt
@@ -1,0 +1,167 @@
+package feature.settings
+
+import core.network.MoneyWebhookRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import model.MoneyWebhookSettings
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MoneyWebhookViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var moneyWebhookRepository: MoneyWebhookRepository
+
+    private val testSettings =
+        MoneyWebhookSettings(
+            url = "https://hooks.example.com/webhook",
+            enabled = true,
+            message = "@everyone",
+        )
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        moneyWebhookRepository = mockk()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(): MoneyWebhookViewModel {
+        coEvery { moneyWebhookRepository.getSettings() } returns testSettings
+        return MoneyWebhookViewModel(moneyWebhookRepository)
+    }
+
+    @Test
+    fun `init loads settings`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.isLoading)
+            assertEquals("https://hooks.example.com/webhook", viewModel.uiState.url)
+            assertTrue(viewModel.uiState.enabled)
+            assertEquals("@everyone", viewModel.uiState.message)
+        }
+
+    @Test
+    fun `init load failure shows error`() =
+        runTest {
+            coEvery { moneyWebhookRepository.getSettings() } throws RuntimeException("load error")
+            val viewModel = MoneyWebhookViewModel(moneyWebhookRepository)
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.isLoading)
+            assertTrue(viewModel.uiState.loadError)
+            assertEquals("load error", viewModel.uiState.loadErrorMessage)
+        }
+
+    @Test
+    fun `loadSettings clears stale error message on retry`() =
+        runTest {
+            coEvery { moneyWebhookRepository.getSettings() } throws RuntimeException("first failure")
+            val viewModel = MoneyWebhookViewModel(moneyWebhookRepository)
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.loadError)
+            assertEquals("first failure", viewModel.uiState.loadErrorMessage)
+
+            coEvery { moneyWebhookRepository.getSettings() } returns testSettings
+            viewModel.loadSettings()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.loadError)
+            assertNull(viewModel.uiState.loadErrorMessage)
+            assertEquals("https://hooks.example.com/webhook", viewModel.uiState.url)
+        }
+
+    @Test
+    fun `onUrlChanged updates url and clears status message`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.onUrlChanged("https://new-url.example.com")
+
+            assertEquals("https://new-url.example.com", viewModel.uiState.url)
+            assertNull(viewModel.uiState.statusMessage)
+        }
+
+    @Test
+    fun `onEnabledChanged updates enabled and clears status message`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.onEnabledChanged(false)
+
+            assertFalse(viewModel.uiState.enabled)
+            assertNull(viewModel.uiState.statusMessage)
+        }
+
+    @Test
+    fun `onMessageChanged updates message and clears status message`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.onMessageChanged("通知本文")
+
+            assertEquals("通知本文", viewModel.uiState.message)
+            assertNull(viewModel.uiState.statusMessage)
+        }
+
+    @Test
+    fun `save success shows status message`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            coEvery { moneyWebhookRepository.updateSettings(any()) } returns testSettings
+
+            viewModel.onSave()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.isSaving)
+            assertEquals("保存しました", viewModel.uiState.statusMessage)
+            coVerify {
+                moneyWebhookRepository.updateSettings(
+                    MoneyWebhookSettings(
+                        url = "https://hooks.example.com/webhook",
+                        enabled = true,
+                        message = "@everyone",
+                    ),
+                )
+            }
+        }
+
+    @Test
+    fun `save failure shows error in status message`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            coEvery { moneyWebhookRepository.updateSettings(any()) } throws RuntimeException("save error")
+
+            viewModel.onSave()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.isSaving)
+            assertEquals("保存失敗: save error", viewModel.uiState.statusMessage)
+        }
+}

--- a/server/src/main/kotlin/server/Application.kt
+++ b/server/src/main/kotlin/server/Application.kt
@@ -46,6 +46,7 @@ import server.garbage.garbageRoutes
 import server.loginhistory.loginHistoryRoutes
 import server.migration.FirestoreMigrations
 import server.money.moneyRoutes
+import server.money.moneyWebhookRoutes
 import server.passkey.PasskeyDatabase
 import server.passkey.passkeyRoutes
 import server.pet.PetAccessDeniedException
@@ -194,6 +195,7 @@ fun Application.module() {
             feedingRoutes()
             garbageRoutes()
             moneyRoutes()
+            moneyWebhookRoutes()
             reportRoutes()
             questRoutes()
             pointRoutes()

--- a/server/src/main/kotlin/server/di/ServerModule.kt
+++ b/server/src/main/kotlin/server/di/ServerModule.kt
@@ -18,6 +18,7 @@ import server.loginhistory.LoginHistoryRepository
 import server.migration.FirestoreMigrations
 import server.money.FirestoreMoneyRepository
 import server.money.MoneyRepository
+import server.money.MoneyWebhookService
 import server.pet.FirestorePetRepository
 import server.pet.PetRepository
 import server.quest.FirestorePointRepository
@@ -40,6 +41,7 @@ val serverModule =
         single<LoginHistoryRepository> { FirestoreLoginHistoryRepository(get()) }
         single<PetRepository> { FirestorePetRepository(get()) }
         single { QuestWebhookService(get()) }
+        single { MoneyWebhookService(get()) }
         single { QuestService(get(), get(), get()) }
         single { FeedingReminderService(get(), get(), get()) }
         single { GarbageNotificationService(get()) }

--- a/server/src/main/kotlin/server/money/MoneyRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyRoutes.kt
@@ -21,6 +21,7 @@ import server.auth.firebasePrincipal
 
 fun Route.moneyRoutes() {
     val moneyRepository by inject<MoneyRepository>()
+    val moneyWebhookService by inject<MoneyWebhookService>()
 
     route("/money/{yearMonth}") {
         // 管理者: データ取得・全体保存
@@ -119,6 +120,10 @@ fun Route.moneyRoutes() {
                 // FROZEN からの遷移も含めて admin に任意の状態遷移を許可する（凍結解除の唯一経路）。
                 val updated = existing.copy(status = body.status)
                 moneyRepository.saveMonthlyMoney(yearMonth, updated)
+                // 同一ステータスへの冪等 PATCH での連打通知を避けるため、実際に遷移した場合のみ送信。
+                if (existing.status != body.status && body.status == MonthlyMoneyStatus.CONFIRMED) {
+                    moneyWebhookService.notifyConfirmed(yearMonth)
+                }
                 call.respond(updated)
             }
         }

--- a/server/src/main/kotlin/server/money/MoneyWebhookRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyWebhookRoutes.kt
@@ -1,0 +1,49 @@
+package server.money
+
+import io.github.smiley4.ktoropenapi.get
+import io.github.smiley4.ktoropenapi.put
+import io.ktor.http.*
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.route
+import model.MoneyWebhookSettings
+import org.koin.ktor.ext.inject
+import server.auth.adminOnly
+
+fun Route.moneyWebhookRoutes() {
+    val moneyWebhookService by inject<MoneyWebhookService>()
+
+    route("/settings/money-webhook") {
+        adminOnly {
+            get({
+                tags = listOf("money-webhook")
+                summary = "お金 Webhook 設定取得（admin）"
+                response {
+                    code(HttpStatusCode.OK) {
+                        body<MoneyWebhookSettings>()
+                    }
+                }
+            }) {
+                call.respond(moneyWebhookService.getSettings())
+            }
+
+            put({
+                tags = listOf("money-webhook")
+                summary = "お金 Webhook 設定更新（admin）"
+                request {
+                    body<MoneyWebhookSettings>()
+                }
+                response {
+                    code(HttpStatusCode.OK) {
+                        body<MoneyWebhookSettings>()
+                    }
+                }
+            }) {
+                val settings = call.receive<MoneyWebhookSettings>()
+                moneyWebhookService.updateSettings(settings)
+                call.respond(moneyWebhookService.getSettings())
+            }
+        }
+    }
+}

--- a/server/src/main/kotlin/server/money/MoneyWebhookService.kt
+++ b/server/src/main/kotlin/server/money/MoneyWebhookService.kt
@@ -131,13 +131,13 @@ class MoneyWebhookService(
     companion object {
         private val appUrl: String? = EnvConfig["APP_URL"]
 
-        /** "YYYY-MM" を "YYYY年M月" 表記に整形。パース失敗時は入力をそのまま返す。 */
+        /** "YYYY-MM" を "YYYY年MM月" 表記（月は 0 埋め 2 桁）に整形。パース失敗時は入力をそのまま返す。 */
         internal fun formatYearMonth(yearMonth: String): String {
             val parts = yearMonth.split("-")
             if (parts.size != 2) return yearMonth
             val year = parts[0].toIntOrNull() ?: return yearMonth
             val month = parts[1].toIntOrNull() ?: return yearMonth
-            return "${year}年${month}月"
+            return "%d年%02d月".format(year, month)
         }
     }
 }

--- a/server/src/main/kotlin/server/money/MoneyWebhookService.kt
+++ b/server/src/main/kotlin/server/money/MoneyWebhookService.kt
@@ -1,0 +1,170 @@
+package server.money
+
+import com.google.cloud.firestore.Firestore
+import com.google.cloud.firestore.SetOptions
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.content.TextContent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import model.MoneyWebhookSettings
+import org.slf4j.LoggerFactory
+import server.config.EnvConfig
+import server.util.DISCORD_EMBED_COLOR
+import server.util.WebhookServiceType
+import server.util.await
+import server.util.detectWebhookService
+
+private val logger = LoggerFactory.getLogger("MoneyWebhookService")
+
+class MoneyWebhookService(
+    private val firestore: Firestore,
+    private val client: HttpClient = HttpClient(),
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    private val moneySettingsDoc get() = firestore.collection("settings").document("money")
+    private val scope = CoroutineScope(dispatcher)
+
+    private val json = Json
+
+    @Suppress("UNCHECKED_CAST")
+    suspend fun getSettings(): MoneyWebhookSettings {
+        val doc = moneySettingsDoc.get().await()
+        if (!doc.exists()) return MoneyWebhookSettings()
+        val webhook = (doc.data?.get("webhook") as? Map<String, Any?>) ?: return MoneyWebhookSettings()
+        return MoneyWebhookSettings(
+            url = webhook["url"] as? String ?: "",
+            enabled = webhook["enabled"] as? Boolean ?: false,
+            message = webhook["message"] as? String ?: "",
+        )
+    }
+
+    suspend fun updateSettings(settings: MoneyWebhookSettings) {
+        moneySettingsDoc
+            .set(
+                mapOf(
+                    "webhook" to
+                        mapOf(
+                            "url" to settings.url,
+                            "enabled" to settings.enabled,
+                            "message" to settings.message,
+                        ),
+                ),
+                SetOptions.merge(),
+            ).await()
+    }
+
+    /** 月次ステータス確定時の通知を fire-and-forget で送信 */
+    fun notifyConfirmed(yearMonth: String) {
+        scope.launch {
+            try {
+                val settings = getSettings()
+                if (!settings.enabled || settings.url.isBlank()) return@launch
+
+                val payload = buildPayload(settings.url, settings.message, yearMonth)
+
+                client.post(settings.url) {
+                    setBody(TextContent(payload, ContentType.Application.Json))
+                }
+            } catch (e: Exception) {
+                logger.warn("Money webhook delivery failed for yearMonth=$yearMonth", e)
+            }
+        }
+    }
+
+    internal fun buildPayload(
+        url: String,
+        message: String,
+        yearMonth: String,
+        dashboardUrl: String? = appUrl,
+    ): String {
+        val description = "${formatYearMonth(yearMonth)} のお金が確定しました"
+        return when (detectWebhookService(url)) {
+            WebhookServiceType.DISCORD -> {
+                json.encodeToString(
+                    DiscordMoneyPayload(
+                        content = message.ifBlank { null },
+                        embeds =
+                            listOf(
+                                DiscordMoneyEmbed(
+                                    title = "お金ステータス確定",
+                                    description = description,
+                                    color = DISCORD_EMBED_COLOR,
+                                    url = dashboardUrl,
+                                ),
+                            ),
+                    ),
+                )
+            }
+            WebhookServiceType.SLACK -> {
+                val text = if (message.isBlank()) description else "$message\n$description"
+                val withLink =
+                    if (dashboardUrl != null) "$text\n<$dashboardUrl|ダッシュボードを開く>" else text
+                json.encodeToString(SlackMoneyPayload(text = withLink))
+            }
+            WebhookServiceType.GENERIC -> {
+                json.encodeToString(
+                    GenericMoneyPayload(
+                        event = "money_status_confirmed",
+                        yearMonth = yearMonth,
+                        message = message,
+                        dashboardUrl = dashboardUrl,
+                    ),
+                )
+            }
+        }
+    }
+
+    companion object {
+        private val appUrl: String? = EnvConfig["APP_URL"]
+
+        /** "YYYY-MM" を "YYYY年M月" 表記に整形。パース失敗時は入力をそのまま返す。 */
+        internal fun formatYearMonth(yearMonth: String): String {
+            val parts = yearMonth.split("-")
+            if (parts.size != 2) return yearMonth
+            val year = parts[0].toIntOrNull() ?: return yearMonth
+            val month = parts[1].toIntOrNull() ?: return yearMonth
+            return "${year}年${month}月"
+        }
+    }
+}
+
+// --- Discord ペイロード ---
+
+@Serializable
+internal data class DiscordMoneyPayload(
+    val content: String? = null,
+    val embeds: List<DiscordMoneyEmbed>,
+)
+
+@Serializable
+internal data class DiscordMoneyEmbed(
+    val title: String,
+    val description: String,
+    val color: Int,
+    val url: String? = null,
+)
+
+// --- Slack ペイロード ---
+
+@Serializable
+internal data class SlackMoneyPayload(
+    val text: String,
+)
+
+// --- 汎用ペイロード ---
+
+@Serializable
+internal data class GenericMoneyPayload(
+    val event: String,
+    val yearMonth: String,
+    val message: String,
+    val dashboardUrl: String? = null,
+)

--- a/server/src/main/kotlin/server/money/MoneyWebhookService.kt
+++ b/server/src/main/kotlin/server/money/MoneyWebhookService.kt
@@ -3,6 +3,7 @@ package server.money
 import com.google.cloud.firestore.Firestore
 import com.google.cloud.firestore.SetOptions
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
@@ -26,7 +27,12 @@ private val logger = LoggerFactory.getLogger("MoneyWebhookService")
 
 class MoneyWebhookService(
     private val firestore: Firestore,
-    private val client: HttpClient = HttpClient(),
+    private val client: HttpClient =
+        HttpClient {
+            install(HttpTimeout) {
+                requestTimeoutMillis = 10_000
+            }
+        },
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     private val moneySettingsDoc get() = firestore.collection("settings").document("money")

--- a/server/src/main/kotlin/server/money/MoneyWebhookService.kt
+++ b/server/src/main/kotlin/server/money/MoneyWebhookService.kt
@@ -85,7 +85,7 @@ class MoneyWebhookService(
         yearMonth: String,
         dashboardUrl: String? = appUrl,
     ): String {
-        val description = "${formatYearMonth(yearMonth)} のお金が確定しました"
+        val description = "${formatYearMonth(yearMonth)} の支払額が確定しました"
         return when (detectWebhookService(url)) {
             WebhookServiceType.DISCORD -> {
                 json.encodeToString(
@@ -94,7 +94,7 @@ class MoneyWebhookService(
                         embeds =
                             listOf(
                                 DiscordMoneyEmbed(
-                                    title = "お金ステータス確定",
+                                    title = "支払額確定",
                                     description = description,
                                     color = DISCORD_EMBED_COLOR,
                                     url = dashboardUrl,

--- a/server/src/test/kotlin/server/money/MoneyWebhookPayloadTest.kt
+++ b/server/src/test/kotlin/server/money/MoneyWebhookPayloadTest.kt
@@ -1,0 +1,196 @@
+package server.money
+
+import com.google.cloud.firestore.Firestore
+import io.mockk.mockk
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import server.money.MoneyWebhookService.Companion.formatYearMonth
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class MoneyWebhookPayloadTest {
+    private val service = MoneyWebhookService(firestore = mockk<Firestore>())
+
+    private fun parseJson(jsonString: String): JsonObject = Json.parseToJsonElement(jsonString).jsonObject
+
+    // --- Discord ペイロード ---
+
+    @Test
+    fun discordPayloadStructure() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://discord.com/api/webhooks/12345/token",
+                    message = "@everyone",
+                    yearMonth = "2026-04",
+                    dashboardUrl = "https://example.com/",
+                ),
+            )
+
+        val embeds = json["embeds"]
+        assertIs<JsonArray>(embeds)
+        assertEquals(1, embeds.size)
+
+        val embed = embeds[0].jsonObject
+        assertEquals("支払額確定", embed["title"]!!.jsonPrimitive.content)
+        val description = embed["description"]!!.jsonPrimitive.content
+        assertTrue(description.contains("2026年4月"), "description should contain '2026年4月': $description")
+    }
+
+    @Test
+    fun discordPayloadIncludesMessageAsContent() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://discord.com/api/webhooks/12345/token",
+                    message = "@everyone",
+                    yearMonth = "2026-04",
+                    dashboardUrl = null,
+                ),
+            )
+
+        assertEquals("@everyone", json["content"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun discordPayloadOmitsContentWhenMessageBlank() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://discord.com/api/webhooks/12345/token",
+                    message = "",
+                    yearMonth = "2026-04",
+                    dashboardUrl = null,
+                ),
+            )
+
+        // 空メッセージ時は content フィールドを省略する（@Serializable のデフォルト null + encodeDefaults=false）
+        assertNull(json["content"])
+    }
+
+    @Test
+    fun discordAppUrlAlsoProducesDiscordPayload() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://discordapp.com/api/webhooks/12345/token",
+                    message = "",
+                    yearMonth = "2026-04",
+                    dashboardUrl = null,
+                ),
+            )
+        assertIs<JsonArray>(json["embeds"])
+    }
+
+    // --- Slack ペイロード ---
+
+    @Test
+    fun slackPayloadTextWithMessageAndDashboard() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://hooks.slack.com/services/T00/B00/xxx",
+                    message = "確定しました",
+                    yearMonth = "2026-04",
+                    dashboardUrl = "https://example.com/",
+                ),
+            )
+
+        val text = json["text"]!!.jsonPrimitive.content
+        assertTrue(text.contains("確定しました"), "text should contain message: $text")
+        assertTrue(text.contains("2026年4月"), "text should contain '2026年4月': $text")
+        assertTrue(
+            text.contains("<https://example.com/|ダッシュボードを開く>"),
+            "text should contain Slack-style link: $text",
+        )
+    }
+
+    @Test
+    fun slackPayloadOmitsLinkWhenDashboardUrlNull() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://hooks.slack.com/services/T00/B00/xxx",
+                    message = "",
+                    yearMonth = "2026-04",
+                    dashboardUrl = null,
+                ),
+            )
+
+        val text = json["text"]!!.jsonPrimitive.content
+        assertTrue(text.contains("2026年4月"), "text should contain year-month: $text")
+        assertTrue(!text.contains("ダッシュボードを開く"), "text should not contain dashboard link: $text")
+    }
+
+    // --- Generic ペイロード ---
+
+    @Test
+    fun genericPayloadFields() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://example.com/webhook",
+                    message = "確定しました",
+                    yearMonth = "2026-04",
+                    dashboardUrl = "https://example.com/",
+                ),
+            )
+
+        assertEquals("money_status_confirmed", json["event"]!!.jsonPrimitive.content)
+        assertEquals("2026-04", json["yearMonth"]!!.jsonPrimitive.content)
+        assertEquals("確定しました", json["message"]!!.jsonPrimitive.content)
+        assertEquals("https://example.com/", json["dashboardUrl"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun genericPayloadOmitsDashboardUrlWhenNull() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://example.com/webhook",
+                    message = "",
+                    yearMonth = "2026-04",
+                    dashboardUrl = null,
+                ),
+            )
+        assertNull(json["dashboardUrl"])
+    }
+
+    // --- URL によるサービス判別 ---
+
+    @Test
+    fun caseInsensitiveDiscordDetection() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://DISCORD.COM/API/WEBHOOKS/12345/token",
+                    message = "",
+                    yearMonth = "2026-04",
+                    dashboardUrl = null,
+                ),
+            )
+        assertIs<JsonArray>(json["embeds"])
+    }
+
+    // --- formatYearMonth ---
+
+    @Test
+    fun formatYearMonthValidInput() {
+        assertEquals("2026年4月", formatYearMonth("2026-04"))
+        assertEquals("2026年12月", formatYearMonth("2026-12"))
+    }
+
+    @Test
+    fun formatYearMonthReturnsInputOnInvalidFormat() {
+        assertEquals("abc", formatYearMonth("abc"))
+        assertEquals("2026", formatYearMonth("2026"))
+        assertEquals("2026-04-01", formatYearMonth("2026-04-01"))
+        assertEquals("2026-XX", formatYearMonth("2026-XX"))
+    }
+}

--- a/server/src/test/kotlin/server/money/MoneyWebhookPayloadTest.kt
+++ b/server/src/test/kotlin/server/money/MoneyWebhookPayloadTest.kt
@@ -40,7 +40,7 @@ class MoneyWebhookPayloadTest {
         val embed = embeds[0].jsonObject
         assertEquals("支払額確定", embed["title"]!!.jsonPrimitive.content)
         val description = embed["description"]!!.jsonPrimitive.content
-        assertTrue(description.contains("2026年4月"), "description should contain '2026年4月': $description")
+        assertTrue(description.contains("2026年04月"), "description should contain '2026年04月': $description")
     }
 
     @Test
@@ -104,7 +104,7 @@ class MoneyWebhookPayloadTest {
 
         val text = json["text"]!!.jsonPrimitive.content
         assertTrue(text.contains("確定しました"), "text should contain message: $text")
-        assertTrue(text.contains("2026年4月"), "text should contain '2026年4月': $text")
+        assertTrue(text.contains("2026年04月"), "text should contain '2026年04月': $text")
         assertTrue(
             text.contains("<https://example.com/|ダッシュボードを開く>"),
             "text should contain Slack-style link: $text",
@@ -124,7 +124,7 @@ class MoneyWebhookPayloadTest {
             )
 
         val text = json["text"]!!.jsonPrimitive.content
-        assertTrue(text.contains("2026年4月"), "text should contain year-month: $text")
+        assertTrue(text.contains("2026年04月"), "text should contain year-month: $text")
         assertTrue(!text.contains("ダッシュボードを開く"), "text should not contain dashboard link: $text")
     }
 
@@ -182,7 +182,7 @@ class MoneyWebhookPayloadTest {
 
     @Test
     fun formatYearMonthValidInput() {
-        assertEquals("2026年4月", formatYearMonth("2026-04"))
+        assertEquals("2026年04月", formatYearMonth("2026-04"))
         assertEquals("2026年12月", formatYearMonth("2026-12"))
     }
 

--- a/shared/src/commonMain/kotlin/model/MoneyModels.kt
+++ b/shared/src/commonMain/kotlin/model/MoneyModels.kt
@@ -56,3 +56,10 @@ data class MonthlyMoney(
 data class MonthlyMoneyStatusUpdate(
     val status: MonthlyMoneyStatus,
 )
+
+@Serializable
+data class MoneyWebhookSettings(
+    val url: String = "",
+    val enabled: Boolean = false,
+    val message: String = "",
+)


### PR DESCRIPTION
## Summary
- お金管理の月次ステータスを「確定済み」(CONFIRMED) に遷移させたタイミングで Webhook 通知を送信する機能を追加しました。
- 設定画面に「お金」カテゴリを新設し、管理者は ON/OFF・URL・通知テキストの 3 項目を編集できます。
- 通知先は URL パターンから Discord / Slack / 汎用 JSON を自動判別します（既存 `WebhookUtils` を流用）。
- 同じ状態への冪等 PATCH による連打を避けるため、ステータスが実際に遷移した場合のみ通知します。`FROZEN` → `CONFIRMED` 遷移（凍結解除して確定に戻す）でも通知が飛ぶ仕様です。
- Discord embed の文言はユーザー視点に寄せ、タイトル「支払額確定」・説明「{yearMonth} の支払額が確定しました」としています。

## 変更点
- `shared` に `MoneyWebhookSettings(url, enabled, message)` を追加
- `server/money/MoneyWebhookService` を新設（Firestore `settings/money.webhook` に永続化、fire-and-forget 送信）
  - `HttpTimeout` (10 秒) を install し、応答しない Webhook 先でコルーチンが滞留しないよう配慮
- `GET /api/settings/money-webhook` / `PUT /api/settings/money-webhook`（admin 専用）を追加
- `PATCH /api/money/{yearMonth}/status` で `PENDING` 等 → `CONFIRMED` 遷移時に `notifyConfirmed` を呼び出し
- `core/network/MoneyWebhookRepository` と Koin 登録を追加
- `feature/settings` に `MoneyWebhookViewModel` と `MoneyWebhookSettingsCard` を追加し、`SettingsCategory.Money` として表示
  - 保存中は Switch / OutlinedTextField / 保存ボタンを無効化
  - `loadSettings` リトライ時に過去の `loadErrorMessage` を破棄
- `CLAUDE.md` の Routes 一覧に `money-webhook` を追記

## 追加テスト
- `server/src/test/kotlin/server/money/MoneyWebhookPayloadTest.kt`
  - Discord embed 構造（title, description, content 省略挙動）
  - Slack text 整形（メッセージ + 年月 + ダッシュボードリンク）
  - Generic JSON（event, yearMonth, message, dashboardUrl）
  - URL 判別（`discord.com` / `discordapp.com` / 大文字小文字）
  - `formatYearMonth` の整形と不正入力フォールバック
- `feature/settings/src/jvmTest/kotlin/feature/settings/MoneyWebhookViewModelTest.kt`
  - 初期ロード成功 / 失敗（`loadErrorMessage` も検証）
  - リトライ時に過去の `loadErrorMessage` がクリアされること
  - `onUrlChanged` / `onEnabledChanged` / `onMessageChanged` の状態更新と `statusMessage` クリア
  - 保存成功 / 失敗時の `statusMessage` 表示と Repository 呼び出し検証

## Test plan
- [x] `./gradlew :shared:jvmTest :server:test` が通ることを確認（ローカル実行済み、`MoneyWebhookPayloadTest` を含む）
- [x] `./gradlew :feature:settings:jvmTest :feature:settings:compileKotlinJvm :core:network:compileKotlinJvm` のコンパイル・テストが通ることを確認
- [x] `./gradlew :server:ktlintCheck :feature:settings:ktlintCheck` が通ることを確認
- [ ] 設定画面 → お金カテゴリで URL・通知テキストを入力して「保存する」が成功すること
- [ ] お金画面で `確定前` → `確定済み` に切り替えた際に Discord/Slack/汎用 Webhook へ通知が届くこと
- [ ] 同じ `CONFIRMED` へ再度 PATCH しても 2 重通知されないこと
- [ ] ON/OFF を OFF にした状態では通知が飛ばないこと
- [ ] 保存中は Switch と URL/通知テキスト入力が無効化されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)