### PR TITLE
fix: Discord 通知の prefix を embed 外のメッセージ本文に移動

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,11 +48,9 @@ jobs:
             title="CD 失敗"
             color=15158332
           fi
-          if [ -n "$PREFIX" ]; then
-            title="$PREFIX $title"
-          fi
           short_sha="${SHA:0:7}"
           payload=$(jq -n \
+            --arg content "$PREFIX" \
             --arg title "$title" \
             --argjson color "$color" \
             --arg ref "$REF_NAME" \
@@ -60,6 +58,7 @@ jobs:
             --arg commit_url "$SERVER_URL/$REPO/commit/$SHA" \
             --arg run_url "$SERVER_URL/$REPO/actions/runs/$RUN_ID" \
             '{
+              content: $content,
               embeds: [{
                 title: $title,
                 color: $color,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,7 @@ The `server/build.gradle.kts` has a `copyWasmFrontend` task that copies the fron
 GitHub Actions で CI/CD を構成。
 
 - **CI** (`.github/workflows/ci.yml`): PR・main push 時に lint / test / build を実行。Renovate の patch auto-merge は `platformAutomerge: false` により CI pass 後に Renovate 自身がマージする。
-- **CD** (`.github/workflows/cd.yml`): `v*` タグ push 時に Docker イメージをビルドし GHCR に push。`:latest` と `:v1.x.x` の2タグ。完了後に Discord へ成否通知（GitHub Secret `DISCORD_WEBHOOK_URL` が必要。未設定時は通知をスキップ）。`DISCORD_WEBHOOK_PREFIX` を設定するとタイトルに prefix を前置できる（例: `[PROD]` → `[PROD] CD 成功`）。複数環境の通知を同一 Discord チャンネルで区別する用途向け。
+- **CD** (`.github/workflows/cd.yml`): `v*` タグ push 時に Docker イメージをビルドし GHCR に push。`:latest` と `:v1.x.x` の2タグ。完了後に Discord へ成否通知（GitHub Secret `DISCORD_WEBHOOK_URL` が必要。未設定時は通知をスキップ）。`DISCORD_WEBHOOK_PREFIX` を設定すると embed 外のメッセージ本文として送信される（例: `[PROD]`）。embed 内タイトルは常に `CD 成功` / `CD 失敗`。複数環境の通知を同一 Discord チャンネルで区別する用途向け。
 
 ### デプロイフロー
 


### PR DESCRIPTION
## Summary
- `DISCORD_WEBHOOK_PREFIX` を embed title への前置から、embed 外のメッセージ本文（`content`）での送信に変更
- embed 内タイトルは常に `CD 成功` / `CD 失敗` のみ
- prefix 未設定時は `content` を空文字で送信（従来通り embed のみ表示される）
- `CLAUDE.md` の該当記述も更新

## Test plan
- [ ] `DISCORD_WEBHOOK_PREFIX` を設定した環境で `v*` タグ push → embed の上に prefix だけが message 本文として表示されること
- [ ] `DISCORD_WEBHOOK_PREFIX` 未設定時は従来通り embed のみ表示されること
- [ ] embed title は prefix 有無によらず `CD 成功` / `CD 失敗` のみであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)