### PR TITLE
refactor(server): logger をクラスフィールド方式に統一 (#199)

### DIFF
--- a/server/src/main/kotlin/server/auth/FirebaseAdmin.kt
+++ b/server/src/main/kotlin/server/auth/FirebaseAdmin.kt
@@ -9,9 +9,8 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.io.FileInputStream
 
-private val logger = LoggerFactory.getLogger("FirebaseAdmin")
-
 object FirebaseAdmin {
+    private val logger = LoggerFactory.getLogger(FirebaseAdmin::class.java)
     private var initialized = false
 
     fun initialize() {

--- a/server/src/main/kotlin/server/feeding/FeedingReminderService.kt
+++ b/server/src/main/kotlin/server/feeding/FeedingReminderService.kt
@@ -22,7 +22,6 @@ import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
-private val logger = LoggerFactory.getLogger("FeedingReminderService")
 private val JST = ZoneId.of("Asia/Tokyo")
 
 class FeedingReminderService(
@@ -36,6 +35,7 @@ class FeedingReminderService(
             }
         },
 ) {
+    private val logger = LoggerFactory.getLogger(FeedingReminderService::class.java)
     private val json = Json
 
     // 単一コルーチンからのみアクセスされるため通常の HashMap で十分

--- a/server/src/main/kotlin/server/garbage/GarbageNotificationService.kt
+++ b/server/src/main/kotlin/server/garbage/GarbageNotificationService.kt
@@ -20,13 +20,13 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
-private val logger = LoggerFactory.getLogger("GarbageNotificationService")
 private val JST = ZoneId.of("Asia/Tokyo")
 
 class GarbageNotificationService(
     private val garbageRepository: GarbageRepository,
     private val client: HttpClient = HttpClient(),
 ) {
+    private val logger = LoggerFactory.getLogger(GarbageNotificationService::class.java)
     private val json = Json
 
     // 通知済みの日付（JST カレンダー日付）

--- a/server/src/main/kotlin/server/migration/FirestoreMigrations.kt
+++ b/server/src/main/kotlin/server/migration/FirestoreMigrations.kt
@@ -13,8 +13,6 @@ private const val MONEY_COLLECTION = "money"
 // https://firebase.google.com/docs/firestore/manage-data/transactions#batched-writes
 private const val FIRESTORE_BATCH_LIMIT = 500
 
-private val logger = LoggerFactory.getLogger("server.migration.FirestoreMigrations")
-
 /**
  * Firestore の一回きりマイグレーションをサーバー起動時に実行する。
  *
@@ -28,6 +26,8 @@ private val logger = LoggerFactory.getLogger("server.migration.FirestoreMigratio
 class FirestoreMigrations(
     private val firestore: Firestore,
 ) {
+    private val logger = LoggerFactory.getLogger(FirestoreMigrations::class.java)
+
     /** money.month → yearMonth マイグレーションにおける 1 ドキュメントの扱い。 */
     internal enum class MoneyMigrationAction {
         /** 対象外。新フィールドのみ保持済み、または両方未設定。 */

--- a/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
+++ b/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
@@ -22,6 +22,8 @@ class FirestoreMoneyRepository(
     private val firestore: Firestore,
 ) : MoneyRepository,
     Cacheable {
+    private val logger = LoggerFactory.getLogger(FirestoreMoneyRepository::class.java)
+
     override val cacheName: String = "money"
 
     override fun clearCache() {
@@ -142,75 +144,71 @@ class FirestoreMoneyRepository(
         return MonthlyMoney(yearMonth = yearMonth, items = items, paymentRecords = records, status = status)
     }
 
-    companion object {
-        private val logger = LoggerFactory.getLogger(FirestoreMoneyRepository::class.java)
+    /**
+     * Firestore の生フィールドから MonthlyMoneyStatus を復元する。
+     *
+     * - 新形式: `status: "FROZEN"` 等の文字列。enum の name で復元する。
+     * - 未知の文字列: WARN ログを出した上で旧形式にフォールバックする。
+     * - 旧形式 (`locked: Boolean`): `locked=true → FROZEN` に変換する。
+     *
+     * それ以外（status 未設定 + locked=false または未設定）は [MonthlyMoneyStatus.PENDING] を
+     * デフォルトとして返す。旧運用では `locked=false` は単に「編集可能」を意味し、新 3 状態の
+     * 「確定済みか未確定か」という情報は存在しなかったため、安全側に倒して PENDING とする。
+     * 既に運用上確定していた月は、マイグレーション後に admin が手動で CONFIRMED に切り替える
+     * ことを想定する。
+     */
+    internal fun parseStatus(
+        statusRaw: String?,
+        legacyLocked: Boolean?,
+    ): MonthlyMoneyStatus {
+        val normalized = statusRaw?.trim()?.takeIf { it.isNotEmpty() }
+        if (normalized != null) {
+            val parsed = runCatching { MonthlyMoneyStatus.valueOf(normalized) }.getOrNull()
+            if (parsed != null) return parsed
+            logger.warn("Unknown MonthlyMoneyStatus value: {} — falling back to legacy locked", normalized)
+        }
+        return if (legacyLocked == true) MonthlyMoneyStatus.FROZEN else MonthlyMoneyStatus.PENDING
+    }
 
-        /**
-         * Firestore の生フィールドから MonthlyMoneyStatus を復元する。
-         *
-         * - 新形式: `status: "FROZEN"` 等の文字列。enum の name で復元する。
-         * - 未知の文字列: WARN ログを出した上で旧形式にフォールバックする。
-         * - 旧形式 (`locked: Boolean`): `locked=true → FROZEN` に変換する。
-         *
-         * それ以外（status 未設定 + locked=false または未設定）は [MonthlyMoneyStatus.PENDING] を
-         * デフォルトとして返す。旧運用では `locked=false` は単に「編集可能」を意味し、新 3 状態の
-         * 「確定済みか未確定か」という情報は存在しなかったため、安全側に倒して PENDING とする。
-         * 既に運用上確定していた月は、マイグレーション後に admin が手動で CONFIRMED に切り替える
-         * ことを想定する。
-         */
-        internal fun parseStatus(
-            statusRaw: String?,
-            legacyLocked: Boolean?,
-        ): MonthlyMoneyStatus {
-            val normalized = statusRaw?.trim()?.takeIf { it.isNotEmpty() }
-            if (normalized != null) {
-                val parsed = runCatching { MonthlyMoneyStatus.valueOf(normalized) }.getOrNull()
-                if (parsed != null) return parsed
-                logger.warn("Unknown MonthlyMoneyStatus value: {} — falling back to legacy locked", normalized)
-            }
-            return if (legacyLocked == true) MonthlyMoneyStatus.FROZEN else MonthlyMoneyStatus.PENDING
+    /** Map リストから MoneyItem リストをパースする（テスト用に internal） */
+    @Suppress("UNCHECKED_CAST")
+    internal fun parseItems(raw: Any?): List<MoneyItem> {
+        val itemsRaw = raw as? List<Map<String, Any?>> ?: return emptyList()
+        return itemsRaw.map { entry ->
+            val paymentsRaw = entry["payments"] as? List<Map<String, Any?>> ?: emptyList()
+            // tags フィールドを読み取り。レガシーデータ対応: recurring=true → tags=["毎月"]
+            val tags =
+                (entry["tags"] as? List<String>)
+                    ?: if (entry["recurring"] as? Boolean == true) listOf(MoneyTags.RECURRING) else emptyList()
+            MoneyItem(
+                id = entry["id"] as String,
+                name = entry["name"] as String,
+                amount = (entry["amount"] as Number).toLong(),
+                note = entry["note"] as? String ?: "",
+                tags = tags,
+                payments =
+                    paymentsRaw.map { p ->
+                        Payment(
+                            uid = p["uid"] as String,
+                            amount = (p["amount"] as Number).toLong(),
+                        )
+                    },
+            )
         }
     }
-}
 
-/** Map リストから MoneyItem リストをパースする（テスト用に internal） */
-@Suppress("UNCHECKED_CAST")
-internal fun parseItems(raw: Any?): List<MoneyItem> {
-    val itemsRaw = raw as? List<Map<String, Any?>> ?: return emptyList()
-    return itemsRaw.map { entry ->
-        val paymentsRaw = entry["payments"] as? List<Map<String, Any?>> ?: emptyList()
-        // tags フィールドを読み取り。レガシーデータ対応: recurring=true → tags=["毎月"]
-        val tags =
-            (entry["tags"] as? List<String>)
-                ?: if (entry["recurring"] as? Boolean == true) listOf(MoneyTags.RECURRING) else emptyList()
-        MoneyItem(
-            id = entry["id"] as String,
-            name = entry["name"] as String,
-            amount = (entry["amount"] as Number).toLong(),
-            note = entry["note"] as? String ?: "",
-            tags = tags,
-            payments =
-                paymentsRaw.map { p ->
-                    Payment(
-                        uid = p["uid"] as String,
-                        amount = (p["amount"] as Number).toLong(),
-                    )
-                },
-        )
-    }
-}
-
-/** Map リストから PaymentRecord リストをパースする（テスト用に internal） */
-@Suppress("UNCHECKED_CAST")
-internal fun parsePaymentRecords(raw: Any?): List<PaymentRecord> {
-    val recordsRaw = raw as? List<Map<String, Any?>> ?: return emptyList()
-    return recordsRaw.map { r ->
-        PaymentRecord(
-            uid = r["uid"] as String,
-            amount = (r["amount"] as Number).toLong(),
-            paidAt = r["paidAt"] as String,
-            note = r["note"] as? String ?: "",
-            isRedemption = r["isRedemption"] as? Boolean ?: false,
-        )
+    /** Map リストから PaymentRecord リストをパースする（テスト用に internal） */
+    @Suppress("UNCHECKED_CAST")
+    internal fun parsePaymentRecords(raw: Any?): List<PaymentRecord> {
+        val recordsRaw = raw as? List<Map<String, Any?>> ?: return emptyList()
+        return recordsRaw.map { r ->
+            PaymentRecord(
+                uid = r["uid"] as String,
+                amount = (r["amount"] as Number).toLong(),
+                paidAt = r["paidAt"] as String,
+                note = r["note"] as? String ?: "",
+                isRedemption = r["isRedemption"] as? Boolean ?: false,
+            )
+        }
     }
 }

--- a/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
+++ b/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
@@ -17,7 +17,6 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 
 private const val MONEY_COLLECTION = "money"
-private val logger = LoggerFactory.getLogger("server.money.FirestoreMoneyRepository")
 
 class FirestoreMoneyRepository(
     private val firestore: Firestore,
@@ -142,32 +141,36 @@ class FirestoreMoneyRepository(
         val status = parseStatus(doc.getString("status"), doc.getBoolean("locked"))
         return MonthlyMoney(yearMonth = yearMonth, items = items, paymentRecords = records, status = status)
     }
-}
 
-/**
- * Firestore の生フィールドから MonthlyMoneyStatus を復元する。
- *
- * - 新形式: `status: "FROZEN"` 等の文字列。enum の name で復元する。
- * - 未知の文字列: WARN ログを出した上で旧形式にフォールバックする。
- * - 旧形式 (`locked: Boolean`): `locked=true → FROZEN` に変換する。
- *
- * それ以外（status 未設定 + locked=false または未設定）は [MonthlyMoneyStatus.PENDING] を
- * デフォルトとして返す。旧運用では `locked=false` は単に「編集可能」を意味し、新 3 状態の
- * 「確定済みか未確定か」という情報は存在しなかったため、安全側に倒して PENDING とする。
- * 既に運用上確定していた月は、マイグレーション後に admin が手動で CONFIRMED に切り替える
- * ことを想定する。
- */
-internal fun parseStatus(
-    statusRaw: String?,
-    legacyLocked: Boolean?,
-): MonthlyMoneyStatus {
-    val normalized = statusRaw?.trim()?.takeIf { it.isNotEmpty() }
-    if (normalized != null) {
-        val parsed = runCatching { MonthlyMoneyStatus.valueOf(normalized) }.getOrNull()
-        if (parsed != null) return parsed
-        logger.warn("Unknown MonthlyMoneyStatus value: {} — falling back to legacy locked", normalized)
+    companion object {
+        private val logger = LoggerFactory.getLogger(FirestoreMoneyRepository::class.java)
+
+        /**
+         * Firestore の生フィールドから MonthlyMoneyStatus を復元する。
+         *
+         * - 新形式: `status: "FROZEN"` 等の文字列。enum の name で復元する。
+         * - 未知の文字列: WARN ログを出した上で旧形式にフォールバックする。
+         * - 旧形式 (`locked: Boolean`): `locked=true → FROZEN` に変換する。
+         *
+         * それ以外（status 未設定 + locked=false または未設定）は [MonthlyMoneyStatus.PENDING] を
+         * デフォルトとして返す。旧運用では `locked=false` は単に「編集可能」を意味し、新 3 状態の
+         * 「確定済みか未確定か」という情報は存在しなかったため、安全側に倒して PENDING とする。
+         * 既に運用上確定していた月は、マイグレーション後に admin が手動で CONFIRMED に切り替える
+         * ことを想定する。
+         */
+        internal fun parseStatus(
+            statusRaw: String?,
+            legacyLocked: Boolean?,
+        ): MonthlyMoneyStatus {
+            val normalized = statusRaw?.trim()?.takeIf { it.isNotEmpty() }
+            if (normalized != null) {
+                val parsed = runCatching { MonthlyMoneyStatus.valueOf(normalized) }.getOrNull()
+                if (parsed != null) return parsed
+                logger.warn("Unknown MonthlyMoneyStatus value: {} — falling back to legacy locked", normalized)
+            }
+            return if (legacyLocked == true) MonthlyMoneyStatus.FROZEN else MonthlyMoneyStatus.PENDING
+        }
     }
-    return if (legacyLocked == true) MonthlyMoneyStatus.FROZEN else MonthlyMoneyStatus.PENDING
 }
 
 /** Map リストから MoneyItem リストをパースする（テスト用に internal） */

--- a/server/src/main/kotlin/server/money/MoneyWebhookService.kt
+++ b/server/src/main/kotlin/server/money/MoneyWebhookService.kt
@@ -23,8 +23,6 @@ import server.util.WebhookServiceType
 import server.util.await
 import server.util.detectWebhookService
 
-private val logger = LoggerFactory.getLogger("MoneyWebhookService")
-
 class MoneyWebhookService(
     private val firestore: Firestore,
     private val client: HttpClient =
@@ -35,6 +33,7 @@ class MoneyWebhookService(
         },
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
+    private val logger = LoggerFactory.getLogger(MoneyWebhookService::class.java)
     private val moneySettingsDoc get() = firestore.collection("settings").document("money")
     private val scope = CoroutineScope(dispatcher)
 

--- a/server/src/main/kotlin/server/passkey/PasskeyRoutes.kt
+++ b/server/src/main/kotlin/server/passkey/PasskeyRoutes.kt
@@ -26,7 +26,7 @@ import server.auth.firebasePrincipal
 import server.ratelimit.RateLimitNames
 import java.util.Base64
 
-private val logger = LoggerFactory.getLogger("PasskeyRoutes")
+private val logger = LoggerFactory.getLogger("server.passkey.PasskeyRoutes")
 
 /** WebAuthn オプション JSON 用。デフォルト値（type="public-key" 等）もシリアライズする */
 private val webAuthnJson = Json { encodeDefaults = true }

--- a/server/src/main/kotlin/server/passkey/PasskeyService.kt
+++ b/server/src/main/kotlin/server/passkey/PasskeyService.kt
@@ -23,9 +23,8 @@ import org.slf4j.LoggerFactory
 import server.config.EnvConfig
 import java.util.Base64
 
-private val logger = LoggerFactory.getLogger("PasskeyService")
-
 object PasskeyService {
+    private val logger = LoggerFactory.getLogger(PasskeyService::class.java)
     private val webAuthnManager = WebAuthnManager.createNonStrictWebAuthnManager()
     private val objectConverter = ObjectConverter()
     private val attestedCredentialDataConverter = AttestedCredentialDataConverter(objectConverter)

--- a/server/src/main/kotlin/server/quest/QuestWebhookService.kt
+++ b/server/src/main/kotlin/server/quest/QuestWebhookService.kt
@@ -23,12 +23,11 @@ import server.util.await
 import server.util.detectWebhookService
 import java.time.Instant
 
-private val logger = LoggerFactory.getLogger("QuestWebhookService")
-
 class QuestWebhookService(
     private val firestore: Firestore,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
+    private val logger = LoggerFactory.getLogger(QuestWebhookService::class.java)
     private val questSettingsDoc get() = firestore.collection("settings").document("quest")
     private val scope = CoroutineScope(dispatcher)
 

--- a/server/src/test/kotlin/server/money/MoneyParsingTest.kt
+++ b/server/src/test/kotlin/server/money/MoneyParsingTest.kt
@@ -2,6 +2,7 @@ package server.money
 
 import model.MoneyTags
 import model.MonthlyMoneyStatus
+import server.money.FirestoreMoneyRepository.Companion.parseStatus
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/server/src/test/kotlin/server/money/MoneyParsingTest.kt
+++ b/server/src/test/kotlin/server/money/MoneyParsingTest.kt
@@ -1,12 +1,18 @@
 package server.money
 
+import com.google.cloud.firestore.Firestore
+import io.mockk.mockk
 import model.MoneyTags
 import model.MonthlyMoneyStatus
-import server.money.FirestoreMoneyRepository.Companion.parseStatus
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class MoneyParsingTest {
+    // parse 関数群は Firestore に触れない純粋関数だが、メンバ関数なので
+    // FirestoreMoneyRepository を instance 化する必要がある。relaxed = true で未使用メソッド呼び出しが
+    // 起きても no-op を返すダミー Firestore を用意する。
+    private val repository = FirestoreMoneyRepository(mockk<Firestore>(relaxed = true))
+
     @Test
     fun parseItemsWithTags() {
         val raw: List<Map<String, Any?>> =
@@ -24,7 +30,7 @@ class MoneyParsingTest {
                         ),
                 ),
             )
-        val items = parseItems(raw)
+        val items = repository.parseItems(raw)
         assertEquals(1, items.size)
         val item = items[0]
         assertEquals("item1", item.id)
@@ -49,7 +55,7 @@ class MoneyParsingTest {
                     "payments" to emptyList<Map<String, Any?>>(),
                 ),
             )
-        val items = parseItems(raw)
+        val items = repository.parseItems(raw)
         assertEquals(1, items.size)
         assertEquals(listOf(MoneyTags.RECURRING), items[0].tags)
     }
@@ -66,7 +72,7 @@ class MoneyParsingTest {
                     "payments" to emptyList<Map<String, Any?>>(),
                 ),
             )
-        val items = parseItems(raw)
+        val items = repository.parseItems(raw)
         assertEquals(1, items.size)
         assertEquals(emptyList(), items[0].tags)
     }
@@ -82,7 +88,7 @@ class MoneyParsingTest {
                     "payments" to emptyList<Map<String, Any?>>(),
                 ),
             )
-        val items = parseItems(raw)
+        val items = repository.parseItems(raw)
         assertEquals(1, items.size)
         assertEquals(emptyList(), items[0].tags)
     }
@@ -100,14 +106,14 @@ class MoneyParsingTest {
                     "payments" to emptyList<Map<String, Any?>>(),
                 ),
             )
-        val items = parseItems(raw)
+        val items = repository.parseItems(raw)
         assertEquals(1, items.size)
         assertEquals(listOf(MoneyTags.RECURRING), items[0].tags)
     }
 
     @Test
     fun parseItemsReturnsEmptyForNull() {
-        assertEquals(emptyList(), parseItems(null))
+        assertEquals(emptyList(), repository.parseItems(null))
     }
 
     @Test
@@ -117,7 +123,7 @@ class MoneyParsingTest {
                 mapOf("uid" to "u1", "amount" to 3000L, "paidAt" to "2024-06-01"),
                 mapOf("uid" to "u2", "amount" to 5000L, "paidAt" to "2024-06-02"),
             )
-        val records = parsePaymentRecords(raw)
+        val records = repository.parsePaymentRecords(raw)
         assertEquals(2, records.size)
         assertEquals("u1", records[0].uid)
         assertEquals(3000L, records[0].amount)
@@ -126,61 +132,61 @@ class MoneyParsingTest {
 
     @Test
     fun parsePaymentRecordsReturnsEmptyForNull() {
-        assertEquals(emptyList(), parsePaymentRecords(null))
+        assertEquals(emptyList(), repository.parsePaymentRecords(null))
     }
 
     @Test
     fun parseStatusFromExplicitString() {
         for (status in MonthlyMoneyStatus.entries) {
-            assertEquals(status, parseStatus(status.name, null))
+            assertEquals(status, repository.parseStatus(status.name, null))
         }
     }
 
     @Test
     fun parseStatusFallsBackToLegacyLockedTrue() {
-        assertEquals(MonthlyMoneyStatus.FROZEN, parseStatus(null, true))
+        assertEquals(MonthlyMoneyStatus.FROZEN, repository.parseStatus(null, true))
     }
 
     @Test
     fun parseStatusFallsBackToLegacyLockedFalse() {
-        assertEquals(MonthlyMoneyStatus.PENDING, parseStatus(null, false))
+        assertEquals(MonthlyMoneyStatus.PENDING, repository.parseStatus(null, false))
     }
 
     @Test
     fun parseStatusDefaultsToPendingWhenAbsent() {
-        assertEquals(MonthlyMoneyStatus.PENDING, parseStatus(null, null))
+        assertEquals(MonthlyMoneyStatus.PENDING, repository.parseStatus(null, null))
     }
 
     @Test
     fun parseStatusStringTakesPrecedenceOverLegacyLocked() {
-        assertEquals(MonthlyMoneyStatus.CONFIRMED, parseStatus("CONFIRMED", true))
+        assertEquals(MonthlyMoneyStatus.CONFIRMED, repository.parseStatus("CONFIRMED", true))
     }
 
     @Test
     fun parseStatusFallsBackToFrozenForUnknownStringWhenLegacyLocked() {
-        assertEquals(MonthlyMoneyStatus.FROZEN, parseStatus("UNKNOWN_VALUE", true))
+        assertEquals(MonthlyMoneyStatus.FROZEN, repository.parseStatus("UNKNOWN_VALUE", true))
     }
 
     @Test
     fun parseStatusFallsBackToPendingForUnknownStringWhenLegacyUnlocked() {
-        assertEquals(MonthlyMoneyStatus.PENDING, parseStatus("UNKNOWN_VALUE", false))
+        assertEquals(MonthlyMoneyStatus.PENDING, repository.parseStatus("UNKNOWN_VALUE", false))
     }
 
     @Test
     fun parseStatusFallsBackToPendingForUnknownStringWhenLegacyAbsent() {
-        assertEquals(MonthlyMoneyStatus.PENDING, parseStatus("UNKNOWN_VALUE", null))
+        assertEquals(MonthlyMoneyStatus.PENDING, repository.parseStatus("UNKNOWN_VALUE", null))
     }
 
     @Test
     fun parseStatusTreatsBlankStringAsAbsent() {
-        assertEquals(MonthlyMoneyStatus.PENDING, parseStatus("", null))
-        assertEquals(MonthlyMoneyStatus.PENDING, parseStatus("   ", null))
-        assertEquals(MonthlyMoneyStatus.FROZEN, parseStatus("", true))
+        assertEquals(MonthlyMoneyStatus.PENDING, repository.parseStatus("", null))
+        assertEquals(MonthlyMoneyStatus.PENDING, repository.parseStatus("   ", null))
+        assertEquals(MonthlyMoneyStatus.FROZEN, repository.parseStatus("", true))
     }
 
     @Test
     fun parseStatusTrimsSurroundingWhitespace() {
-        assertEquals(MonthlyMoneyStatus.CONFIRMED, parseStatus(" CONFIRMED ", null))
-        assertEquals(MonthlyMoneyStatus.FROZEN, parseStatus("\tFROZEN\n", null))
+        assertEquals(MonthlyMoneyStatus.CONFIRMED, repository.parseStatus(" CONFIRMED ", null))
+        assertEquals(MonthlyMoneyStatus.FROZEN, repository.parseStatus("\tFROZEN\n", null))
     }
 }


### PR DESCRIPTION
## Summary
- class / object を持つ 8 ファイルの logger を「クラス内フィールド + `::class.java`」方式に統一しました。リファクタ時に IDE が class 名変更を自動追従できるようになります。
- `FirestoreMoneyRepository` は `parseStatus` / `parseItems` / `parsePaymentRecords` の 3 関数すべてを class のインスタンス internal メソッドへ移動し、logger を class フィールドに配置しました。テストはプロジェクト既存の Firestore-bound クラスのテストパターン (`mockk<Firestore>(relaxed = true)`) に揃えました。
- `PasskeyRoutes.kt` はクラスを持たずトップレベル文字列キーのままですが、`Application.kt` / `ServerModule.kt` と命名規則を揃えるため `"PasskeyRoutes"` → `"server.passkey.PasskeyRoutes"` の FQN に変更しました。
- `Application.kt` / `ServerModule.kt` はクラスを持たないユーティリティ関数群のため、issue 本文の指示および memory feedback「ユーティリティ関数群はトップレベル文字列キー可」に従い現状維持としました。

Closes #199

## 変更ファイル

| ファイル | 変換方針 |
|---------|---------|
| `server/auth/FirebaseAdmin.kt` | `object FirebaseAdmin` のフィールドへ |
| `server/feeding/FeedingReminderService.kt` | `class` のフィールドへ |
| `server/garbage/GarbageNotificationService.kt` | `class` のフィールドへ |
| `server/migration/FirestoreMigrations.kt` | `class` のフィールドへ |
| `server/money/FirestoreMoneyRepository.kt` | `class` のフィールドへ。parse 関数 3 つもインスタンスメソッド化 |
| `server/money/MoneyWebhookService.kt` | `class` のフィールドへ |
| `server/passkey/PasskeyService.kt` | `object PasskeyService` のフィールドへ |
| `server/quest/QuestWebhookService.kt` | `class` のフィールドへ |
| `server/passkey/PasskeyRoutes.kt` | トップレベル文字列キーのまま、引数を FQN に統一 |
| `server/test/.../MoneyParsingTest.kt` | `mockk<Firestore>(relaxed = true)` でインスタンス化し `repository.parseXxx(...)` 形式に書き換え |

## 現状維持としたファイル

issue 本文の対象 11 ファイル中、以下 2 ファイルはクラス / object を持たないため現状維持としました。

- `server/Application.kt`: Ktor の `Application.module()` 拡張関数群
- `server/di/ServerModule.kt`: トップレベル `val serverModule = module { ... }` と loader 関数

memory feedback `feedback_logger_class_field.md` でも「ユーティリティ関数群（クラスを持たないファイル）: トップレベル `private val logger = LoggerFactory.getLogger(\"...\")` 可」と整理されており、無理に `object` でラップすると意味のない構造変更になるため触れていません。

## Test plan
- [x] `./gradlew :server:ktlintFormat :server:test :server:compileKotlin -PskipFrontend` 成功
- [x] `MoneyParsingTest` 単独実行で全 17 テスト pass
- [ ] サーバー起動時のログ出力カテゴリが想定通り（class 名で出力される）