### PR TITLE
feat: 入金時の Webhook 通知機能を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ shared/              → Kotlin Multiplatform library
 
 server/              → Ktor server (Netty, JVM)
                        Depends on :shared
-                       Routes: /api/{firebase-config,users,pets,feeding,garbage,money,money-webhook,report,quest,point,quest-webhook,cache,login-history,passkey}
+                       Routes: /api/{firebase-config,users,pets,feeding,garbage,money,money-webhook,payment-webhook,report,quest,point,quest-webhook,cache,login-history,passkey}
                        IP ジオロケーション: server/geo/ (MaxMind GeoLite2-City オフライン DB、ファイル不在時は NoOp)
                        Firebase Auth verification
                        Koin DI でリポジトリ注入（ServerModule）

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ feature/money/       → 支出管理画面（管理者向け）
 feature/payment/     → 支払い画面（ユーザー向け）
 feature/quest/       → クエスト画面
 feature/report/      → 家計レポート画面（月別支出グラフ・内訳）
-feature/settings/    → 設定画面（パスワード変更・パスキー管理・ログイン履歴・ペット設定）
+feature/settings/    → 設定画面（パスワード変更・パスキー管理・ログイン履歴・ペット設定・各種 Webhook 通知設定）
 app/                 → アプリシェル（ルーティング・レイアウト）
 ```
 

--- a/core/network/src/commonMain/kotlin/core/network/PaymentWebhookRepository.kt
+++ b/core/network/src/commonMain/kotlin/core/network/PaymentWebhookRepository.kt
@@ -1,0 +1,29 @@
+package core.network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import model.PaymentWebhookSettings
+
+interface PaymentWebhookRepository {
+    suspend fun getSettings(): PaymentWebhookSettings
+
+    suspend fun updateSettings(settings: PaymentWebhookSettings): PaymentWebhookSettings
+}
+
+class PaymentWebhookRepositoryImpl(
+    private val client: HttpClient,
+) : PaymentWebhookRepository {
+    override suspend fun getSettings(): PaymentWebhookSettings = client.get("/api/settings/payment-webhook").body()
+
+    override suspend fun updateSettings(settings: PaymentWebhookSettings): PaymentWebhookSettings =
+        client
+            .put("/api/settings/payment-webhook") {
+                contentType(ContentType.Application.Json)
+                setBody(settings)
+            }.body()
+}

--- a/core/network/src/wasmJsMain/kotlin/core/network/di/NetworkModule.kt
+++ b/core/network/src/wasmJsMain/kotlin/core/network/di/NetworkModule.kt
@@ -16,6 +16,8 @@ import core.network.MoneyWebhookRepository
 import core.network.MoneyWebhookRepositoryImpl
 import core.network.PasskeyRepository
 import core.network.PasskeyRepositoryImpl
+import core.network.PaymentWebhookRepository
+import core.network.PaymentWebhookRepositoryImpl
 import core.network.PetRepository
 import core.network.PetRepositoryImpl
 import core.network.PointRepository
@@ -50,6 +52,7 @@ val networkModule =
         single<PasskeyRepository> { PasskeyRepositoryImpl(get()) }
         single<QuestWebhookRepository> { QuestWebhookRepositoryImpl(get()) }
         single<MoneyWebhookRepository> { MoneyWebhookRepositoryImpl(get()) }
+        single<PaymentWebhookRepository> { PaymentWebhookRepositoryImpl(get()) }
         single<CacheRepository> { CacheRepositoryImpl(get()) }
         single<LoginHistoryRepository> { LoginHistoryRepositoryImpl(get()) }
     }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/PaymentWebhookViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/PaymentWebhookViewModel.kt
@@ -1,0 +1,86 @@
+package feature.settings
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import core.network.PaymentWebhookRepository
+import kotlinx.coroutines.launch
+import model.PaymentWebhookSettings
+
+data class PaymentWebhookUiState(
+    val url: String = "",
+    val enabled: Boolean = false,
+    val message: String = "",
+    val isLoading: Boolean = true,
+    val loadError: Boolean = false,
+    val loadErrorMessage: String? = null,
+    val isSaving: Boolean = false,
+    val statusMessage: String? = null,
+)
+
+class PaymentWebhookViewModel(
+    private val paymentWebhookRepository: PaymentWebhookRepository,
+) : ViewModel() {
+    var uiState by mutableStateOf(PaymentWebhookUiState())
+        private set
+
+    init {
+        loadSettings()
+    }
+
+    fun loadSettings() {
+        uiState =
+            uiState.copy(
+                isLoading = true,
+                loadError = false,
+                loadErrorMessage = null,
+                statusMessage = null,
+            )
+        viewModelScope.launch {
+            try {
+                val settings = paymentWebhookRepository.getSettings()
+                uiState =
+                    uiState.copy(
+                        url = settings.url,
+                        enabled = settings.enabled,
+                        message = settings.message,
+                        isLoading = false,
+                    )
+            } catch (e: Exception) {
+                uiState = uiState.copy(isLoading = false, loadError = true, loadErrorMessage = e.message)
+            }
+        }
+    }
+
+    fun onUrlChanged(url: String) {
+        uiState = uiState.copy(url = url, statusMessage = null)
+    }
+
+    fun onEnabledChanged(enabled: Boolean) {
+        uiState = uiState.copy(enabled = enabled, statusMessage = null)
+    }
+
+    fun onMessageChanged(message: String) {
+        uiState = uiState.copy(message = message, statusMessage = null)
+    }
+
+    fun onSave() {
+        uiState = uiState.copy(isSaving = true, statusMessage = null)
+        viewModelScope.launch {
+            try {
+                val settings =
+                    PaymentWebhookSettings(
+                        url = uiState.url,
+                        enabled = uiState.enabled,
+                        message = uiState.message,
+                    )
+                paymentWebhookRepository.updateSettings(settings)
+                uiState = uiState.copy(isSaving = false, statusMessage = "保存しました")
+            } catch (e: Exception) {
+                uiState = uiState.copy(isSaving = false, statusMessage = "保存失敗: ${e.message}")
+            }
+        }
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -1464,7 +1464,7 @@ private fun PaymentWebhookSettingsCard(
                 }
 
                 Text(
-                    text = "支払い記録が追加された際に Webhook で通知します（過払い精算は除外）。",
+                    text = "ユーザーが入金を登録した際に Webhook で通知します。",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -95,6 +95,7 @@ fun SettingsScreen(
     val garbageVm = remember(isAdmin) { if (isAdmin) koin.get<GarbageScheduleViewModel>() else null }
     val questWebhookVm = remember(isAdmin) { if (isAdmin) koin.get<QuestWebhookViewModel>() else null }
     val moneyWebhookVm = remember(isAdmin) { if (isAdmin) koin.get<MoneyWebhookViewModel>() else null }
+    val paymentWebhookVm = remember(isAdmin) { if (isAdmin) koin.get<PaymentWebhookViewModel>() else null }
     val cacheVm = remember(isAdmin) { if (isAdmin) koin.get<CacheRefreshViewModel>() else null }
     val petSettingsVm = remember(isAdmin) { if (isAdmin) koin.get<PetSettingsViewModel>() else null }
     val windowSizeClass = LocalWindowSizeClass.current
@@ -182,6 +183,19 @@ fun SettingsScreen(
         onMoneyWebhookMessageChanged = { moneyWebhookVm?.onMessageChanged(it) },
         onSaveMoneyWebhook = { moneyWebhookVm?.onSave() },
         onRetryMoneyWebhook = { moneyWebhookVm?.loadSettings() },
+        paymentWebhookLoading = paymentWebhookVm?.uiState?.isLoading ?: false,
+        paymentWebhookLoadError = paymentWebhookVm?.uiState?.loadError ?: false,
+        paymentWebhookLoadErrorMessage = paymentWebhookVm?.uiState?.loadErrorMessage,
+        paymentWebhookUrl = paymentWebhookVm?.uiState?.url ?: "",
+        paymentWebhookEnabled = paymentWebhookVm?.uiState?.enabled ?: false,
+        paymentWebhookMessage = paymentWebhookVm?.uiState?.message ?: "",
+        paymentWebhookSaving = paymentWebhookVm?.uiState?.isSaving ?: false,
+        paymentWebhookStatusMessage = paymentWebhookVm?.uiState?.statusMessage,
+        onPaymentWebhookUrlChanged = { paymentWebhookVm?.onUrlChanged(it) },
+        onPaymentWebhookEnabledChanged = { paymentWebhookVm?.onEnabledChanged(it) },
+        onPaymentWebhookMessageChanged = { paymentWebhookVm?.onMessageChanged(it) },
+        onSavePaymentWebhook = { paymentWebhookVm?.onSave() },
+        onRetryPaymentWebhook = { paymentWebhookVm?.loadSettings() },
         cacheClearing = cacheVm?.uiState?.isClearing ?: false,
         cacheMessage = cacheVm?.uiState?.message,
         onClearCache = { cacheVm?.onClearCache() },
@@ -296,6 +310,19 @@ internal fun SettingsContent(
     onMoneyWebhookMessageChanged: (String) -> Unit = {},
     onSaveMoneyWebhook: () -> Unit = {},
     onRetryMoneyWebhook: () -> Unit = {},
+    paymentWebhookLoading: Boolean = false,
+    paymentWebhookLoadError: Boolean = false,
+    paymentWebhookLoadErrorMessage: String? = null,
+    paymentWebhookUrl: String = "",
+    paymentWebhookEnabled: Boolean = false,
+    paymentWebhookMessage: String = "",
+    paymentWebhookSaving: Boolean = false,
+    paymentWebhookStatusMessage: String? = null,
+    onPaymentWebhookUrlChanged: (String) -> Unit = {},
+    onPaymentWebhookEnabledChanged: (Boolean) -> Unit = {},
+    onPaymentWebhookMessageChanged: (String) -> Unit = {},
+    onSavePaymentWebhook: () -> Unit = {},
+    onRetryPaymentWebhook: () -> Unit = {},
     cacheClearing: Boolean = false,
     cacheMessage: String? = null,
     onClearCache: () -> Unit = {},
@@ -494,6 +521,22 @@ internal fun SettingsContent(
                     onMessageChanged = onMoneyWebhookMessageChanged,
                     onSave = onSaveMoneyWebhook,
                     onRetry = onRetryMoneyWebhook,
+                    modifier = cardModifier,
+                )
+                PaymentWebhookSettingsCard(
+                    isLoading = paymentWebhookLoading,
+                    loadError = paymentWebhookLoadError,
+                    loadErrorMessage = paymentWebhookLoadErrorMessage,
+                    url = paymentWebhookUrl,
+                    enabled = paymentWebhookEnabled,
+                    message = paymentWebhookMessage,
+                    isSaving = paymentWebhookSaving,
+                    statusMessage = paymentWebhookStatusMessage,
+                    onUrlChanged = onPaymentWebhookUrlChanged,
+                    onEnabledChanged = onPaymentWebhookEnabledChanged,
+                    onMessageChanged = onPaymentWebhookMessageChanged,
+                    onSave = onSavePaymentWebhook,
+                    onRetry = onRetryPaymentWebhook,
                     modifier = cardModifier,
                 )
             }
@@ -1321,6 +1364,107 @@ private fun MoneyWebhookSettingsCard(
 
                 Text(
                     text = "月のお金ステータスを「確定済み」に切り替えた際に Webhook で通知します。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                OutlinedTextField(
+                    value = url,
+                    onValueChange = onUrlChanged,
+                    label = { Text("Webhook URL") },
+                    placeholder = { Text("https://discord.com/api/webhooks/...") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = !isSaving,
+                )
+
+                OutlinedTextField(
+                    value = message,
+                    onValueChange = onMessageChanged,
+                    label = { Text("通知テキスト") },
+                    placeholder = { Text("@everyone") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = !isSaving,
+                )
+
+                if (statusMessage != null) {
+                    Text(
+                        text = statusMessage,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+
+                Button(
+                    onClick = onSave,
+                    modifier = Modifier.height(48.dp),
+                    enabled = !isSaving,
+                ) {
+                    if (isSaving) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                        )
+                    } else {
+                        Text("保存する")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PaymentWebhookSettingsCard(
+    isLoading: Boolean,
+    loadError: Boolean = false,
+    loadErrorMessage: String? = null,
+    url: String,
+    enabled: Boolean,
+    message: String,
+    isSaving: Boolean,
+    statusMessage: String?,
+    onUrlChanged: (String) -> Unit,
+    onEnabledChanged: (Boolean) -> Unit,
+    onMessageChanged: (String) -> Unit,
+    onSave: () -> Unit,
+    onRetry: () -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier,
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            ),
+    ) {
+        LoadableCardContent(
+            isLoading = isLoading,
+            loadError = loadError,
+            loadErrorMessage = loadErrorMessage,
+            onRetry = onRetry,
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp).fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text("入金通知", style = MaterialTheme.typography.titleSmall)
+                    Switch(
+                        checked = enabled,
+                        onCheckedChange = onEnabledChanged,
+                        enabled = !isSaving,
+                    )
+                }
+
+                Text(
+                    text = "支払い記録が追加された際に Webhook で通知します（過払い精算は除外）。",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/feature/settings/src/commonMain/kotlin/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/di/SettingsModule.kt
@@ -6,6 +6,7 @@ import feature.settings.LoginHistoryViewModel
 import feature.settings.MoneyWebhookViewModel
 import feature.settings.PasskeyManagementViewModel
 import feature.settings.PasswordChangeViewModel
+import feature.settings.PaymentWebhookViewModel
 import feature.settings.PetSettingsViewModel
 import feature.settings.QuestWebhookViewModel
 import feature.settings.UserNameViewModel
@@ -22,6 +23,7 @@ val settingsModule =
         factory { GarbageScheduleViewModel(get()) }
         factory { QuestWebhookViewModel(get()) }
         factory { MoneyWebhookViewModel(get()) }
+        factory { PaymentWebhookViewModel(get()) }
         factory { CacheRefreshViewModel(get()) }
         factory { PetSettingsViewModel(get(), get(), get()) }
     }

--- a/feature/settings/src/jvmTest/kotlin/feature/settings/PaymentWebhookViewModelTest.kt
+++ b/feature/settings/src/jvmTest/kotlin/feature/settings/PaymentWebhookViewModelTest.kt
@@ -150,6 +150,31 @@ class PaymentWebhookViewModelTest {
         }
 
     @Test
+    fun `save sends edited values to repository`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            coEvery { paymentWebhookRepository.updateSettings(any()) } returns testSettings
+
+            viewModel.onUrlChanged("https://updated.example.com")
+            viewModel.onEnabledChanged(false)
+            viewModel.onMessageChanged("更新後メッセージ")
+            viewModel.onSave()
+            advanceUntilIdle()
+
+            coVerify {
+                paymentWebhookRepository.updateSettings(
+                    PaymentWebhookSettings(
+                        url = "https://updated.example.com",
+                        enabled = false,
+                        message = "更新後メッセージ",
+                    ),
+                )
+            }
+        }
+
+    @Test
     fun `save failure shows error in status message`() =
         runTest {
             val viewModel = createViewModel()

--- a/feature/settings/src/jvmTest/kotlin/feature/settings/PaymentWebhookViewModelTest.kt
+++ b/feature/settings/src/jvmTest/kotlin/feature/settings/PaymentWebhookViewModelTest.kt
@@ -1,0 +1,166 @@
+package feature.settings
+
+import core.network.PaymentWebhookRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import model.PaymentWebhookSettings
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PaymentWebhookViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var paymentWebhookRepository: PaymentWebhookRepository
+
+    private val testSettings =
+        PaymentWebhookSettings(
+            url = "https://hooks.example.com/payment",
+            enabled = true,
+            message = "@everyone",
+        )
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        paymentWebhookRepository = mockk()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(): PaymentWebhookViewModel {
+        coEvery { paymentWebhookRepository.getSettings() } returns testSettings
+        return PaymentWebhookViewModel(paymentWebhookRepository)
+    }
+
+    @Test
+    fun `init loads settings`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.isLoading)
+            assertEquals("https://hooks.example.com/payment", viewModel.uiState.url)
+            assertTrue(viewModel.uiState.enabled)
+            assertEquals("@everyone", viewModel.uiState.message)
+        }
+
+    @Test
+    fun `init load failure shows error`() =
+        runTest {
+            coEvery { paymentWebhookRepository.getSettings() } throws RuntimeException("load error")
+            val viewModel = PaymentWebhookViewModel(paymentWebhookRepository)
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.isLoading)
+            assertTrue(viewModel.uiState.loadError)
+            assertEquals("load error", viewModel.uiState.loadErrorMessage)
+        }
+
+    @Test
+    fun `loadSettings clears stale error message on retry`() =
+        runTest {
+            coEvery { paymentWebhookRepository.getSettings() } throws RuntimeException("first failure")
+            val viewModel = PaymentWebhookViewModel(paymentWebhookRepository)
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.loadError)
+
+            coEvery { paymentWebhookRepository.getSettings() } returns testSettings
+            viewModel.loadSettings()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.loadError)
+            assertNull(viewModel.uiState.loadErrorMessage)
+            assertEquals("https://hooks.example.com/payment", viewModel.uiState.url)
+        }
+
+    @Test
+    fun `onUrlChanged updates url and clears status message`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.onUrlChanged("https://new.example.com")
+
+            assertEquals("https://new.example.com", viewModel.uiState.url)
+            assertNull(viewModel.uiState.statusMessage)
+        }
+
+    @Test
+    fun `onEnabledChanged updates enabled and clears status message`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.onEnabledChanged(false)
+
+            assertFalse(viewModel.uiState.enabled)
+            assertNull(viewModel.uiState.statusMessage)
+        }
+
+    @Test
+    fun `onMessageChanged updates message and clears status message`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.onMessageChanged("通知本文")
+
+            assertEquals("通知本文", viewModel.uiState.message)
+            assertNull(viewModel.uiState.statusMessage)
+        }
+
+    @Test
+    fun `save success shows status message`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            coEvery { paymentWebhookRepository.updateSettings(any()) } returns testSettings
+
+            viewModel.onSave()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.isSaving)
+            assertEquals("保存しました", viewModel.uiState.statusMessage)
+            coVerify {
+                paymentWebhookRepository.updateSettings(
+                    PaymentWebhookSettings(
+                        url = "https://hooks.example.com/payment",
+                        enabled = true,
+                        message = "@everyone",
+                    ),
+                )
+            }
+        }
+
+    @Test
+    fun `save failure shows error in status message`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            coEvery { paymentWebhookRepository.updateSettings(any()) } throws RuntimeException("save error")
+
+            viewModel.onSave()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.isSaving)
+            assertEquals("保存失敗: save error", viewModel.uiState.statusMessage)
+        }
+}

--- a/server/src/main/kotlin/server/Application.kt
+++ b/server/src/main/kotlin/server/Application.kt
@@ -47,6 +47,7 @@ import server.loginhistory.loginHistoryRoutes
 import server.migration.FirestoreMigrations
 import server.money.moneyRoutes
 import server.money.moneyWebhookRoutes
+import server.money.paymentWebhookRoutes
 import server.passkey.PasskeyDatabase
 import server.passkey.passkeyRoutes
 import server.pet.PetAccessDeniedException
@@ -196,6 +197,7 @@ fun Application.module() {
             garbageRoutes()
             moneyRoutes()
             moneyWebhookRoutes()
+            paymentWebhookRoutes()
             reportRoutes()
             questRoutes()
             pointRoutes()

--- a/server/src/main/kotlin/server/auth/FirebaseAdmin.kt
+++ b/server/src/main/kotlin/server/auth/FirebaseAdmin.kt
@@ -64,4 +64,19 @@ object FirebaseAdmin {
             null
         }
     }
+
+    /** uid から displayName を取得。未設定（null / 空文字）や取得失敗時は null を返す。 */
+    fun getDisplayName(uid: String): String? {
+        if (!initialized) return null
+        return try {
+            FirebaseAuth
+                .getInstance()
+                .getUser(uid)
+                .displayName
+                ?.takeIf { it.isNotBlank() }
+        } catch (e: Exception) {
+            logger.warn("Failed to get displayName for uid={}", uid, e)
+            null
+        }
+    }
 }

--- a/server/src/main/kotlin/server/di/ServerModule.kt
+++ b/server/src/main/kotlin/server/di/ServerModule.kt
@@ -25,6 +25,7 @@ import server.migration.FirestoreMigrations
 import server.money.FirestoreMoneyRepository
 import server.money.MoneyRepository
 import server.money.MoneyWebhookService
+import server.money.PaymentWebhookService
 import server.pet.FirestorePetRepository
 import server.pet.PetRepository
 import server.quest.FirestorePointRepository
@@ -73,6 +74,7 @@ val serverModule =
         single<PetRepository> { FirestorePetRepository(get()) }
         single { QuestWebhookService(get()) }
         single { MoneyWebhookService(get()) }
+        single { PaymentWebhookService(get()) }
         single { QuestService(get(), get(), get()) }
         single { FeedingNotificationService(get(), get(), get()) }
         single { GarbageNotificationService(get()) }

--- a/server/src/main/kotlin/server/money/MoneyRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyRoutes.kt
@@ -1,5 +1,6 @@
 package server.money
 
+import com.google.firebase.auth.FirebaseAuth
 import io.github.smiley4.ktoropenapi.get
 import io.github.smiley4.ktoropenapi.patch
 import io.github.smiley4.ktoropenapi.post
@@ -15,13 +16,25 @@ import model.MonthlyMoneyStatus
 import model.MonthlyMoneyStatusUpdate
 import model.PaymentRecord
 import org.koin.ktor.ext.inject
+import org.slf4j.LoggerFactory
 import server.auth.adminOnly
 import server.auth.authenticated
 import server.auth.firebasePrincipal
 
+private val moneyRoutesLogger = LoggerFactory.getLogger("server.money.MoneyRoutes")
+
+/** uid から Firebase Auth の displayName を解決。失敗時は uid をそのまま返して通知は止めない。 */
+private fun resolvePayerName(uid: String): String =
+    runCatching { FirebaseAuth.getInstance().getUser(uid).displayName }
+        .getOrElse { e ->
+            moneyRoutesLogger.warn("Failed to resolve payer displayName for uid=$uid", e)
+            null
+        }?.takeIf { it.isNotBlank() } ?: uid
+
 fun Route.moneyRoutes() {
     val moneyRepository by inject<MoneyRepository>()
     val moneyWebhookService by inject<MoneyWebhookService>()
+    val paymentWebhookService by inject<PaymentWebhookService>()
 
     route("/money/{yearMonth}") {
         // 管理者: データ取得・全体保存
@@ -190,6 +203,17 @@ fun Route.moneyRoutes() {
                 }
                 val updated = data.copy(paymentRecords = data.paymentRecords + safeRecord)
                 moneyRepository.saveMonthlyMoney(yearMonth, updated)
+
+                // 通常の入金のみ通知。isRedemption=true は過払い金の精算（ユーザーへ戻る方向）なので除外する。
+                if (!safeRecord.isRedemption) {
+                    val payerName = resolvePayerName(uid)
+                    paymentWebhookService.notifyPayment(
+                        yearMonth = yearMonth,
+                        payerName = payerName,
+                        amount = safeRecord.amount,
+                        note = safeRecord.note,
+                    )
+                }
 
                 call.respond(updated.filterForUser(uid))
             }

--- a/server/src/main/kotlin/server/money/MoneyRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyRoutes.kt
@@ -1,6 +1,5 @@
 package server.money
 
-import com.google.firebase.auth.FirebaseAuth
 import io.github.smiley4.ktoropenapi.get
 import io.github.smiley4.ktoropenapi.patch
 import io.github.smiley4.ktoropenapi.post
@@ -16,20 +15,10 @@ import model.MonthlyMoneyStatus
 import model.MonthlyMoneyStatusUpdate
 import model.PaymentRecord
 import org.koin.ktor.ext.inject
-import org.slf4j.LoggerFactory
+import server.auth.FirebaseAdmin
 import server.auth.adminOnly
 import server.auth.authenticated
 import server.auth.firebasePrincipal
-
-private val moneyRoutesLogger = LoggerFactory.getLogger("server.money.MoneyRoutes")
-
-/** uid から Firebase Auth の displayName を解決。失敗時は uid をそのまま返して通知は止めない。 */
-private fun resolvePayerName(uid: String): String =
-    runCatching { FirebaseAuth.getInstance().getUser(uid).displayName }
-        .getOrElse { e ->
-            moneyRoutesLogger.warn("Failed to resolve payer displayName for uid=$uid", e)
-            null
-        }?.takeIf { it.isNotBlank() } ?: uid
 
 fun Route.moneyRoutes() {
     val moneyRepository by inject<MoneyRepository>()
@@ -206,7 +195,7 @@ fun Route.moneyRoutes() {
 
                 // 通常の入金のみ通知。isRedemption=true は過払い金の精算（ユーザーへ戻る方向）なので除外する。
                 if (!safeRecord.isRedemption) {
-                    val payerName = resolvePayerName(uid)
+                    val payerName = FirebaseAdmin.getDisplayName(uid) ?: uid
                     paymentWebhookService.notifyPayment(
                         yearMonth = yearMonth,
                         payerName = payerName,

--- a/server/src/main/kotlin/server/money/MoneyRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyRoutes.kt
@@ -211,7 +211,6 @@ fun Route.moneyRoutes() {
                         yearMonth = yearMonth,
                         payerName = payerName,
                         amount = safeRecord.amount,
-                        note = safeRecord.note,
                     )
                 }
 

--- a/server/src/main/kotlin/server/money/MoneyRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyRoutes.kt
@@ -177,8 +177,12 @@ fun Route.moneyRoutes() {
                 val yearMonth = call.parameters.getOrFail("yearMonth")
                 val uid = call.firebasePrincipal.uid
                 val record = call.receive<PaymentRecord>()
-                // uid をサーバー側で上書き（改ざん防止）
-                val safeRecord = record.copy(uid = uid)
+                // /pay は通常入金の専用エンドポイントで、過払い精算 (isRedemption=true) は
+                // ReportRoutes 経由でのみ永続化される。クライアントが isRedemption=true を
+                // 送ると BalanceCalculationService 上で「過払い引き出し済み」扱いになり残債
+                // 計算が崩れるうえ、入金通知バイパスにも使えるため、サーバー側で false に
+                // 強制上書きする。uid も同様に改ざん防止のため上書き。
+                val safeRecord = record.copy(uid = uid, isRedemption = false)
 
                 val data = moneyRepository.getMonthlyMoney(yearMonth)
                 if (data == null) {
@@ -193,17 +197,14 @@ fun Route.moneyRoutes() {
                 val updated = data.copy(paymentRecords = data.paymentRecords + safeRecord)
                 moneyRepository.saveMonthlyMoney(yearMonth, updated)
 
-                // 通常の入金のみ通知。isRedemption=true は過払い金の精算（ユーザーへ戻る方向）なので除外する。
-                if (!safeRecord.isRedemption) {
-                    // displayName 未設定時に Firebase UID を Webhook 経路で外部チャネル（Discord/Slack）に
-                    // 流すと逆引き材料になりうるため、表示用フォールバックに置き換える。
-                    val payerName = FirebaseAdmin.getDisplayName(uid) ?: "不明なユーザー"
-                    paymentWebhookService.notifyPayment(
-                        yearMonth = yearMonth,
-                        payerName = payerName,
-                        amount = safeRecord.amount,
-                    )
-                }
+                // displayName 未設定時に Firebase UID を Webhook 経路で外部チャネル（Discord/Slack）に
+                // 流すと逆引き材料になりうるため、表示用フォールバックに置き換える。
+                val payerName = FirebaseAdmin.getDisplayName(uid) ?: "不明なユーザー"
+                paymentWebhookService.notifyPayment(
+                    yearMonth = yearMonth,
+                    payerName = payerName,
+                    amount = safeRecord.amount,
+                )
 
                 call.respond(updated.filterForUser(uid))
             }

--- a/server/src/main/kotlin/server/money/MoneyRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyRoutes.kt
@@ -195,7 +195,9 @@ fun Route.moneyRoutes() {
 
                 // 通常の入金のみ通知。isRedemption=true は過払い金の精算（ユーザーへ戻る方向）なので除外する。
                 if (!safeRecord.isRedemption) {
-                    val payerName = FirebaseAdmin.getDisplayName(uid) ?: uid
+                    // displayName 未設定時に Firebase UID を Webhook 経路で外部チャネル（Discord/Slack）に
+                    // 流すと逆引き材料になりうるため、表示用フォールバックに置き換える。
+                    val payerName = FirebaseAdmin.getDisplayName(uid) ?: "不明なユーザー"
                     paymentWebhookService.notifyPayment(
                         yearMonth = yearMonth,
                         payerName = payerName,

--- a/server/src/main/kotlin/server/money/MoneyRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyRoutes.kt
@@ -177,6 +177,13 @@ fun Route.moneyRoutes() {
                 val yearMonth = call.parameters.getOrFail("yearMonth")
                 val uid = call.firebasePrincipal.uid
                 val record = call.receive<PaymentRecord>()
+                // 0 円・負額の入金は残債計算 (BalanceCalculationService) を歪めるうえ、
+                // 0 円連投で Webhook 通知洪水を引き起こせるため、サーバー側で弾く。
+                // /report/balances/redeem (ReportRoutes) と対称な制約。
+                if (record.amount <= 0L) {
+                    call.respond(HttpStatusCode.BadRequest, mapOf("error" to "amount must be positive"))
+                    return@post
+                }
                 // /pay は通常入金の専用エンドポイントで、過払い精算 (isRedemption=true) は
                 // ReportRoutes 経由でのみ永続化される。クライアントが isRedemption=true を
                 // 送ると BalanceCalculationService 上で「過払い引き出し済み」扱いになり残債

--- a/server/src/main/kotlin/server/money/PaymentWebhookRoutes.kt
+++ b/server/src/main/kotlin/server/money/PaymentWebhookRoutes.kt
@@ -1,0 +1,49 @@
+package server.money
+
+import io.github.smiley4.ktoropenapi.get
+import io.github.smiley4.ktoropenapi.put
+import io.ktor.http.*
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.route
+import model.PaymentWebhookSettings
+import org.koin.ktor.ext.inject
+import server.auth.adminOnly
+
+fun Route.paymentWebhookRoutes() {
+    val paymentWebhookService by inject<PaymentWebhookService>()
+
+    route("/settings/payment-webhook") {
+        adminOnly {
+            get({
+                tags = listOf("payment-webhook")
+                summary = "入金 Webhook 設定取得（admin）"
+                response {
+                    code(HttpStatusCode.OK) {
+                        body<PaymentWebhookSettings>()
+                    }
+                }
+            }) {
+                call.respond(paymentWebhookService.getSettings())
+            }
+
+            put({
+                tags = listOf("payment-webhook")
+                summary = "入金 Webhook 設定更新（admin）"
+                request {
+                    body<PaymentWebhookSettings>()
+                }
+                response {
+                    code(HttpStatusCode.OK) {
+                        body<PaymentWebhookSettings>()
+                    }
+                }
+            }) {
+                val settings = call.receive<PaymentWebhookSettings>()
+                paymentWebhookService.updateSettings(settings)
+                call.respond(paymentWebhookService.getSettings())
+            }
+        }
+    }
+}

--- a/server/src/main/kotlin/server/money/PaymentWebhookService.kt
+++ b/server/src/main/kotlin/server/money/PaymentWebhookService.kt
@@ -163,7 +163,7 @@ class PaymentWebhookService(
             return "%d年%02d月".format(year, month)
         }
 
-        /** 金額を 3 桁区切り + 円付きで整形（例: 12345 → "12,345 円"）。負値は支払い取消等の意味合いで先頭に符号付き。 */
+        /** 金額を 3 桁区切り + "円" 付きで整形（例: 12345 → "12,345 円"）。 */
         internal fun formatAmount(amount: Long): String = "%,d 円".format(amount)
     }
 }

--- a/server/src/main/kotlin/server/money/PaymentWebhookService.kt
+++ b/server/src/main/kotlin/server/money/PaymentWebhookService.kt
@@ -1,0 +1,222 @@
+package server.money
+
+import com.google.cloud.firestore.Firestore
+import com.google.cloud.firestore.SetOptions
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.content.TextContent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import model.PaymentWebhookSettings
+import org.slf4j.LoggerFactory
+import server.config.EnvConfig
+import server.util.DISCORD_EMBED_COLOR
+import server.util.WebhookServiceType
+import server.util.await
+import server.util.detectWebhookService
+
+class PaymentWebhookService(
+    private val firestore: Firestore,
+    private val client: HttpClient =
+        HttpClient {
+            install(HttpTimeout) {
+                requestTimeoutMillis = 10_000
+            }
+        },
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    private val logger = LoggerFactory.getLogger(PaymentWebhookService::class.java)
+    private val paymentSettingsDoc get() = firestore.collection("settings").document("payment")
+    private val scope = CoroutineScope(dispatcher)
+
+    private val json = Json
+
+    @Suppress("UNCHECKED_CAST")
+    suspend fun getSettings(): PaymentWebhookSettings {
+        val doc = paymentSettingsDoc.get().await()
+        if (!doc.exists()) return PaymentWebhookSettings()
+        val webhook = (doc.data?.get("webhook") as? Map<String, Any?>) ?: return PaymentWebhookSettings()
+        return PaymentWebhookSettings(
+            url = webhook["url"] as? String ?: "",
+            enabled = webhook["enabled"] as? Boolean ?: false,
+            message = webhook["message"] as? String ?: "",
+        )
+    }
+
+    suspend fun updateSettings(settings: PaymentWebhookSettings) {
+        paymentSettingsDoc
+            .set(
+                mapOf(
+                    "webhook" to
+                        mapOf(
+                            "url" to settings.url,
+                            "enabled" to settings.enabled,
+                            "message" to settings.message,
+                        ),
+                ),
+                SetOptions.merge(),
+            ).await()
+    }
+
+    /** 入金通知を fire-and-forget で送信 */
+    fun notifyPayment(
+        yearMonth: String,
+        payerName: String,
+        amount: Long,
+        note: String,
+    ) {
+        scope.launch {
+            try {
+                val settings = getSettings()
+                if (!settings.enabled || settings.url.isBlank()) return@launch
+
+                val payload =
+                    buildPayload(
+                        url = settings.url,
+                        message = settings.message,
+                        yearMonth = yearMonth,
+                        payerName = payerName,
+                        amount = amount,
+                        note = note,
+                    )
+
+                client.post(settings.url) {
+                    setBody(TextContent(payload, ContentType.Application.Json))
+                }
+            } catch (e: Exception) {
+                logger.warn("Payment webhook delivery failed for yearMonth=$yearMonth payer=$payerName", e)
+            }
+        }
+    }
+
+    internal fun buildPayload(
+        url: String,
+        message: String,
+        yearMonth: String,
+        payerName: String,
+        amount: Long,
+        note: String,
+        dashboardUrl: String? = appUrl,
+    ): String {
+        val formattedYearMonth = formatYearMonth(yearMonth)
+        val formattedAmount = formatAmount(amount)
+        val description = "$formattedYearMonth に $payerName が $formattedAmount を支払いました"
+        return when (detectWebhookService(url)) {
+            WebhookServiceType.DISCORD -> {
+                val fields =
+                    buildList {
+                        add(DiscordPaymentField(name = "支払者", value = payerName, inline = true))
+                        add(DiscordPaymentField(name = "金額", value = formattedAmount, inline = true))
+                        add(DiscordPaymentField(name = "対象月", value = formattedYearMonth, inline = true))
+                        if (note.isNotBlank()) {
+                            add(DiscordPaymentField(name = "メモ", value = note, inline = false))
+                        }
+                    }
+                json.encodeToString(
+                    DiscordPaymentPayload(
+                        content = message.ifBlank { null },
+                        embeds =
+                            listOf(
+                                DiscordPaymentEmbed(
+                                    title = "入金あり",
+                                    description = description,
+                                    color = DISCORD_EMBED_COLOR,
+                                    url = dashboardUrl,
+                                    fields = fields,
+                                ),
+                            ),
+                    ),
+                )
+            }
+            WebhookServiceType.SLACK -> {
+                val noteSuffix = if (note.isNotBlank()) "\nメモ: $note" else ""
+                val base = if (message.isBlank()) description else "$message\n$description"
+                val withNote = "$base$noteSuffix"
+                val withLink =
+                    if (dashboardUrl != null) "$withNote\n<$dashboardUrl|ダッシュボードを開く>" else withNote
+                json.encodeToString(SlackPaymentPayload(text = withLink))
+            }
+            WebhookServiceType.GENERIC -> {
+                json.encodeToString(
+                    GenericPaymentPayload(
+                        event = "payment_recorded",
+                        yearMonth = yearMonth,
+                        payerName = payerName,
+                        amount = amount,
+                        note = note.ifBlank { null },
+                        message = message,
+                        dashboardUrl = dashboardUrl,
+                    ),
+                )
+            }
+        }
+    }
+
+    companion object {
+        private val appUrl: String? = EnvConfig["APP_URL"]
+
+        /** "YYYY-MM" を "YYYY年MM月" 表記（月は 0 埋め 2 桁）に整形。パース失敗時は入力をそのまま返す。 */
+        internal fun formatYearMonth(yearMonth: String): String {
+            val parts = yearMonth.split("-")
+            if (parts.size != 2) return yearMonth
+            val year = parts[0].toIntOrNull() ?: return yearMonth
+            val month = parts[1].toIntOrNull() ?: return yearMonth
+            return "%d年%02d月".format(year, month)
+        }
+
+        /** 金額を 3 桁区切り + 円付きで整形（例: 12345 → "12,345 円"）。負値は支払い取消等の意味合いで先頭に符号付き。 */
+        internal fun formatAmount(amount: Long): String = "%,d 円".format(amount)
+    }
+}
+
+// --- Discord ペイロード ---
+
+@Serializable
+internal data class DiscordPaymentPayload(
+    val content: String? = null,
+    val embeds: List<DiscordPaymentEmbed>,
+)
+
+@Serializable
+internal data class DiscordPaymentEmbed(
+    val title: String,
+    val description: String,
+    val color: Int,
+    val url: String? = null,
+    val fields: List<DiscordPaymentField> = emptyList(),
+)
+
+@Serializable
+internal data class DiscordPaymentField(
+    val name: String,
+    val value: String,
+    val inline: Boolean = false,
+)
+
+// --- Slack ペイロード ---
+
+@Serializable
+internal data class SlackPaymentPayload(
+    val text: String,
+)
+
+// --- 汎用ペイロード ---
+
+@Serializable
+internal data class GenericPaymentPayload(
+    val event: String,
+    val yearMonth: String,
+    val payerName: String,
+    val amount: Long,
+    val note: String? = null,
+    val message: String,
+    val dashboardUrl: String? = null,
+)

--- a/server/src/main/kotlin/server/money/PaymentWebhookService.kt
+++ b/server/src/main/kotlin/server/money/PaymentWebhookService.kt
@@ -71,7 +71,6 @@ class PaymentWebhookService(
         yearMonth: String,
         payerName: String,
         amount: Long,
-        note: String,
     ) {
         scope.launch {
             try {
@@ -85,7 +84,6 @@ class PaymentWebhookService(
                         yearMonth = yearMonth,
                         payerName = payerName,
                         amount = amount,
-                        note = note,
                     )
 
                 client.post(settings.url) {
@@ -103,7 +101,6 @@ class PaymentWebhookService(
         yearMonth: String,
         payerName: String,
         amount: Long,
-        note: String,
         dashboardUrl: String? = appUrl,
     ): String {
         val formattedYearMonth = formatYearMonth(yearMonth)
@@ -112,14 +109,11 @@ class PaymentWebhookService(
         return when (detectWebhookService(url)) {
             WebhookServiceType.DISCORD -> {
                 val fields =
-                    buildList {
-                        add(DiscordPaymentField(name = "支払者", value = payerName, inline = true))
-                        add(DiscordPaymentField(name = "金額", value = formattedAmount, inline = true))
-                        add(DiscordPaymentField(name = "対象月", value = formattedYearMonth, inline = true))
-                        if (note.isNotBlank()) {
-                            add(DiscordPaymentField(name = "メモ", value = note, inline = false))
-                        }
-                    }
+                    listOf(
+                        DiscordPaymentField(name = "支払者", value = payerName, inline = true),
+                        DiscordPaymentField(name = "金額", value = formattedAmount, inline = true),
+                        DiscordPaymentField(name = "対象月", value = formattedYearMonth, inline = true),
+                    )
                 json.encodeToString(
                     DiscordPaymentPayload(
                         content = message.ifBlank { null },
@@ -137,11 +131,9 @@ class PaymentWebhookService(
                 )
             }
             WebhookServiceType.SLACK -> {
-                val noteSuffix = if (note.isNotBlank()) "\nメモ: $note" else ""
                 val base = if (message.isBlank()) description else "$message\n$description"
-                val withNote = "$base$noteSuffix"
                 val withLink =
-                    if (dashboardUrl != null) "$withNote\n<$dashboardUrl|ダッシュボードを開く>" else withNote
+                    if (dashboardUrl != null) "$base\n<$dashboardUrl|ダッシュボードを開く>" else base
                 json.encodeToString(SlackPaymentPayload(text = withLink))
             }
             WebhookServiceType.GENERIC -> {
@@ -151,7 +143,6 @@ class PaymentWebhookService(
                         yearMonth = yearMonth,
                         payerName = payerName,
                         amount = amount,
-                        note = note.ifBlank { null },
                         message = message,
                         dashboardUrl = dashboardUrl,
                     ),
@@ -216,7 +207,6 @@ internal data class GenericPaymentPayload(
     val yearMonth: String,
     val payerName: String,
     val amount: Long,
-    val note: String? = null,
     val message: String,
     val dashboardUrl: String? = null,
 )

--- a/server/src/main/kotlin/server/report/ReportRoutes.kt
+++ b/server/src/main/kotlin/server/report/ReportRoutes.kt
@@ -1,6 +1,5 @@
 package server.report
 
-import com.google.firebase.auth.FirebaseAuth
 import io.github.smiley4.ktoropenapi.get
 import io.github.smiley4.ktoropenapi.post
 import io.ktor.http.HttpStatusCode
@@ -18,6 +17,7 @@ import model.OverpaymentRedemptionRequest
 import model.PaymentRecord
 import model.UserBalance
 import org.koin.ktor.ext.inject
+import server.auth.FirebaseAdmin
 import server.auth.adminOnly
 import server.auth.authenticated
 import server.money.MoneyRepository
@@ -90,12 +90,7 @@ fun Route.reportRoutes() {
             val balances =
                 result.overpayments.mapNotNull { overpayment ->
                     if (overpayment.net <= 0L) return@mapNotNull null
-                    val displayName =
-                        try {
-                            FirebaseAuth.getInstance().getUser(overpayment.uid).displayName ?: overpayment.uid
-                        } catch (_: Exception) {
-                            overpayment.uid
-                        }
+                    val displayName = FirebaseAdmin.getDisplayName(overpayment.uid) ?: overpayment.uid
                     UserBalance(overpayment.uid, displayName, 0L, 0L, overpayment.net)
                 }
 

--- a/server/src/test/kotlin/server/money/PaymentWebhookPayloadTest.kt
+++ b/server/src/test/kotlin/server/money/PaymentWebhookPayloadTest.kt
@@ -31,7 +31,6 @@ class PaymentWebhookPayloadTest {
                     yearMonth = "2026-04",
                     payerName = "山田太郎",
                     amount = 12345L,
-                    note = "クレジット引き落とし",
                     dashboardUrl = "https://example.com/",
                 ),
             )
@@ -49,7 +48,7 @@ class PaymentWebhookPayloadTest {
     }
 
     @Test
-    fun discordPayloadFieldsIncludePayerAmountYearMonthAndNote() {
+    fun discordPayloadFieldsIncludePayerAmountAndYearMonth() {
         val json =
             parseJson(
                 service.buildPayload(
@@ -58,35 +57,12 @@ class PaymentWebhookPayloadTest {
                     yearMonth = "2026-04",
                     payerName = "Alice",
                     amount = 5000L,
-                    note = "現金手渡し",
                 ),
             )
 
         val fields = json["embeds"]!!.jsonArray[0].jsonObject["fields"]!!.jsonArray
         val names = fields.map { it.jsonObject["name"]!!.jsonPrimitive.content }
-        assertTrue("支払者" in names)
-        assertTrue("金額" in names)
-        assertTrue("対象月" in names)
-        assertTrue("メモ" in names)
-    }
-
-    @Test
-    fun discordPayloadOmitsNoteFieldWhenBlank() {
-        val json =
-            parseJson(
-                service.buildPayload(
-                    url = "https://discord.com/api/webhooks/12345/token",
-                    message = "",
-                    yearMonth = "2026-04",
-                    payerName = "Alice",
-                    amount = 5000L,
-                    note = "",
-                ),
-            )
-
-        val fields = json["embeds"]!!.jsonArray[0].jsonObject["fields"]!!.jsonArray
-        val names = fields.map { it.jsonObject["name"]!!.jsonPrimitive.content }
-        assertTrue("メモ" !in names, "Empty note should not produce a メモ field")
+        assertEquals(listOf("支払者", "金額", "対象月"), names)
     }
 
     @Test
@@ -99,7 +75,6 @@ class PaymentWebhookPayloadTest {
                     yearMonth = "2026-04",
                     payerName = "Alice",
                     amount = 5000L,
-                    note = "",
                     dashboardUrl = null,
                 ),
             )
@@ -116,7 +91,6 @@ class PaymentWebhookPayloadTest {
                     yearMonth = "2026-04",
                     payerName = "Alice",
                     amount = 5000L,
-                    note = "",
                     dashboardUrl = null,
                 ),
             )
@@ -135,7 +109,6 @@ class PaymentWebhookPayloadTest {
                     yearMonth = "2026-04",
                     payerName = "Alice",
                     amount = 5000L,
-                    note = "現金",
                     dashboardUrl = "https://example.com/",
                 ),
             )
@@ -145,7 +118,6 @@ class PaymentWebhookPayloadTest {
         assertTrue(text.contains("Alice"), text)
         assertTrue(text.contains("5,000"), text)
         assertTrue(text.contains("2026年04月"), text)
-        assertTrue(text.contains("メモ: 現金"), text)
         assertTrue(text.contains("<https://example.com/|ダッシュボードを開く>"), text)
     }
 
@@ -159,7 +131,6 @@ class PaymentWebhookPayloadTest {
                     yearMonth = "2026-04",
                     payerName = "Alice",
                     amount = 5000L,
-                    note = "",
                     dashboardUrl = null,
                 ),
             )
@@ -179,7 +150,6 @@ class PaymentWebhookPayloadTest {
                     yearMonth = "2026-04",
                     payerName = "Alice",
                     amount = 5000L,
-                    note = "現金",
                     dashboardUrl = "https://example.com/",
                 ),
             )
@@ -188,13 +158,12 @@ class PaymentWebhookPayloadTest {
         assertEquals("2026-04", json["yearMonth"]!!.jsonPrimitive.content)
         assertEquals("Alice", json["payerName"]!!.jsonPrimitive.content)
         assertEquals(5000L, json["amount"]!!.jsonPrimitive.content.toLong())
-        assertEquals("現金", json["note"]!!.jsonPrimitive.content)
         assertEquals("入金通知", json["message"]!!.jsonPrimitive.content)
         assertEquals("https://example.com/", json["dashboardUrl"]!!.jsonPrimitive.content)
     }
 
     @Test
-    fun genericPayloadOmitsNoteWhenBlank() {
+    fun genericPayloadOmitsDashboardUrlWhenNull() {
         val json =
             parseJson(
                 service.buildPayload(
@@ -203,11 +172,9 @@ class PaymentWebhookPayloadTest {
                     yearMonth = "2026-04",
                     payerName = "Alice",
                     amount = 5000L,
-                    note = "",
                     dashboardUrl = null,
                 ),
             )
-        assertNull(json["note"])
         assertNull(json["dashboardUrl"])
     }
 
@@ -223,7 +190,6 @@ class PaymentWebhookPayloadTest {
                     yearMonth = "2026-04",
                     payerName = "Alice",
                     amount = 5000L,
-                    note = "",
                     dashboardUrl = null,
                 ),
             )

--- a/server/src/test/kotlin/server/money/PaymentWebhookPayloadTest.kt
+++ b/server/src/test/kotlin/server/money/PaymentWebhookPayloadTest.kt
@@ -1,0 +1,232 @@
+package server.money
+
+import com.google.cloud.firestore.Firestore
+import io.mockk.mockk
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PaymentWebhookPayloadTest {
+    private val service = PaymentWebhookService(firestore = mockk<Firestore>())
+
+    private fun parseJson(jsonString: String): JsonObject = Json.parseToJsonElement(jsonString).jsonObject
+
+    // --- Discord ペイロード ---
+
+    @Test
+    fun discordPayloadStructure() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://discord.com/api/webhooks/12345/token",
+                    message = "@everyone",
+                    yearMonth = "2026-04",
+                    payerName = "山田太郎",
+                    amount = 12345L,
+                    note = "クレジット引き落とし",
+                    dashboardUrl = "https://example.com/",
+                ),
+            )
+
+        val embeds = json["embeds"]
+        assertIs<JsonArray>(embeds)
+        assertEquals(1, embeds.size)
+
+        val embed = embeds[0].jsonObject
+        assertEquals("入金あり", embed["title"]!!.jsonPrimitive.content)
+        val description = embed["description"]!!.jsonPrimitive.content
+        assertTrue(description.contains("2026年04月"), "description should contain '2026年04月': $description")
+        assertTrue(description.contains("山田太郎"), "description should contain payerName: $description")
+        assertTrue(description.contains("12,345"), "description should contain formatted amount: $description")
+    }
+
+    @Test
+    fun discordPayloadFieldsIncludePayerAmountYearMonthAndNote() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://discord.com/api/webhooks/12345/token",
+                    message = "",
+                    yearMonth = "2026-04",
+                    payerName = "Alice",
+                    amount = 5000L,
+                    note = "現金手渡し",
+                ),
+            )
+
+        val fields = json["embeds"]!!.jsonArray[0].jsonObject["fields"]!!.jsonArray
+        val names = fields.map { it.jsonObject["name"]!!.jsonPrimitive.content }
+        assertTrue("支払者" in names)
+        assertTrue("金額" in names)
+        assertTrue("対象月" in names)
+        assertTrue("メモ" in names)
+    }
+
+    @Test
+    fun discordPayloadOmitsNoteFieldWhenBlank() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://discord.com/api/webhooks/12345/token",
+                    message = "",
+                    yearMonth = "2026-04",
+                    payerName = "Alice",
+                    amount = 5000L,
+                    note = "",
+                ),
+            )
+
+        val fields = json["embeds"]!!.jsonArray[0].jsonObject["fields"]!!.jsonArray
+        val names = fields.map { it.jsonObject["name"]!!.jsonPrimitive.content }
+        assertTrue("メモ" !in names, "Empty note should not produce a メモ field")
+    }
+
+    @Test
+    fun discordPayloadIncludesMessageAsContent() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://discord.com/api/webhooks/12345/token",
+                    message = "@everyone",
+                    yearMonth = "2026-04",
+                    payerName = "Alice",
+                    amount = 5000L,
+                    note = "",
+                    dashboardUrl = null,
+                ),
+            )
+        assertEquals("@everyone", json["content"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun discordPayloadOmitsContentWhenMessageBlank() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://discord.com/api/webhooks/12345/token",
+                    message = "",
+                    yearMonth = "2026-04",
+                    payerName = "Alice",
+                    amount = 5000L,
+                    note = "",
+                    dashboardUrl = null,
+                ),
+            )
+        assertNull(json["content"])
+    }
+
+    // --- Slack ペイロード ---
+
+    @Test
+    fun slackPayloadIncludesMessagePayerAmountAndDashboard() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://hooks.slack.com/services/T00/B00/xxx",
+                    message = "入金通知",
+                    yearMonth = "2026-04",
+                    payerName = "Alice",
+                    amount = 5000L,
+                    note = "現金",
+                    dashboardUrl = "https://example.com/",
+                ),
+            )
+
+        val text = json["text"]!!.jsonPrimitive.content
+        assertTrue(text.contains("入金通知"), text)
+        assertTrue(text.contains("Alice"), text)
+        assertTrue(text.contains("5,000"), text)
+        assertTrue(text.contains("2026年04月"), text)
+        assertTrue(text.contains("メモ: 現金"), text)
+        assertTrue(text.contains("<https://example.com/|ダッシュボードを開く>"), text)
+    }
+
+    @Test
+    fun slackPayloadOmitsLinkWhenDashboardUrlNull() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://hooks.slack.com/services/T00/B00/xxx",
+                    message = "",
+                    yearMonth = "2026-04",
+                    payerName = "Alice",
+                    amount = 5000L,
+                    note = "",
+                    dashboardUrl = null,
+                ),
+            )
+        val text = json["text"]!!.jsonPrimitive.content
+        assertTrue(!text.contains("ダッシュボードを開く"), text)
+    }
+
+    // --- 汎用ペイロード ---
+
+    @Test
+    fun genericPayloadFields() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://example.com/webhook",
+                    message = "入金通知",
+                    yearMonth = "2026-04",
+                    payerName = "Alice",
+                    amount = 5000L,
+                    note = "現金",
+                    dashboardUrl = "https://example.com/",
+                ),
+            )
+
+        assertEquals("payment_recorded", json["event"]!!.jsonPrimitive.content)
+        assertEquals("2026-04", json["yearMonth"]!!.jsonPrimitive.content)
+        assertEquals("Alice", json["payerName"]!!.jsonPrimitive.content)
+        assertEquals(5000L, json["amount"]!!.jsonPrimitive.content.toLong())
+        assertEquals("現金", json["note"]!!.jsonPrimitive.content)
+        assertEquals("入金通知", json["message"]!!.jsonPrimitive.content)
+        assertEquals("https://example.com/", json["dashboardUrl"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun genericPayloadOmitsNoteWhenBlank() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://example.com/webhook",
+                    message = "",
+                    yearMonth = "2026-04",
+                    payerName = "Alice",
+                    amount = 5000L,
+                    note = "",
+                    dashboardUrl = null,
+                ),
+            )
+        assertNull(json["note"])
+        assertNull(json["dashboardUrl"])
+    }
+
+    // --- URL によるサービス判別 ---
+
+    @Test
+    fun caseInsensitiveDiscordDetection() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://DISCORD.COM/API/WEBHOOKS/12345/token",
+                    message = "",
+                    yearMonth = "2026-04",
+                    payerName = "Alice",
+                    amount = 5000L,
+                    note = "",
+                    dashboardUrl = null,
+                ),
+            )
+        assertIs<JsonArray>(json["embeds"])
+    }
+}

--- a/shared/src/commonMain/kotlin/model/MoneyModels.kt
+++ b/shared/src/commonMain/kotlin/model/MoneyModels.kt
@@ -63,3 +63,10 @@ data class MoneyWebhookSettings(
     val enabled: Boolean = false,
     val message: String = "",
 )
+
+@Serializable
+data class PaymentWebhookSettings(
+    val url: String = "",
+    val enabled: Boolean = false,
+    val message: String = "",
+)

--- a/shared/src/commonMain/kotlin/model/MoneyModels.kt
+++ b/shared/src/commonMain/kotlin/model/MoneyModels.kt
@@ -64,6 +64,9 @@ data class MoneyWebhookSettings(
     val message: String = "",
 )
 
+// 構造は MoneyWebhookSettings と同型だが、Firestore 保存先 (settings/payment) と通知タイミング
+// （入金時 vs 月次ステータス確定時）が異なるため別型として定義している。共通化は両 webhook の
+// 設定キャッシュ・抽象化リファクタと合わせて検討する。
 @Serializable
 data class PaymentWebhookSettings(
     val url: String = "",


### PR DESCRIPTION
## Summary
- 支払い記録（PaymentRecord）追加時に Webhook で通知する機能を新規追加
- 既存の月次ステータス確定通知（MoneyWebhook）とは独立した別 webhook 設定として実装
- 過払い精算（`isRedemption=true`）は通知対象から除外（お金がユーザーへ戻る方向のため）

## 変更内容

### サーバー
- `shared/MoneyModels.kt`: `PaymentWebhookSettings` モデル追加
- `server/money/PaymentWebhookService.kt`: 新規サービス
  - `getSettings` / `updateSettings`: Firestore `settings/payment` ドキュメントに格納
  - `notifyPayment(yearMonth, payerName, amount)`: fire-and-forget で送信
  - Discord（embed + fields）/ Slack / Generic の3形式ペイロード対応
- `server/money/PaymentWebhookRoutes.kt`: `GET/PUT /api/settings/payment-webhook`（admin）
- `server/money/MoneyRoutes.kt`: `/pay` で `isRedemption=false` のとき通知発火
- `server/auth/FirebaseAdmin.kt`: `getDisplayName(uid): String?` を追加（汎用関数として集約。空文字は null 扱い）
- `server/di/ServerModule.kt` / `Application.kt`: DI 登録・ルート登録

### フロントエンド
- `core/network/PaymentWebhookRepository.kt`: API クライアント
- `feature/settings/PaymentWebhookViewModel.kt`: ViewModel
- `feature/settings/SettingsScreen.kt`: 「お金」カテゴリ内に `MoneyWebhookSettingsCard`（ステータス確定通知）と並べて `PaymentWebhookSettingsCard`（入金通知）を表示

### ドキュメント
- `CLAUDE.md`: ルート一覧に `payment-webhook` を追記
- `README.md`: `feature/settings` の説明に「各種 Webhook 通知設定」を追記（既存 Money / Quest / Garbage / 新規 Payment Webhook を含む既存ドリフト解消も兼ねる）

### テスト
- `PaymentWebhookPayloadTest`: Discord/Slack/Generic 各形式の構造・フィールド検証
- `PaymentWebhookViewModelTest`: ロード/保存/エラー時の UI 状態遷移を検証

## 設計判断メモ
- **note フィールドは通知に含めない**: `PaymentRecord.note` は通常入金 UI (PaymentViewModel) では未入力で常に空文字。OverpaymentViewModel（精算）のみが note を設定するが、これは isRedemption=true で通知対象外。実質常に空文字なので payload から削除した
- **支払者名の解決は `FirebaseAdmin.getDisplayName(uid)` に集約**: MoneyRoutes に閉じる必要がない汎用ロジックなので `FirebaseAdmin` に移し、他の機能からも使えるようにした

## Test plan
- [ ] `./gradlew :shared:jvmTest :server:test :feature:settings:jvmTest -PskipFrontend` が通る
- [ ] 設定画面 → お金カテゴリで「入金通知」カードが表示され、URL/メッセージ/有効化スイッチを保存できる
- [ ] 入金登録（/pay 通常入金）を行うと Webhook が発火する
- [ ] 過払い精算（isRedemption=true）では Webhook が発火しない
- [ ] Discord webhook URL で embed 形式が届く（支払者・金額・対象月のフィールド付き）
- [ ] Slack webhook URL で text 形式が届く（ダッシュボードリンク付き）

🤖 Generated with [Claude Code](https://claude.com/claude-code)