### PR TITLE
fix: Webhook の displayName 経由メンションインジェクション対策

### DIFF
--- a/server/src/main/kotlin/server/feeding/FeedingNotificationService.kt
+++ b/server/src/main/kotlin/server/feeding/FeedingNotificationService.kt
@@ -17,6 +17,8 @@ import server.pet.PetRepository
 import server.util.DISCORD_EMBED_COLOR
 import server.util.WebhookServiceType
 import server.util.detectWebhookService
+import server.util.sanitizeForDiscord
+import server.util.sanitizeForSlack
 import java.time.Instant
 import java.time.LocalTime
 import java.time.ZoneId
@@ -174,17 +176,18 @@ class FeedingNotificationService(
                 FeedingNotificationPhase.SCHEDULED -> "給餌時間"
                 FeedingNotificationPhase.REMINDER -> "給餌リマインダー"
             }
-        val message =
-            when (phase) {
-                FeedingNotificationPhase.SCHEDULED ->
-                    "${petName}の${mealLabel}ごはんの時間です（予定: $scheduledTime）"
-                FeedingNotificationPhase.REMINDER ->
-                    "${petName}の${mealLabel}ごはん（予定: $scheduledTime）がまだ記録されていません"
-            }
         val event =
             when (phase) {
                 FeedingNotificationPhase.SCHEDULED -> "feeding_scheduled"
                 FeedingNotificationPhase.REMINDER -> "feeding_reminder"
+            }
+
+        fun message(safePetName: String): String =
+            when (phase) {
+                FeedingNotificationPhase.SCHEDULED ->
+                    "${safePetName}の${mealLabel}ごはんの時間です（予定: $scheduledTime）"
+                FeedingNotificationPhase.REMINDER ->
+                    "${safePetName}の${mealLabel}ごはん（予定: $scheduledTime）がまだ記録されていません"
             }
         return when (detectWebhookService(url)) {
             WebhookServiceType.DISCORD -> {
@@ -195,7 +198,7 @@ class FeedingNotificationService(
                             listOf(
                                 DiscordNotificationEmbed(
                                     title = title,
-                                    description = message,
+                                    description = message(sanitizeForDiscord(petName)),
                                     color = DISCORD_EMBED_COLOR,
                                     url = feedingPageUrl,
                                 ),
@@ -204,7 +207,9 @@ class FeedingNotificationService(
                 json.encodeToString(discord)
             }
             WebhookServiceType.SLACK -> {
-                val text = if (prefix.isBlank()) message else "$prefix $message"
+                val text =
+                    message(sanitizeForSlack(petName))
+                        .let { if (prefix.isBlank()) it else "$prefix $it" }
                 val withLink =
                     if (feedingPageUrl != null) "$text\n<$feedingPageUrl|ごはんページを開く>" else text
                 json.encodeToString(SlackNotificationPayload(text = withLink))
@@ -218,7 +223,7 @@ class FeedingNotificationService(
                         petName = petName,
                         mealTime = mealLabel,
                         scheduledTime = scheduledTime,
-                        message = message,
+                        message = message(petName),
                         feedingPageUrl = feedingPageUrl,
                     ),
                 )

--- a/server/src/main/kotlin/server/money/PaymentWebhookService.kt
+++ b/server/src/main/kotlin/server/money/PaymentWebhookService.kt
@@ -22,6 +22,8 @@ import server.util.DISCORD_EMBED_COLOR
 import server.util.WebhookServiceType
 import server.util.await
 import server.util.detectWebhookService
+import server.util.sanitizeForDiscord
+import server.util.sanitizeForSlack
 
 class PaymentWebhookService(
     private val firestore: Firestore,
@@ -105,12 +107,13 @@ class PaymentWebhookService(
     ): String {
         val formattedYearMonth = formatYearMonth(yearMonth)
         val formattedAmount = formatAmount(amount)
-        val description = "$formattedYearMonth に $payerName が $formattedAmount を支払いました"
         return when (detectWebhookService(url)) {
             WebhookServiceType.DISCORD -> {
+                val safePayerName = sanitizeForDiscord(payerName)
+                val description = "$formattedYearMonth に $safePayerName が $formattedAmount を支払いました"
                 val fields =
                     listOf(
-                        DiscordPaymentField(name = "支払者", value = payerName, inline = true),
+                        DiscordPaymentField(name = "支払者", value = safePayerName, inline = true),
                         DiscordPaymentField(name = "金額", value = formattedAmount, inline = true),
                         DiscordPaymentField(name = "対象月", value = formattedYearMonth, inline = true),
                     )
@@ -131,6 +134,8 @@ class PaymentWebhookService(
                 )
             }
             WebhookServiceType.SLACK -> {
+                val safePayerName = sanitizeForSlack(payerName)
+                val description = "$formattedYearMonth に $safePayerName が $formattedAmount を支払いました"
                 val base = if (message.isBlank()) description else "$message\n$description"
                 val withLink =
                     if (dashboardUrl != null) "$base\n<$dashboardUrl|ダッシュボードを開く>" else base

--- a/server/src/main/kotlin/server/quest/QuestWebhookService.kt
+++ b/server/src/main/kotlin/server/quest/QuestWebhookService.kt
@@ -21,6 +21,8 @@ import server.util.DISCORD_EMBED_COLOR
 import server.util.WebhookServiceType
 import server.util.await
 import server.util.detectWebhookService
+import server.util.sanitizeForDiscord
+import server.util.sanitizeForSlack
 import java.time.Instant
 
 class QuestWebhookService(
@@ -107,17 +109,20 @@ class QuestWebhookService(
         quest: Quest,
     ): DiscordPayload {
         val prefix = eventPrefix(event)
+        val safeTitle = sanitizeForDiscord(quest.title)
+        val safeDescription = sanitizeForDiscord(quest.description)
+        val safeCreatorName = sanitizeForDiscord(quest.creatorName)
         return DiscordPayload(
             embeds =
                 listOf(
                     DiscordEmbed(
-                        title = "$prefix: ${quest.title}",
-                        description = quest.description,
+                        title = "$prefix: $safeTitle",
+                        description = safeDescription,
                         color = DISCORD_EMBED_COLOR,
                         fields =
                             listOf(
                                 DiscordField(name = "報酬", value = "${quest.rewardPoints}pt", inline = true),
-                                DiscordField(name = "依頼者", value = quest.creatorName, inline = true),
+                                DiscordField(name = "依頼者", value = safeCreatorName, inline = true),
                             ),
                     ),
                 ),
@@ -129,8 +134,11 @@ class QuestWebhookService(
         quest: Quest,
     ): SlackPayload {
         val prefix = eventPrefix(event)
+        val safeTitle = sanitizeForSlack(quest.title)
+        val safeDescription = sanitizeForSlack(quest.description)
+        val safeCreatorName = sanitizeForSlack(quest.creatorName)
         return SlackPayload(
-            text = "$prefix: ${quest.title}\n${quest.description}\n報酬: ${quest.rewardPoints}pt | 依頼者: ${quest.creatorName}",
+            text = "$prefix: $safeTitle\n$safeDescription\n報酬: ${quest.rewardPoints}pt | 依頼者: $safeCreatorName",
         )
     }
 

--- a/server/src/main/kotlin/server/util/WebhookSanitizer.kt
+++ b/server/src/main/kotlin/server/util/WebhookSanitizer.kt
@@ -10,9 +10,15 @@ package server.util
  * 対象外のため、admin が `<@USER_ID>` 等のユーザー指定メンションを意図的に埋め込む運用は
  * 維持される。サニタイズはあくまで「不特定多数のユーザーが自由に書き換えられる値」が
  * Discord/Slack に渡る経路に限定する。
+ *
+ * **設計判断**: Discord の `allowed_mentions` パラメータや Slack の HTML エンティティ化
+ * (`<` → `&lt;`) も無効化手段として存在するが、いずれも payload 全体に作用するため
+ * admin message 内の `<@USER_ID>` も同時に無効化されてしまう。本プロジェクトは
+ * 「ユーザー入力フィールドのみサニタイズ・admin message は素通し」という要件のため、
+ * フィールド単位で適用できる ZWS 分断方式を採用している。
  */
 
-private const val ZWS = "​"
+internal const val ZWS = "​"
 
 /**
  * Discord 用にユーザー入力をサニタイズする。

--- a/server/src/main/kotlin/server/util/WebhookSanitizer.kt
+++ b/server/src/main/kotlin/server/util/WebhookSanitizer.kt
@@ -1,0 +1,44 @@
+package server.util
+
+/**
+ * Webhook 送信先（Discord / Slack）のメンションインジェクション対策。
+ *
+ * 信頼境界を超えてユーザー入力（displayName, quest.title 等）を Discord embed / Slack text
+ * に埋め込む箇所で、メンション系記法をゼロ幅スペースで分断し無効化する。
+ *
+ * Webhook 設定の admin 配信メッセージ（PaymentWebhookSettings.message 等）はサニタイズ
+ * 対象外のため、admin が `<@USER_ID>` 等のユーザー指定メンションを意図的に埋め込む運用は
+ * 維持される。サニタイズはあくまで「不特定多数のユーザーが自由に書き換えられる値」が
+ * Discord/Slack に渡る経路に限定する。
+ */
+
+private const val ZWS = "​"
+
+/**
+ * Discord 用にユーザー入力をサニタイズする。
+ *
+ * 無効化対象:
+ * - `@everyone`, `@here`（一斉メンション）
+ * - `<@USER_ID>`, `<@!USER_ID>`, `<@&ROLE_ID>`（ユーザー / ロールメンション）
+ * - `<#CHANNEL_ID>`（チャンネルメンション）
+ */
+fun sanitizeForDiscord(text: String): String =
+    text
+        .replace("@everyone", "@${ZWS}everyone")
+        .replace("@here", "@${ZWS}here")
+        .replace("<@", "<$ZWS@")
+        .replace("<#", "<$ZWS#")
+
+/**
+ * Slack 用にユーザー入力をサニタイズする。
+ *
+ * 無効化対象:
+ * - `<!channel>`, `<!here>`, `<!everyone>`, `<!subteam^ID>`（特殊メンション・ユーザーグループ）
+ * - `<@USER_ID>`（ユーザーメンション）
+ * - `<#CHANNEL_ID>`（チャンネルメンション）
+ */
+fun sanitizeForSlack(text: String): String =
+    text
+        .replace("<!", "<$ZWS!")
+        .replace("<@", "<$ZWS@")
+        .replace("<#", "<$ZWS#")

--- a/server/src/main/kotlin/server/util/WebhookSanitizer.kt
+++ b/server/src/main/kotlin/server/util/WebhookSanitizer.kt
@@ -4,24 +4,26 @@ package server.util
  * Webhook 送信先（Discord / Slack）のメンションインジェクション対策。
  *
  * 信頼境界を超えてユーザー入力（displayName, quest.title 等）を Discord embed / Slack text
- * に埋め込む箇所で、メンション系記法をゼロ幅スペースで分断し無効化する。
+ * に埋め込む箇所で、メンション系記法を無効化する。
  *
  * Webhook 設定の admin 配信メッセージ（PaymentWebhookSettings.message 等）はサニタイズ
  * 対象外のため、admin が `<@USER_ID>` 等のユーザー指定メンションを意図的に埋め込む運用は
  * 維持される。サニタイズはあくまで「不特定多数のユーザーが自由に書き換えられる値」が
  * Discord/Slack に渡る経路に限定する。
  *
- * **設計判断**: Discord の `allowed_mentions` パラメータや Slack の HTML エンティティ化
- * (`<` → `&lt;`) も無効化手段として存在するが、いずれも payload 全体に作用するため
- * admin message 内の `<@USER_ID>` も同時に無効化されてしまう。本プロジェクトは
- * 「ユーザー入力フィールドのみサニタイズ・admin message は素通し」という要件のため、
- * フィールド単位で適用できる ZWS 分断方式を採用している。
+ * **方式の選択**:
+ * - **Discord**: 公式 `allowed_mentions` パラメータも存在するが、payload 全体に作用する
+ *   ため admin message の `<@USER_ID>` も同時に無効化されてしまう。フィールド単位で適用
+ *   できる ZWS (U+200B) 分断方式を採用。
+ * - **Slack**: 公式が推奨する HTML エンティティ化方式 (`<` → `&lt;`, `>` → `&gt;`,
+ *   `&` → `&amp;`) を採用。フィールド単位で適用可能で、将来 Slack が新しいメンション
+ *   記法を追加しても自動的に無効化される。
  */
 
 internal const val ZWS = "​"
 
 /**
- * Discord 用にユーザー入力をサニタイズする。
+ * Discord 用にユーザー入力をサニタイズする。ZWS 分断方式。
  *
  * 無効化対象:
  * - `@everyone`, `@here`（一斉メンション）
@@ -30,21 +32,25 @@ internal const val ZWS = "​"
  */
 fun sanitizeForDiscord(text: String): String =
     text
+        // 置換順序依存: 先に `@everyone` / `@here` を分断してから `<@` の汎用置換を行うことで
+        // `<@everyone` のような不正記法も正しく無効化される。順序を入れ替えると挙動が変わるため注意。
         .replace("@everyone", "@${ZWS}everyone")
         .replace("@here", "@${ZWS}here")
         .replace("<@", "<$ZWS@")
         .replace("<#", "<$ZWS#")
 
 /**
- * Slack 用にユーザー入力をサニタイズする。
+ * Slack 用にユーザー入力をサニタイズする。HTML エンティティ化方式。
  *
- * 無効化対象:
- * - `<!channel>`, `<!here>`, `<!everyone>`, `<!subteam^ID>`（特殊メンション・ユーザーグループ）
- * - `<@USER_ID>`（ユーザーメンション）
- * - `<#CHANNEL_ID>`（チャンネルメンション）
+ * Slack のメンション・チャンネル参照・特殊コマンドはすべて `<` で始まる記法のため、
+ * `<` / `>` / `&` を HTML エンティティ化することで、現存・将来の全ての記法を一括無効化する。
+ * `<URL|text>` 形式のリンクや `<mailto:>` も同様に無効化される（ユーザー入力経由で勝手に
+ * リンクが生成されるのを防ぐ副次効果あり）。
+ *
+ * 置換順序: `&` を最初に処理しないと `<` → `&lt;` → `&amp;lt;` と二重エンコードされる。
  */
 fun sanitizeForSlack(text: String): String =
     text
-        .replace("<!", "<$ZWS!")
-        .replace("<@", "<$ZWS@")
-        .replace("<#", "<$ZWS#")
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")

--- a/server/src/test/kotlin/server/feeding/FeedingNotificationServiceTest.kt
+++ b/server/src/test/kotlin/server/feeding/FeedingNotificationServiceTest.kt
@@ -470,4 +470,92 @@ class FeedingNotificationServiceTest {
         // embed.url が null なので、リンク (https://example.com/feeding) は payload に出ない
         assertFalse(payload.contains("example.com"))
     }
+
+    // --- petName 経由のメンションインジェクション対策 ---
+
+    @Test
+    fun discordPetNameWithEveryoneIsSanitized() {
+        val service = createService()
+        val payload =
+            service.buildPayload(
+                url = "https://discord.com/api/webhooks/x/y",
+                prefix = "",
+                phase = FeedingNotificationPhase.REMINDER,
+                petId = "pet1",
+                petName = "@everyone",
+                mealLabel = "朝",
+                scheduledTime = "07:00",
+                feedingPageUrl = null,
+            )
+        assertFalse(payload.contains("@everyone"), "payload should not contain raw @everyone: $payload")
+    }
+
+    @Test
+    fun discordPetNameWithUserMentionIsSanitized() {
+        val service = createService()
+        val payload =
+            service.buildPayload(
+                url = "https://discord.com/api/webhooks/x/y",
+                prefix = "",
+                phase = FeedingNotificationPhase.SCHEDULED,
+                petId = "pet1",
+                petName = "<@123456789>",
+                mealLabel = "朝",
+                scheduledTime = "07:00",
+                feedingPageUrl = null,
+            )
+        assertFalse(payload.contains("<@1"), "payload should not contain raw user mention: $payload")
+    }
+
+    @Test
+    fun discordPrefixIsPreserved() {
+        // prefix は admin 設定のため温存される
+        val service = createService()
+        val payload =
+            service.buildPayload(
+                url = "https://discord.com/api/webhooks/x/y",
+                prefix = "<@123456789>",
+                phase = FeedingNotificationPhase.REMINDER,
+                petId = "pet1",
+                petName = "ポチ",
+                mealLabel = "朝",
+                scheduledTime = "07:00",
+                feedingPageUrl = null,
+            )
+        assertTrue(payload.contains("<@123456789>"), "admin prefix should be preserved: $payload")
+    }
+
+    @Test
+    fun slackPetNameWithChannelIsSanitized() {
+        val service = createService()
+        val payload =
+            service.buildPayload(
+                url = "https://hooks.slack.com/services/x/y/z",
+                prefix = "",
+                phase = FeedingNotificationPhase.REMINDER,
+                petId = "pet1",
+                petName = "<!channel>",
+                mealLabel = "朝",
+                scheduledTime = "07:00",
+                feedingPageUrl = null,
+            )
+        assertFalse(payload.contains("<!channel>"), "payload should not contain raw <!channel>: $payload")
+    }
+
+    @Test
+    fun slackPetNameWithUserMentionIsSanitized() {
+        val service = createService()
+        val payload =
+            service.buildPayload(
+                url = "https://hooks.slack.com/services/x/y/z",
+                prefix = "",
+                phase = FeedingNotificationPhase.SCHEDULED,
+                petId = "pet1",
+                petName = "<@U12345>",
+                mealLabel = "朝",
+                scheduledTime = "07:00",
+                feedingPageUrl = null,
+            )
+        assertFalse(payload.contains("<@U"), "payload should not contain raw user mention: $payload")
+    }
 }

--- a/server/src/test/kotlin/server/feeding/FeedingNotificationServiceTest.kt
+++ b/server/src/test/kotlin/server/feeding/FeedingNotificationServiceTest.kt
@@ -540,6 +540,8 @@ class FeedingNotificationServiceTest {
                 feedingPageUrl = null,
             )
         assertFalse(payload.contains("<!channel>"), "payload should not contain raw <!channel>: $payload")
+        // JSON 文字列内では `<` → `&lt;` のため `<` ではなく `&lt;` がそのまま含まれる
+        assertTrue(payload.contains("&lt;!channel&gt;"), "payload should contain HTML-encoded <!channel>: $payload")
     }
 
     @Test
@@ -557,5 +559,6 @@ class FeedingNotificationServiceTest {
                 feedingPageUrl = null,
             )
         assertFalse(payload.contains("<@U"), "payload should not contain raw user mention: $payload")
+        assertTrue(payload.contains("&lt;@U12345&gt;"), "payload should contain HTML-encoded user mention: $payload")
     }
 }

--- a/server/src/test/kotlin/server/money/PaymentWebhookPayloadTest.kt
+++ b/server/src/test/kotlin/server/money/PaymentWebhookPayloadTest.kt
@@ -257,6 +257,7 @@ class PaymentWebhookPayloadTest {
             )
         val text = json["text"]!!.jsonPrimitive.content
         assertTrue(!text.contains("<!channel>"), "text should not contain raw <!channel>: $text")
+        assertTrue(text.contains("&lt;!channel&gt;"), "text should contain HTML-encoded <!channel>: $text")
     }
 
     @Test
@@ -274,6 +275,7 @@ class PaymentWebhookPayloadTest {
             )
         val text = json["text"]!!.jsonPrimitive.content
         assertTrue(!text.contains("<@U"), "text should not contain raw user mention: $text")
+        assertTrue(text.contains("&lt;@U12345&gt;"), "text should contain HTML-encoded user mention: $text")
     }
 
     // --- URL によるサービス判別 ---

--- a/server/src/test/kotlin/server/money/PaymentWebhookPayloadTest.kt
+++ b/server/src/test/kotlin/server/money/PaymentWebhookPayloadTest.kt
@@ -178,6 +178,104 @@ class PaymentWebhookPayloadTest {
         assertNull(json["dashboardUrl"])
     }
 
+    // --- displayName 経由のメンションインジェクション対策 ---
+
+    @Test
+    fun discordPayerNameWithEveryoneIsSanitized() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://discord.com/api/webhooks/12345/token",
+                    message = "",
+                    yearMonth = "2026-04",
+                    payerName = "@everyone",
+                    amount = 5000L,
+                    dashboardUrl = null,
+                ),
+            )
+        val description =
+            json["embeds"]!!
+                .jsonArray[0]
+                .jsonObject["description"]!!
+                .jsonPrimitive.content
+        assertTrue(!description.contains("@everyone"), "description should not contain raw @everyone: $description")
+    }
+
+    @Test
+    fun discordPayerNameWithUserMentionIsSanitized() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://discord.com/api/webhooks/12345/token",
+                    message = "",
+                    yearMonth = "2026-04",
+                    payerName = "<@123456789>",
+                    amount = 5000L,
+                    dashboardUrl = null,
+                ),
+            )
+        val payerField =
+            json["embeds"]!!
+                .jsonArray[0]
+                .jsonObject["fields"]!!
+                .jsonArray
+                .first { it.jsonObject["name"]!!.jsonPrimitive.content == "支払者" }
+                .jsonObject["value"]!!
+                .jsonPrimitive.content
+        assertTrue(!payerField.contains("<@1"), "支払者 field should not contain raw user mention: $payerField")
+    }
+
+    @Test
+    fun discordAdminMessageMentionIsPreserved() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://discord.com/api/webhooks/12345/token",
+                    message = "<@123456789> 入金確認お願い",
+                    yearMonth = "2026-04",
+                    payerName = "Alice",
+                    amount = 5000L,
+                    dashboardUrl = null,
+                ),
+            )
+        // admin が設定する message は意図的なメンションのため温存される
+        assertEquals("<@123456789> 入金確認お願い", json["content"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun slackPayerNameWithChannelIsSanitized() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://hooks.slack.com/services/T00/B00/xxx",
+                    message = "",
+                    yearMonth = "2026-04",
+                    payerName = "<!channel>",
+                    amount = 5000L,
+                    dashboardUrl = null,
+                ),
+            )
+        val text = json["text"]!!.jsonPrimitive.content
+        assertTrue(!text.contains("<!channel>"), "text should not contain raw <!channel>: $text")
+    }
+
+    @Test
+    fun slackPayerNameWithUserMentionIsSanitized() {
+        val json =
+            parseJson(
+                service.buildPayload(
+                    url = "https://hooks.slack.com/services/T00/B00/xxx",
+                    message = "",
+                    yearMonth = "2026-04",
+                    payerName = "<@U12345>",
+                    amount = 5000L,
+                    dashboardUrl = null,
+                ),
+            )
+        val text = json["text"]!!.jsonPrimitive.content
+        assertTrue(!text.contains("<@U"), "text should not contain raw user mention: $text")
+    }
+
     // --- URL によるサービス判別 ---
 
     @Test

--- a/server/src/test/kotlin/server/quest/QuestWebhookPayloadTest.kt
+++ b/server/src/test/kotlin/server/quest/QuestWebhookPayloadTest.kt
@@ -133,6 +133,52 @@ class QuestWebhookPayloadTest {
         assertEquals(sampleQuest.creatorName, quest["creatorName"]!!.jsonPrimitive.content)
     }
 
+    // --- ユーザー入力経由のメンションインジェクション対策 ---
+
+    @Test
+    fun discordSanitizesQuestTitleAndDescriptionAndCreator() {
+        val maliciousQuest =
+            sampleQuest.copy(
+                title = "@everyone 緊急",
+                description = "<#999999> でやる",
+                creatorName = "<@123456789>",
+            )
+        val json =
+            parseJson(
+                service.buildPayload("https://discord.com/api/webhooks/12345/token", "quest_created", maliciousQuest),
+            )
+        val embed = json["embeds"]!!.jsonArray[0].jsonObject
+        val title = embed["title"]!!.jsonPrimitive.content
+        val description = embed["description"]!!.jsonPrimitive.content
+        val creatorField =
+            embed["fields"]!!
+                .jsonArray
+                .first { it.jsonObject["name"]!!.jsonPrimitive.content == "依頼者" }
+                .jsonObject["value"]!!
+                .jsonPrimitive.content
+        assertTrue(!title.contains("@everyone"), "title should not contain raw @everyone: $title")
+        assertTrue(!description.contains("<#9"), "description should not contain raw channel mention: $description")
+        assertTrue(!creatorField.contains("<@1"), "creatorName should not contain raw user mention: $creatorField")
+    }
+
+    @Test
+    fun slackSanitizesQuestTitleAndDescriptionAndCreator() {
+        val maliciousQuest =
+            sampleQuest.copy(
+                title = "<!channel>",
+                description = "<#C12345|general>",
+                creatorName = "<@U12345>",
+            )
+        val json =
+            parseJson(
+                service.buildPayload("https://hooks.slack.com/services/T00/B00/xxx", "quest_created", maliciousQuest),
+            )
+        val text = json["text"]!!.jsonPrimitive.content
+        assertTrue(!text.contains("<!channel>"), "text should not contain raw <!channel>: $text")
+        assertTrue(!text.contains("<#C"), "text should not contain raw channel mention: $text")
+        assertTrue(!text.contains("<@U"), "text should not contain raw user mention: $text")
+    }
+
     // --- URL によるサービス判別 ---
 
     @Test

--- a/server/src/test/kotlin/server/quest/QuestWebhookPayloadTest.kt
+++ b/server/src/test/kotlin/server/quest/QuestWebhookPayloadTest.kt
@@ -177,6 +177,9 @@ class QuestWebhookPayloadTest {
         assertTrue(!text.contains("<!channel>"), "text should not contain raw <!channel>: $text")
         assertTrue(!text.contains("<#C"), "text should not contain raw channel mention: $text")
         assertTrue(!text.contains("<@U"), "text should not contain raw user mention: $text")
+        assertTrue(text.contains("&lt;!channel&gt;"), "text should contain HTML-encoded <!channel>: $text")
+        assertTrue(text.contains("&lt;#C12345|general&gt;"), "text should contain HTML-encoded channel mention: $text")
+        assertTrue(text.contains("&lt;@U12345&gt;"), "text should contain HTML-encoded user mention: $text")
     }
 
     // --- URL によるサービス判別 ---

--- a/server/src/test/kotlin/server/util/WebhookSanitizerTest.kt
+++ b/server/src/test/kotlin/server/util/WebhookSanitizerTest.kt
@@ -77,58 +77,62 @@ class WebhookSanitizerTest {
         assertFalse(result.contains("<@e"), "result should not contain raw <@e: $result")
     }
 
-    // --- Slack ---
+    // --- Slack (HTML エンティティ化方式) ---
 
     @Test
     fun slackBreaksChannelSpecial() {
         val result = sanitizeForSlack("<!channel>")
         assertFalse(result.contains("<!channel>"), "result should not contain <!channel>: $result")
-        assertTrue(result.contains("<$ZWS!channel>"), "result should contain ZWS-broken <!channel>: $result")
+        assertEquals("&lt;!channel&gt;", result)
     }
 
     @Test
     fun slackBreaksHere() {
-        val result = sanitizeForSlack("<!here>")
-        assertFalse(result.contains("<!here>"))
-    }
-
-    @Test
-    fun slackBreaksEveryone() {
-        val result = sanitizeForSlack("<!everyone>")
-        assertFalse(result.contains("<!everyone>"))
+        assertEquals("&lt;!here&gt;", sanitizeForSlack("<!here>"))
     }
 
     @Test
     fun slackBreaksSubteam() {
         val result = sanitizeForSlack("<!subteam^S12345>")
         assertFalse(result.contains("<!subteam"))
+        assertEquals("&lt;!subteam^S12345&gt;", result)
     }
 
     @Test
     fun slackBreaksChannelMention() {
-        val result = sanitizeForSlack("<#C12345>")
-        assertFalse(result.contains("<#"))
-        assertTrue(result.contains("<$ZWS#"))
+        assertEquals("&lt;#C12345&gt;", sanitizeForSlack("<#C12345>"))
     }
 
     @Test
     fun slackBreaksChannelMentionWithLabel() {
-        val result = sanitizeForSlack("<#C12345|general>")
-        assertFalse(result.contains("<#"))
+        assertEquals("&lt;#C12345|general&gt;", sanitizeForSlack("<#C12345|general>"))
     }
 
     @Test
     fun slackBreaksUserMention() {
-        val result = sanitizeForSlack("<@U12345>")
-        assertFalse(result.contains("<@U"), "result should not contain raw user mention: $result")
-        assertTrue(result.contains("<$ZWS@"), "result should contain ZWS-broken user mention: $result")
+        assertEquals("&lt;@U12345&gt;", sanitizeForSlack("<@U12345>"))
     }
 
     @Test
-    fun slackPreservesLinkSyntax() {
-        // Slack のリンク <URL|text> はメンション記号 (<!, <@, <#) を含まないため温存される
-        val text = "<https://example.com|ダッシュボード>"
-        assertEquals(text, sanitizeForSlack(text))
+    fun slackBreaksLinkSyntax() {
+        // HTML エンティティ化方式では <URL|text> 形式のリンクも無効化される
+        // （ユーザー入力経由で勝手にリンクが生成されないようにする副次効果）
+        val result = sanitizeForSlack("<https://example.com|ダッシュボード>")
+        assertEquals("&lt;https://example.com|ダッシュボード&gt;", result)
+    }
+
+    @Test
+    fun slackEscapesAmpersand() {
+        // & は最初にエスケープしないと <  → &lt; → &amp;lt; と二重エンコードされる
+        assertEquals("AT&amp;T", sanitizeForSlack("AT&T"))
+    }
+
+    @Test
+    fun slackEscapesAmpersandBeforeLessThan() {
+        // & が < より先にエスケープされていることを確認（順序逆だと &amp;lt; になる）
+        val result = sanitizeForSlack("<a&b>")
+        assertEquals("&lt;a&amp;b&gt;", result)
+        assertFalse(result.contains("&amp;lt;"), "must not double-encode <: $result")
     }
 
     @Test

--- a/server/src/test/kotlin/server/util/WebhookSanitizerTest.kt
+++ b/server/src/test/kotlin/server/util/WebhookSanitizerTest.kt
@@ -1,0 +1,128 @@
+package server.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private const val ZWS = "​"
+
+class WebhookSanitizerTest {
+    // --- Discord ---
+
+    @Test
+    fun discordBreaksEveryone() {
+        val result = sanitizeForDiscord("@everyone こんにちは")
+        assertFalse(result.contains("@everyone"), "result should not contain @everyone: $result")
+        assertTrue(result.contains("@${ZWS}everyone"), "result should contain @<ZWS>everyone: $result")
+    }
+
+    @Test
+    fun discordBreaksHere() {
+        val result = sanitizeForDiscord("やあ @here")
+        assertFalse(result.contains("@here"), "result should not contain @here: $result")
+        assertTrue(result.contains("@${ZWS}here"), "result should contain @<ZWS>here: $result")
+    }
+
+    @Test
+    fun discordBreaksRoleMention() {
+        val result = sanitizeForDiscord("<@&123456789>")
+        assertFalse(result.contains("<@&"), "result should not contain raw <@&: $result")
+        assertTrue(result.contains("<$ZWS@&"), "result should contain ZWS-broken role mention: $result")
+    }
+
+    @Test
+    fun discordBreaksChannelMention() {
+        val result = sanitizeForDiscord("<#987654321>")
+        assertFalse(result.contains("<#"), "result should not contain raw <#: $result")
+        assertTrue(result.contains("<$ZWS#"), "result should contain ZWS-broken channel mention: $result")
+    }
+
+    @Test
+    fun discordBreaksUserMention() {
+        val result = sanitizeForDiscord("<@123456789>")
+        assertFalse(result.contains("<@1"), "result should not contain raw user mention: $result")
+        assertTrue(result.contains("<$ZWS@"), "result should contain ZWS-broken user mention: $result")
+    }
+
+    @Test
+    fun discordBreaksUserMentionWithBang() {
+        val result = sanitizeForDiscord("<@!123456789>")
+        assertFalse(result.contains("<@!"), "result should not contain raw nickname mention: $result")
+    }
+
+    @Test
+    fun discordPlainTextIsUnchanged() {
+        val text = "山田太郎 が 12,345 円 を支払いました"
+        assertEquals(text, sanitizeForDiscord(text))
+    }
+
+    @Test
+    fun discordHandlesMultiplePatterns() {
+        val result = sanitizeForDiscord("@everyone <@&111> <#222> <@333>")
+        assertFalse(result.contains("@everyone"))
+        assertFalse(result.contains("<@&111>"))
+        assertFalse(result.contains("<#222>"))
+        assertFalse(result.contains("<@333>"))
+    }
+
+    // --- Slack ---
+
+    @Test
+    fun slackBreaksChannelSpecial() {
+        val result = sanitizeForSlack("<!channel>")
+        assertFalse(result.contains("<!channel>"), "result should not contain <!channel>: $result")
+        assertTrue(result.contains("<$ZWS!channel>"), "result should contain ZWS-broken <!channel>: $result")
+    }
+
+    @Test
+    fun slackBreaksHere() {
+        val result = sanitizeForSlack("<!here>")
+        assertFalse(result.contains("<!here>"))
+    }
+
+    @Test
+    fun slackBreaksEveryone() {
+        val result = sanitizeForSlack("<!everyone>")
+        assertFalse(result.contains("<!everyone>"))
+    }
+
+    @Test
+    fun slackBreaksSubteam() {
+        val result = sanitizeForSlack("<!subteam^S12345>")
+        assertFalse(result.contains("<!subteam"))
+    }
+
+    @Test
+    fun slackBreaksChannelMention() {
+        val result = sanitizeForSlack("<#C12345>")
+        assertFalse(result.contains("<#"))
+        assertTrue(result.contains("<$ZWS#"))
+    }
+
+    @Test
+    fun slackBreaksChannelMentionWithLabel() {
+        val result = sanitizeForSlack("<#C12345|general>")
+        assertFalse(result.contains("<#"))
+    }
+
+    @Test
+    fun slackBreaksUserMention() {
+        val result = sanitizeForSlack("<@U12345>")
+        assertFalse(result.contains("<@U"), "result should not contain raw user mention: $result")
+        assertTrue(result.contains("<$ZWS@"), "result should contain ZWS-broken user mention: $result")
+    }
+
+    @Test
+    fun slackPreservesLinkSyntax() {
+        // Slack のリンク <URL|text> はメンション記号 (<!, <@, <#) を含まないため温存される
+        val text = "<https://example.com|ダッシュボード>"
+        assertEquals(text, sanitizeForSlack(text))
+    }
+
+    @Test
+    fun slackPlainTextIsUnchanged() {
+        val text = "山田太郎"
+        assertEquals(text, sanitizeForSlack(text))
+    }
+}

--- a/server/src/test/kotlin/server/util/WebhookSanitizerTest.kt
+++ b/server/src/test/kotlin/server/util/WebhookSanitizerTest.kt
@@ -5,8 +5,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-private const val ZWS = "​"
-
 class WebhookSanitizerTest {
     // --- Discord ---
 
@@ -64,6 +62,19 @@ class WebhookSanitizerTest {
         assertFalse(result.contains("<@&111>"))
         assertFalse(result.contains("<#222>"))
         assertFalse(result.contains("<@333>"))
+        // 各置換に ZWS が挿入されている
+        assertTrue(result.contains("@${ZWS}everyone"), "result should contain ZWS-broken @everyone: $result")
+        assertTrue(result.contains("<$ZWS@&"), "result should contain ZWS-broken role mention: $result")
+        assertTrue(result.contains("<$ZWS#"), "result should contain ZWS-broken channel mention: $result")
+        assertTrue(result.contains("<$ZWS@3"), "result should contain ZWS-broken user mention: $result")
+    }
+
+    @Test
+    fun discordHandlesMalformedNestedPattern() {
+        // `<@everyone` のような不正記法でも、@everyone が発火しないことを保証
+        val result = sanitizeForDiscord("<@everyone")
+        assertFalse(result.contains("@everyone"), "result should not contain raw @everyone: $result")
+        assertFalse(result.contains("<@e"), "result should not contain raw <@e: $result")
     }
 
     // --- Slack ---


### PR DESCRIPTION
## Summary
- ユーザー入力（Firebase Auth displayName / Quest title・description・creatorName / Pet name）を Discord embed / Slack text に流す経路で、メンション系記法を無効化する `WebhookSanitizer` を追加。
- **Discord**: `@everyone` / `@here` / `<@USER_ID>` / `<@&ROLE_ID>` / `<#CHANNEL_ID>` をゼロ幅スペース (U+200B) で分断する ZWS 方式。
- **Slack**: 公式推奨の HTML エンティティ化方式（`<` / `>` / `&` を `&lt;` / `&gt;` / `&amp;` に変換）。`<` で始まる全ての Slack 記法を一括無効化するため、将来新メンション記法が追加されても自動対応できる。
- `PaymentWebhookService.buildPayload` の `payerName`、`QuestWebhookService` の `quest.title / description / creatorName`、`FeedingNotificationService.buildPayload` の `petName` にサニタイザを適用。
- admin が設定する webhook `message`（PaymentWebhookSettings.message 等）や `prefix`（FeedingSettings.reminderPrefix）は意図的なメンション運用のためサニタイズ対象外。admin は引き続き `<@USER_ID>` 等で特定ユーザーを ping できる。

Closes #205

## 設計判断
- Discord は `allowed_mentions` パラメータも候補だが、payload 全体に作用するため admin message の `<@USER_ID>` も無効化されてしまう。フィールド単位で適用できる ZWS 分断方式を採用。
- Slack の HTML エンティティ化は `<URL|text>` 形式のリンクや `<mailto:>` も無効化するため、ユーザー入力経由で勝手にリンクが生成される副次的リスクも同時に防げる。
- GENERIC webhook（Discord/Slack 以外）は消費側がレンダリング責任を持つため、サニタイズ対象外。

## Test plan
- [x] `./gradlew :server:test -PskipFrontend` パス
- [x] `./gradlew :server:ktlintCheck` パス
- [x] `WebhookSanitizerTest`: Discord (ZWS 分断) と Slack (HTML エンティティ化) の各メンションパターンが無効化されることを確認
- [x] `PaymentWebhookPayloadTest` / `QuestWebhookPayloadTest` / `FeedingNotificationServiceTest`: 各サービスで displayName / petName / quest フィールド経由のインジェクションが無効化されること、admin message / prefix の `<@USER_ID>` は温存されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)