### PR TITLE
refactor: WebhookService 群の共通化（サーバー側）

### DIFF
--- a/server/src/main/kotlin/server/money/MoneyWebhookRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyWebhookRoutes.kt
@@ -41,8 +41,7 @@ fun Route.moneyWebhookRoutes() {
                 }
             }) {
                 val settings = call.receive<MoneyWebhookSettings>()
-                moneyWebhookService.updateSettings(settings)
-                call.respond(moneyWebhookService.getSettings())
+                call.respond(moneyWebhookService.updateSettings(settings))
             }
         }
     }

--- a/server/src/main/kotlin/server/money/MoneyWebhookService.kt
+++ b/server/src/main/kotlin/server/money/MoneyWebhookService.kt
@@ -22,6 +22,7 @@ import server.util.DISCORD_EMBED_COLOR
 import server.util.WebhookServiceType
 import server.util.await
 import server.util.detectWebhookService
+import server.util.formatYearMonth
 
 class MoneyWebhookService(
     private val firestore: Firestore,
@@ -129,15 +130,6 @@ class MoneyWebhookService(
 
     companion object {
         private val appUrl: String? = EnvConfig["APP_URL"]
-
-        /** "YYYY-MM" を "YYYY年MM月" 表記（月は 0 埋め 2 桁）に整形。パース失敗時は入力をそのまま返す。 */
-        internal fun formatYearMonth(yearMonth: String): String {
-            val parts = yearMonth.split("-")
-            if (parts.size != 2) return yearMonth
-            val year = parts[0].toIntOrNull() ?: return yearMonth
-            val month = parts[1].toIntOrNull() ?: return yearMonth
-            return "%d年%02d月".format(year, month)
-        }
     }
 }
 

--- a/server/src/main/kotlin/server/money/MoneyWebhookService.kt
+++ b/server/src/main/kotlin/server/money/MoneyWebhookService.kt
@@ -1,69 +1,46 @@
 package server.money
 
 import com.google.cloud.firestore.Firestore
-import com.google.cloud.firestore.SetOptions
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.content.TextContent
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import model.MoneyWebhookSettings
-import org.slf4j.LoggerFactory
 import server.config.EnvConfig
+import server.util.AbstractWebhookService
+import server.util.AbstractWebhookService.Companion.defaultWebhookClient
 import server.util.DISCORD_EMBED_COLOR
 import server.util.WebhookServiceType
-import server.util.await
 import server.util.detectWebhookService
 import server.util.formatYearMonth
 
 class MoneyWebhookService(
-    private val firestore: Firestore,
-    private val client: HttpClient =
-        HttpClient {
-            install(HttpTimeout) {
-                requestTimeoutMillis = 10_000
-            }
-        },
+    firestore: Firestore,
+    client: HttpClient = defaultWebhookClient(),
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
-) {
-    private val logger = LoggerFactory.getLogger(MoneyWebhookService::class.java)
-    private val moneySettingsDoc get() = firestore.collection("settings").document("money")
-    private val scope = CoroutineScope(dispatcher)
+) : AbstractWebhookService<MoneyWebhookSettings>(firestore, "money", client, dispatcher) {
+    override fun defaultSettings() = MoneyWebhookSettings()
 
-    @Suppress("UNCHECKED_CAST")
-    suspend fun getSettings(): MoneyWebhookSettings {
-        val doc = moneySettingsDoc.get().await()
-        if (!doc.exists()) return MoneyWebhookSettings()
-        val webhook = (doc.data?.get("webhook") as? Map<String, Any?>) ?: return MoneyWebhookSettings()
-        return MoneyWebhookSettings(
-            url = webhook["url"] as? String ?: "",
-            enabled = webhook["enabled"] as? Boolean ?: false,
-            message = webhook["message"] as? String ?: "",
+    override fun fromWebhookMap(map: Map<String, Any?>) =
+        MoneyWebhookSettings(
+            url = map["url"] as? String ?: "",
+            enabled = map["enabled"] as? Boolean ?: false,
+            message = map["message"] as? String ?: "",
         )
-    }
 
-    suspend fun updateSettings(settings: MoneyWebhookSettings) {
-        moneySettingsDoc
-            .set(
-                mapOf(
-                    "webhook" to
-                        mapOf(
-                            "url" to settings.url,
-                            "enabled" to settings.enabled,
-                            "message" to settings.message,
-                        ),
-                ),
-                SetOptions.merge(),
-            ).await()
-    }
+    override fun toWebhookMap(settings: MoneyWebhookSettings) =
+        mapOf(
+            "url" to settings.url,
+            "enabled" to settings.enabled,
+            "message" to settings.message,
+        )
 
     /** 月次ステータス確定時の通知を fire-and-forget で送信 */
     fun notifyConfirmed(yearMonth: String) {

--- a/server/src/main/kotlin/server/money/MoneyWebhookService.kt
+++ b/server/src/main/kotlin/server/money/MoneyWebhookService.kt
@@ -38,8 +38,6 @@ class MoneyWebhookService(
     private val moneySettingsDoc get() = firestore.collection("settings").document("money")
     private val scope = CoroutineScope(dispatcher)
 
-    private val json = Json
-
     @Suppress("UNCHECKED_CAST")
     suspend fun getSettings(): MoneyWebhookSettings {
         val doc = moneySettingsDoc.get().await()
@@ -74,7 +72,7 @@ class MoneyWebhookService(
                 val settings = getSettings()
                 if (!settings.enabled || settings.url.isBlank()) return@launch
 
-                val payload = buildPayload(settings.url, settings.message, yearMonth)
+                val payload = buildMoneyPayload(settings.url, settings.message, yearMonth, appUrl)
 
                 client.post(settings.url) {
                     setBody(TextContent(payload, ContentType.Application.Json))
@@ -85,51 +83,57 @@ class MoneyWebhookService(
         }
     }
 
-    internal fun buildPayload(
-        url: String,
-        message: String,
-        yearMonth: String,
-        dashboardUrl: String? = appUrl,
-    ): String {
-        val description = "${formatYearMonth(yearMonth)} の支払額が確定しました"
-        return when (detectWebhookService(url)) {
-            WebhookServiceType.DISCORD -> {
-                json.encodeToString(
-                    DiscordMoneyPayload(
-                        content = message.ifBlank { null },
-                        embeds =
-                            listOf(
-                                DiscordMoneyEmbed(
-                                    title = "支払額確定",
-                                    description = description,
-                                    color = DISCORD_EMBED_COLOR,
-                                    url = dashboardUrl,
-                                ),
-                            ),
-                    ),
-                )
-            }
-            WebhookServiceType.SLACK -> {
-                val text = if (message.isBlank()) description else "$message\n$description"
-                val withLink =
-                    if (dashboardUrl != null) "$text\n<$dashboardUrl|ダッシュボードを開く>" else text
-                json.encodeToString(SlackMoneyPayload(text = withLink))
-            }
-            WebhookServiceType.GENERIC -> {
-                json.encodeToString(
-                    GenericMoneyPayload(
-                        event = "money_status_confirmed",
-                        yearMonth = yearMonth,
-                        message = message,
-                        dashboardUrl = dashboardUrl,
-                    ),
-                )
-            }
-        }
-    }
-
     companion object {
         private val appUrl: String? = EnvConfig["APP_URL"]
+    }
+}
+
+private val json = Json
+
+/**
+ * 月次ステータス確定通知の payload を URL のサービス種別に応じて生成する。
+ * Firestore 非依存の純粋関数。`dashboardUrl` は呼び出し側で `APP_URL` を解決して渡す。
+ */
+internal fun buildMoneyPayload(
+    url: String,
+    message: String,
+    yearMonth: String,
+    dashboardUrl: String?,
+): String {
+    val description = "${formatYearMonth(yearMonth)} の支払額が確定しました"
+    return when (detectWebhookService(url)) {
+        WebhookServiceType.DISCORD -> {
+            json.encodeToString(
+                DiscordMoneyPayload(
+                    content = message.ifBlank { null },
+                    embeds =
+                        listOf(
+                            DiscordMoneyEmbed(
+                                title = "支払額確定",
+                                description = description,
+                                color = DISCORD_EMBED_COLOR,
+                                url = dashboardUrl,
+                            ),
+                        ),
+                ),
+            )
+        }
+        WebhookServiceType.SLACK -> {
+            val text = if (message.isBlank()) description else "$message\n$description"
+            val withLink =
+                if (dashboardUrl != null) "$text\n<$dashboardUrl|ダッシュボードを開く>" else text
+            json.encodeToString(SlackMoneyPayload(text = withLink))
+        }
+        WebhookServiceType.GENERIC -> {
+            json.encodeToString(
+                GenericMoneyPayload(
+                    event = "money_status_confirmed",
+                    yearMonth = yearMonth,
+                    message = message,
+                    dashboardUrl = dashboardUrl,
+                ),
+            )
+        }
     }
 }
 

--- a/server/src/main/kotlin/server/money/PaymentWebhookRoutes.kt
+++ b/server/src/main/kotlin/server/money/PaymentWebhookRoutes.kt
@@ -41,8 +41,7 @@ fun Route.paymentWebhookRoutes() {
                 }
             }) {
                 val settings = call.receive<PaymentWebhookSettings>()
-                paymentWebhookService.updateSettings(settings)
-                call.respond(paymentWebhookService.getSettings())
+                call.respond(paymentWebhookService.updateSettings(settings))
             }
         }
     }

--- a/server/src/main/kotlin/server/money/PaymentWebhookService.kt
+++ b/server/src/main/kotlin/server/money/PaymentWebhookService.kt
@@ -1,26 +1,23 @@
 package server.money
 
 import com.google.cloud.firestore.Firestore
-import com.google.cloud.firestore.SetOptions
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.content.TextContent
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import model.PaymentWebhookSettings
-import org.slf4j.LoggerFactory
 import server.config.EnvConfig
+import server.util.AbstractWebhookService
+import server.util.AbstractWebhookService.Companion.defaultWebhookClient
 import server.util.DISCORD_EMBED_COLOR
 import server.util.WebhookServiceType
-import server.util.await
 import server.util.detectWebhookService
 import server.util.formatAmount
 import server.util.formatYearMonth
@@ -28,45 +25,25 @@ import server.util.sanitizeForDiscord
 import server.util.sanitizeForSlack
 
 class PaymentWebhookService(
-    private val firestore: Firestore,
-    private val client: HttpClient =
-        HttpClient {
-            install(HttpTimeout) {
-                requestTimeoutMillis = 10_000
-            }
-        },
+    firestore: Firestore,
+    client: HttpClient = defaultWebhookClient(),
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
-) {
-    private val logger = LoggerFactory.getLogger(PaymentWebhookService::class.java)
-    private val paymentSettingsDoc get() = firestore.collection("settings").document("payment")
-    private val scope = CoroutineScope(dispatcher)
+) : AbstractWebhookService<PaymentWebhookSettings>(firestore, "payment", client, dispatcher) {
+    override fun defaultSettings() = PaymentWebhookSettings()
 
-    @Suppress("UNCHECKED_CAST")
-    suspend fun getSettings(): PaymentWebhookSettings {
-        val doc = paymentSettingsDoc.get().await()
-        if (!doc.exists()) return PaymentWebhookSettings()
-        val webhook = (doc.data?.get("webhook") as? Map<String, Any?>) ?: return PaymentWebhookSettings()
-        return PaymentWebhookSettings(
-            url = webhook["url"] as? String ?: "",
-            enabled = webhook["enabled"] as? Boolean ?: false,
-            message = webhook["message"] as? String ?: "",
+    override fun fromWebhookMap(map: Map<String, Any?>) =
+        PaymentWebhookSettings(
+            url = map["url"] as? String ?: "",
+            enabled = map["enabled"] as? Boolean ?: false,
+            message = map["message"] as? String ?: "",
         )
-    }
 
-    suspend fun updateSettings(settings: PaymentWebhookSettings) {
-        paymentSettingsDoc
-            .set(
-                mapOf(
-                    "webhook" to
-                        mapOf(
-                            "url" to settings.url,
-                            "enabled" to settings.enabled,
-                            "message" to settings.message,
-                        ),
-                ),
-                SetOptions.merge(),
-            ).await()
-    }
+    override fun toWebhookMap(settings: PaymentWebhookSettings) =
+        mapOf(
+            "url" to settings.url,
+            "enabled" to settings.enabled,
+            "message" to settings.message,
+        )
 
     /** 入金通知を fire-and-forget で送信 */
     fun notifyPayment(

--- a/server/src/main/kotlin/server/money/PaymentWebhookService.kt
+++ b/server/src/main/kotlin/server/money/PaymentWebhookService.kt
@@ -22,6 +22,8 @@ import server.util.DISCORD_EMBED_COLOR
 import server.util.WebhookServiceType
 import server.util.await
 import server.util.detectWebhookService
+import server.util.formatAmount
+import server.util.formatYearMonth
 import server.util.sanitizeForDiscord
 import server.util.sanitizeForSlack
 
@@ -158,18 +160,6 @@ class PaymentWebhookService(
 
     companion object {
         private val appUrl: String? = EnvConfig["APP_URL"]
-
-        /** "YYYY-MM" を "YYYY年MM月" 表記（月は 0 埋め 2 桁）に整形。パース失敗時は入力をそのまま返す。 */
-        internal fun formatYearMonth(yearMonth: String): String {
-            val parts = yearMonth.split("-")
-            if (parts.size != 2) return yearMonth
-            val year = parts[0].toIntOrNull() ?: return yearMonth
-            val month = parts[1].toIntOrNull() ?: return yearMonth
-            return "%d年%02d月".format(year, month)
-        }
-
-        /** 金額を 3 桁区切り + "円" 付きで整形（例: 12345 → "12,345 円"）。 */
-        internal fun formatAmount(amount: Long): String = "%,d 円".format(amount)
     }
 }
 

--- a/server/src/main/kotlin/server/money/PaymentWebhookService.kt
+++ b/server/src/main/kotlin/server/money/PaymentWebhookService.kt
@@ -41,8 +41,6 @@ class PaymentWebhookService(
     private val paymentSettingsDoc get() = firestore.collection("settings").document("payment")
     private val scope = CoroutineScope(dispatcher)
 
-    private val json = Json
-
     @Suppress("UNCHECKED_CAST")
     suspend fun getSettings(): PaymentWebhookSettings {
         val doc = paymentSettingsDoc.get().await()
@@ -82,12 +80,13 @@ class PaymentWebhookService(
                 if (!settings.enabled || settings.url.isBlank()) return@launch
 
                 val payload =
-                    buildPayload(
+                    buildPaymentPayload(
                         url = settings.url,
                         message = settings.message,
                         yearMonth = yearMonth,
                         payerName = payerName,
                         amount = amount,
+                        dashboardUrl = appUrl,
                     )
 
                 client.post(settings.url) {
@@ -99,67 +98,73 @@ class PaymentWebhookService(
         }
     }
 
-    internal fun buildPayload(
-        url: String,
-        message: String,
-        yearMonth: String,
-        payerName: String,
-        amount: Long,
-        dashboardUrl: String? = appUrl,
-    ): String {
-        val formattedYearMonth = formatYearMonth(yearMonth)
-        val formattedAmount = formatAmount(amount)
-        return when (detectWebhookService(url)) {
-            WebhookServiceType.DISCORD -> {
-                val safePayerName = sanitizeForDiscord(payerName)
-                val description = "$formattedYearMonth に $safePayerName が $formattedAmount を支払いました"
-                val fields =
-                    listOf(
-                        DiscordPaymentField(name = "支払者", value = safePayerName, inline = true),
-                        DiscordPaymentField(name = "金額", value = formattedAmount, inline = true),
-                        DiscordPaymentField(name = "対象月", value = formattedYearMonth, inline = true),
-                    )
-                json.encodeToString(
-                    DiscordPaymentPayload(
-                        content = message.ifBlank { null },
-                        embeds =
-                            listOf(
-                                DiscordPaymentEmbed(
-                                    title = "入金あり",
-                                    description = description,
-                                    color = DISCORD_EMBED_COLOR,
-                                    url = dashboardUrl,
-                                    fields = fields,
-                                ),
-                            ),
-                    ),
-                )
-            }
-            WebhookServiceType.SLACK -> {
-                val safePayerName = sanitizeForSlack(payerName)
-                val description = "$formattedYearMonth に $safePayerName が $formattedAmount を支払いました"
-                val base = if (message.isBlank()) description else "$message\n$description"
-                val withLink =
-                    if (dashboardUrl != null) "$base\n<$dashboardUrl|ダッシュボードを開く>" else base
-                json.encodeToString(SlackPaymentPayload(text = withLink))
-            }
-            WebhookServiceType.GENERIC -> {
-                json.encodeToString(
-                    GenericPaymentPayload(
-                        event = "payment_recorded",
-                        yearMonth = yearMonth,
-                        payerName = payerName,
-                        amount = amount,
-                        message = message,
-                        dashboardUrl = dashboardUrl,
-                    ),
-                )
-            }
-        }
-    }
-
     companion object {
         private val appUrl: String? = EnvConfig["APP_URL"]
+    }
+}
+
+private val json = Json
+
+/**
+ * 入金通知の payload を URL のサービス種別に応じて生成する。
+ * Firestore 非依存の純粋関数。`dashboardUrl` は呼び出し側で `APP_URL` を解決して渡す。
+ */
+internal fun buildPaymentPayload(
+    url: String,
+    message: String,
+    yearMonth: String,
+    payerName: String,
+    amount: Long,
+    dashboardUrl: String?,
+): String {
+    val formattedYearMonth = formatYearMonth(yearMonth)
+    val formattedAmount = formatAmount(amount)
+    return when (detectWebhookService(url)) {
+        WebhookServiceType.DISCORD -> {
+            val safePayerName = sanitizeForDiscord(payerName)
+            val description = "$formattedYearMonth に $safePayerName が $formattedAmount を支払いました"
+            val fields =
+                listOf(
+                    DiscordPaymentField(name = "支払者", value = safePayerName, inline = true),
+                    DiscordPaymentField(name = "金額", value = formattedAmount, inline = true),
+                    DiscordPaymentField(name = "対象月", value = formattedYearMonth, inline = true),
+                )
+            json.encodeToString(
+                DiscordPaymentPayload(
+                    content = message.ifBlank { null },
+                    embeds =
+                        listOf(
+                            DiscordPaymentEmbed(
+                                title = "入金あり",
+                                description = description,
+                                color = DISCORD_EMBED_COLOR,
+                                url = dashboardUrl,
+                                fields = fields,
+                            ),
+                        ),
+                ),
+            )
+        }
+        WebhookServiceType.SLACK -> {
+            val safePayerName = sanitizeForSlack(payerName)
+            val description = "$formattedYearMonth に $safePayerName が $formattedAmount を支払いました"
+            val base = if (message.isBlank()) description else "$message\n$description"
+            val withLink =
+                if (dashboardUrl != null) "$base\n<$dashboardUrl|ダッシュボードを開く>" else base
+            json.encodeToString(SlackPaymentPayload(text = withLink))
+        }
+        WebhookServiceType.GENERIC -> {
+            json.encodeToString(
+                GenericPaymentPayload(
+                    event = "payment_recorded",
+                    yearMonth = yearMonth,
+                    payerName = payerName,
+                    amount = amount,
+                    message = message,
+                    dashboardUrl = dashboardUrl,
+                ),
+            )
+        }
     }
 }
 

--- a/server/src/main/kotlin/server/quest/QuestWebhookRoutes.kt
+++ b/server/src/main/kotlin/server/quest/QuestWebhookRoutes.kt
@@ -41,8 +41,7 @@ fun Route.questWebhookRoutes() {
                 }
             }) {
                 val settings = call.receive<QuestWebhookSettings>()
-                questWebhookService.updateSettings(settings)
-                call.respond(questWebhookService.getSettings())
+                call.respond(questWebhookService.updateSettings(settings))
             }
         }
     }

--- a/server/src/main/kotlin/server/quest/QuestWebhookService.kt
+++ b/server/src/main/kotlin/server/quest/QuestWebhookService.kt
@@ -34,7 +34,6 @@ class QuestWebhookService(
     private val scope = CoroutineScope(dispatcher)
 
     private val client = HttpClient()
-    private val json = Json
 
     @Suppress("UNCHECKED_CAST")
     suspend fun getSettings(): QuestWebhookSettings {
@@ -73,7 +72,7 @@ class QuestWebhookService(
                 val settings = getSettings()
                 if (!settings.enabled || settings.url.isBlank() || event !in settings.events) return@launch
 
-                val payload = buildPayload(settings.url, event, quest)
+                val payload = buildQuestPayload(settings.url, event, quest)
 
                 client.post(settings.url) {
                     setBody(TextContent(payload, ContentType.Application.Json))
@@ -83,82 +82,87 @@ class QuestWebhookService(
             }
         }
     }
-
-    /** URL パターンからサービスを判別し JSON 文字列を生成 */
-    internal fun buildPayload(
-        url: String,
-        event: String,
-        quest: Quest,
-        timestamp: String = Instant.now().toString(),
-    ): String =
-        when (detectWebhookService(url)) {
-            WebhookServiceType.DISCORD -> json.encodeToString(buildDiscordPayload(event, quest))
-            WebhookServiceType.SLACK -> json.encodeToString(buildSlackPayload(event, quest))
-            WebhookServiceType.GENERIC -> json.encodeToString(buildGenericPayload(event, quest, timestamp))
-        }
-
-    private fun eventPrefix(event: String): String =
-        when (event) {
-            "quest_created" -> "\uD83C\uDD95 新しいクエスト"
-            "quest_verified" -> "\u2705 クエスト達成"
-            else -> event
-        }
-
-    private fun buildDiscordPayload(
-        event: String,
-        quest: Quest,
-    ): DiscordPayload {
-        val prefix = eventPrefix(event)
-        val safeTitle = sanitizeForDiscord(quest.title)
-        val safeDescription = sanitizeForDiscord(quest.description)
-        val safeCreatorName = sanitizeForDiscord(quest.creatorName)
-        return DiscordPayload(
-            embeds =
-                listOf(
-                    DiscordEmbed(
-                        title = "$prefix: $safeTitle",
-                        description = safeDescription,
-                        color = DISCORD_EMBED_COLOR,
-                        fields =
-                            listOf(
-                                DiscordField(name = "報酬", value = "${quest.rewardPoints}pt", inline = true),
-                                DiscordField(name = "依頼者", value = safeCreatorName, inline = true),
-                            ),
-                    ),
-                ),
-        )
-    }
-
-    private fun buildSlackPayload(
-        event: String,
-        quest: Quest,
-    ): SlackPayload {
-        val prefix = eventPrefix(event)
-        val safeTitle = sanitizeForSlack(quest.title)
-        val safeDescription = sanitizeForSlack(quest.description)
-        val safeCreatorName = sanitizeForSlack(quest.creatorName)
-        return SlackPayload(
-            text = "$prefix: $safeTitle\n$safeDescription\n報酬: ${quest.rewardPoints}pt | 依頼者: $safeCreatorName",
-        )
-    }
-
-    private fun buildGenericPayload(
-        event: String,
-        quest: Quest,
-        timestamp: String,
-    ): GenericPayload =
-        GenericPayload(
-            event = event,
-            quest =
-                GenericQuestData(
-                    title = quest.title,
-                    description = quest.description,
-                    rewardPoints = quest.rewardPoints,
-                    creatorName = quest.creatorName,
-                ),
-            timestamp = timestamp,
-        )
 }
+
+private val json = Json
+
+/**
+ * クエストイベントの payload を URL のサービス種別に応じて生成する。
+ * Firestore 非依存の純粋関数。
+ */
+internal fun buildQuestPayload(
+    url: String,
+    event: String,
+    quest: Quest,
+    timestamp: String = Instant.now().toString(),
+): String =
+    when (detectWebhookService(url)) {
+        WebhookServiceType.DISCORD -> json.encodeToString(buildDiscordPayload(event, quest))
+        WebhookServiceType.SLACK -> json.encodeToString(buildSlackPayload(event, quest))
+        WebhookServiceType.GENERIC -> json.encodeToString(buildGenericPayload(event, quest, timestamp))
+    }
+
+private fun eventPrefix(event: String): String =
+    when (event) {
+        "quest_created" -> "🆕 新しいクエスト"
+        "quest_verified" -> "✅ クエスト達成"
+        else -> event
+    }
+
+private fun buildDiscordPayload(
+    event: String,
+    quest: Quest,
+): DiscordPayload {
+    val prefix = eventPrefix(event)
+    val safeTitle = sanitizeForDiscord(quest.title)
+    val safeDescription = sanitizeForDiscord(quest.description)
+    val safeCreatorName = sanitizeForDiscord(quest.creatorName)
+    return DiscordPayload(
+        embeds =
+            listOf(
+                DiscordEmbed(
+                    title = "$prefix: $safeTitle",
+                    description = safeDescription,
+                    color = DISCORD_EMBED_COLOR,
+                    fields =
+                        listOf(
+                            DiscordField(name = "報酬", value = "${quest.rewardPoints}pt", inline = true),
+                            DiscordField(name = "依頼者", value = safeCreatorName, inline = true),
+                        ),
+                ),
+            ),
+    )
+}
+
+private fun buildSlackPayload(
+    event: String,
+    quest: Quest,
+): SlackPayload {
+    val prefix = eventPrefix(event)
+    val safeTitle = sanitizeForSlack(quest.title)
+    val safeDescription = sanitizeForSlack(quest.description)
+    val safeCreatorName = sanitizeForSlack(quest.creatorName)
+    return SlackPayload(
+        text = "$prefix: $safeTitle\n$safeDescription\n報酬: ${quest.rewardPoints}pt | 依頼者: $safeCreatorName",
+    )
+}
+
+private fun buildGenericPayload(
+    event: String,
+    quest: Quest,
+    timestamp: String,
+): GenericPayload =
+    GenericPayload(
+        event = event,
+        quest =
+            GenericQuestData(
+                title = quest.title,
+                description = quest.description,
+                rewardPoints = quest.rewardPoints,
+                creatorName = quest.creatorName,
+            ),
+        timestamp = timestamp,
+    )
 
 // --- Discord ペイロード ---
 

--- a/server/src/main/kotlin/server/quest/QuestWebhookService.kt
+++ b/server/src/main/kotlin/server/quest/QuestWebhookService.kt
@@ -1,14 +1,12 @@
 package server.quest
 
 import com.google.cloud.firestore.Firestore
-import com.google.cloud.firestore.SetOptions
 import io.ktor.client.HttpClient
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.content.TextContent
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
@@ -16,51 +14,35 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import model.Quest
 import model.QuestWebhookSettings
-import org.slf4j.LoggerFactory
+import server.util.AbstractWebhookService
+import server.util.AbstractWebhookService.Companion.defaultWebhookClient
 import server.util.DISCORD_EMBED_COLOR
 import server.util.WebhookServiceType
-import server.util.await
 import server.util.detectWebhookService
 import server.util.sanitizeForDiscord
 import server.util.sanitizeForSlack
 import java.time.Instant
 
 class QuestWebhookService(
-    private val firestore: Firestore,
+    firestore: Firestore,
+    client: HttpClient = defaultWebhookClient(),
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
-) {
-    private val logger = LoggerFactory.getLogger(QuestWebhookService::class.java)
-    private val questSettingsDoc get() = firestore.collection("settings").document("quest")
-    private val scope = CoroutineScope(dispatcher)
+) : AbstractWebhookService<QuestWebhookSettings>(firestore, "quest", client, dispatcher) {
+    override fun defaultSettings() = QuestWebhookSettings()
 
-    private val client = HttpClient()
-
-    @Suppress("UNCHECKED_CAST")
-    suspend fun getSettings(): QuestWebhookSettings {
-        val doc = questSettingsDoc.get().await()
-        if (!doc.exists()) return QuestWebhookSettings()
-        val webhook = (doc.data?.get("webhook") as? Map<String, Any?>) ?: return QuestWebhookSettings()
-        return QuestWebhookSettings(
-            url = webhook["url"] as? String ?: "",
-            enabled = webhook["enabled"] as? Boolean ?: false,
-            events = (webhook["events"] as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
+    override fun fromWebhookMap(map: Map<String, Any?>) =
+        QuestWebhookSettings(
+            url = map["url"] as? String ?: "",
+            enabled = map["enabled"] as? Boolean ?: false,
+            events = (map["events"] as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
         )
-    }
 
-    suspend fun updateSettings(settings: QuestWebhookSettings) {
-        questSettingsDoc
-            .set(
-                mapOf(
-                    "webhook" to
-                        mapOf(
-                            "url" to settings.url,
-                            "enabled" to settings.enabled,
-                            "events" to settings.events,
-                        ),
-                ),
-                SetOptions.merge(),
-            ).await()
-    }
+    override fun toWebhookMap(settings: QuestWebhookSettings) =
+        mapOf(
+            "url" to settings.url,
+            "enabled" to settings.enabled,
+            "events" to settings.events,
+        )
 
     /** fire-and-forget でイベントを送信 */
     fun notify(

--- a/server/src/main/kotlin/server/util/AbstractWebhookService.kt
+++ b/server/src/main/kotlin/server/util/AbstractWebhookService.kt
@@ -1,0 +1,73 @@
+package server.util
+
+import com.google.cloud.firestore.Firestore
+import com.google.cloud.firestore.SetOptions
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import model.WebhookSettings
+import org.slf4j.LoggerFactory
+
+/**
+ * `settings/{documentName}` ドキュメントの `webhook` map に設定を保存する Webhook サービスの共通基底。
+ *
+ * Money / Payment / Quest で重複していた以下を集約する:
+ * - `getSettings` / `updateSettings`（Firestore I/O）
+ * - logger / scope / HttpClient の初期化
+ *
+ * 設定モデル ↔ Firestore map の変換だけをサブクラスが [defaultSettings] / [fromWebhookMap] /
+ * [toWebhookMap] で与え、ドメイン固有の通知メソッドはサブクラス側に実装する。
+ *
+ * キャッシュは持たず毎回 Firestore から読む。webhook 設定の read 頻度は低く、
+ * in-memory キャッシュは将来のマルチインスタンス運用で設定変更が反映されない
+ * stale リスクを招くため、即時反映性を優先する。
+ */
+abstract class AbstractWebhookService<S : WebhookSettings>(
+    private val firestore: Firestore,
+    private val documentName: String,
+    protected val client: HttpClient = defaultWebhookClient(),
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    protected val logger = LoggerFactory.getLogger(this::class.java)
+    protected val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    private val settingsDoc get() = firestore.collection("settings").document(documentName)
+
+    /** 設定が未保存のときに返すデフォルト値。 */
+    protected abstract fun defaultSettings(): S
+
+    /** Firestore の `webhook` map を設定モデルへ変換する。 */
+    protected abstract fun fromWebhookMap(map: Map<String, Any?>): S
+
+    /** 設定モデルを Firestore 保存用 map へ変換する。 */
+    protected abstract fun toWebhookMap(settings: S): Map<String, Any?>
+
+    suspend fun getSettings(): S {
+        val doc = settingsDoc.get().await()
+        if (!doc.exists()) return defaultSettings()
+
+        @Suppress("UNCHECKED_CAST")
+        val webhook = doc.data?.get("webhook") as? Map<String, Any?> ?: return defaultSettings()
+        return fromWebhookMap(webhook)
+    }
+
+    /** 設定を保存し、保存値をそのまま返す（merge は webhook map を全上書きするため再 GET 不要）。 */
+    suspend fun updateSettings(settings: S): S {
+        settingsDoc
+            .set(mapOf("webhook" to toWebhookMap(settings)), SetOptions.merge())
+            .await()
+        return settings
+    }
+
+    companion object {
+        fun defaultWebhookClient(): HttpClient =
+            HttpClient {
+                install(HttpTimeout) {
+                    requestTimeoutMillis = 10_000
+                }
+            }
+    }
+}

--- a/server/src/main/kotlin/server/util/AbstractWebhookService.kt
+++ b/server/src/main/kotlin/server/util/AbstractWebhookService.kt
@@ -54,7 +54,7 @@ abstract class AbstractWebhookService<S : WebhookSettings>(
         return fromWebhookMap(webhook)
     }
 
-    /** 設定を保存し、保存値をそのまま返す（merge は webhook map を全上書きするため再 GET 不要）。 */
+    /** 設定を保存し、保存値をそのまま返す（toWebhookMap が常に全フィールドを返すため、保存値と実体が一致し再 GET 不要）。 */
     suspend fun updateSettings(settings: S): S {
         settingsDoc
             .set(mapOf("webhook" to toWebhookMap(settings)), SetOptions.merge())

--- a/server/src/main/kotlin/server/util/WebhookFormat.kt
+++ b/server/src/main/kotlin/server/util/WebhookFormat.kt
@@ -1,0 +1,13 @@
+package server.util
+
+/** "YYYY-MM" を "YYYY年MM月" 表記（月は 0 埋め 2 桁）に整形。パース失敗時は入力をそのまま返す。 */
+fun formatYearMonth(yearMonth: String): String {
+    val parts = yearMonth.split("-")
+    if (parts.size != 2) return yearMonth
+    val year = parts[0].toIntOrNull() ?: return yearMonth
+    val month = parts[1].toIntOrNull() ?: return yearMonth
+    return "%d年%02d月".format(year, month)
+}
+
+/** 金額を 3 桁区切り + "円" 付きで整形（例: 12345 → "12,345 円"）。 */
+fun formatAmount(amount: Long): String = "%,d 円".format(amount)

--- a/server/src/test/kotlin/server/money/MoneyWebhookPayloadTest.kt
+++ b/server/src/test/kotlin/server/money/MoneyWebhookPayloadTest.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import server.money.MoneyWebhookService.Companion.formatYearMonth
+import server.util.formatYearMonth
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs

--- a/server/src/test/kotlin/server/money/MoneyWebhookPayloadTest.kt
+++ b/server/src/test/kotlin/server/money/MoneyWebhookPayloadTest.kt
@@ -1,7 +1,5 @@
 package server.money
 
-import com.google.cloud.firestore.Firestore
-import io.mockk.mockk
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -15,8 +13,6 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class MoneyWebhookPayloadTest {
-    private val service = MoneyWebhookService(firestore = mockk<Firestore>())
-
     private fun parseJson(jsonString: String): JsonObject = Json.parseToJsonElement(jsonString).jsonObject
 
     // --- Discord ペイロード ---
@@ -25,7 +21,7 @@ class MoneyWebhookPayloadTest {
     fun discordPayloadStructure() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildMoneyPayload(
                     url = "https://discord.com/api/webhooks/12345/token",
                     message = "@everyone",
                     yearMonth = "2026-04",
@@ -47,7 +43,7 @@ class MoneyWebhookPayloadTest {
     fun discordPayloadIncludesMessageAsContent() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildMoneyPayload(
                     url = "https://discord.com/api/webhooks/12345/token",
                     message = "@everyone",
                     yearMonth = "2026-04",
@@ -62,7 +58,7 @@ class MoneyWebhookPayloadTest {
     fun discordPayloadOmitsContentWhenMessageBlank() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildMoneyPayload(
                     url = "https://discord.com/api/webhooks/12345/token",
                     message = "",
                     yearMonth = "2026-04",
@@ -78,7 +74,7 @@ class MoneyWebhookPayloadTest {
     fun discordAppUrlAlsoProducesDiscordPayload() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildMoneyPayload(
                     url = "https://discordapp.com/api/webhooks/12345/token",
                     message = "",
                     yearMonth = "2026-04",
@@ -94,7 +90,7 @@ class MoneyWebhookPayloadTest {
     fun slackPayloadTextWithMessageAndDashboard() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildMoneyPayload(
                     url = "https://hooks.slack.com/services/T00/B00/xxx",
                     message = "確定しました",
                     yearMonth = "2026-04",
@@ -115,7 +111,7 @@ class MoneyWebhookPayloadTest {
     fun slackPayloadOmitsLinkWhenDashboardUrlNull() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildMoneyPayload(
                     url = "https://hooks.slack.com/services/T00/B00/xxx",
                     message = "",
                     yearMonth = "2026-04",
@@ -134,7 +130,7 @@ class MoneyWebhookPayloadTest {
     fun genericPayloadFields() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildMoneyPayload(
                     url = "https://example.com/webhook",
                     message = "確定しました",
                     yearMonth = "2026-04",
@@ -152,7 +148,7 @@ class MoneyWebhookPayloadTest {
     fun genericPayloadOmitsDashboardUrlWhenNull() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildMoneyPayload(
                     url = "https://example.com/webhook",
                     message = "",
                     yearMonth = "2026-04",
@@ -168,7 +164,7 @@ class MoneyWebhookPayloadTest {
     fun caseInsensitiveDiscordDetection() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildMoneyPayload(
                     url = "https://DISCORD.COM/API/WEBHOOKS/12345/token",
                     message = "",
                     yearMonth = "2026-04",

--- a/server/src/test/kotlin/server/money/PaymentWebhookPayloadTest.kt
+++ b/server/src/test/kotlin/server/money/PaymentWebhookPayloadTest.kt
@@ -1,7 +1,5 @@
 package server.money
 
-import com.google.cloud.firestore.Firestore
-import io.mockk.mockk
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -15,8 +13,6 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class PaymentWebhookPayloadTest {
-    private val service = PaymentWebhookService(firestore = mockk<Firestore>())
-
     private fun parseJson(jsonString: String): JsonObject = Json.parseToJsonElement(jsonString).jsonObject
 
     // --- Discord ペイロード ---
@@ -25,7 +21,7 @@ class PaymentWebhookPayloadTest {
     fun discordPayloadStructure() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildPaymentPayload(
                     url = "https://discord.com/api/webhooks/12345/token",
                     message = "@everyone",
                     yearMonth = "2026-04",
@@ -51,12 +47,13 @@ class PaymentWebhookPayloadTest {
     fun discordPayloadFieldsIncludePayerAmountAndYearMonth() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildPaymentPayload(
                     url = "https://discord.com/api/webhooks/12345/token",
                     message = "",
                     yearMonth = "2026-04",
                     payerName = "Alice",
                     amount = 5000L,
+                    dashboardUrl = null,
                 ),
             )
 
@@ -69,7 +66,7 @@ class PaymentWebhookPayloadTest {
     fun discordPayloadIncludesMessageAsContent() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildPaymentPayload(
                     url = "https://discord.com/api/webhooks/12345/token",
                     message = "@everyone",
                     yearMonth = "2026-04",
@@ -85,7 +82,7 @@ class PaymentWebhookPayloadTest {
     fun discordPayloadOmitsContentWhenMessageBlank() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildPaymentPayload(
                     url = "https://discord.com/api/webhooks/12345/token",
                     message = "",
                     yearMonth = "2026-04",
@@ -103,7 +100,7 @@ class PaymentWebhookPayloadTest {
     fun slackPayloadIncludesMessagePayerAmountAndDashboard() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildPaymentPayload(
                     url = "https://hooks.slack.com/services/T00/B00/xxx",
                     message = "入金通知",
                     yearMonth = "2026-04",
@@ -125,7 +122,7 @@ class PaymentWebhookPayloadTest {
     fun slackPayloadOmitsLinkWhenDashboardUrlNull() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildPaymentPayload(
                     url = "https://hooks.slack.com/services/T00/B00/xxx",
                     message = "",
                     yearMonth = "2026-04",
@@ -144,7 +141,7 @@ class PaymentWebhookPayloadTest {
     fun genericPayloadFields() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildPaymentPayload(
                     url = "https://example.com/webhook",
                     message = "入金通知",
                     yearMonth = "2026-04",
@@ -166,7 +163,7 @@ class PaymentWebhookPayloadTest {
     fun genericPayloadOmitsDashboardUrlWhenNull() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildPaymentPayload(
                     url = "https://example.com/webhook",
                     message = "",
                     yearMonth = "2026-04",
@@ -184,7 +181,7 @@ class PaymentWebhookPayloadTest {
     fun discordPayerNameWithEveryoneIsSanitized() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildPaymentPayload(
                     url = "https://discord.com/api/webhooks/12345/token",
                     message = "",
                     yearMonth = "2026-04",
@@ -205,7 +202,7 @@ class PaymentWebhookPayloadTest {
     fun discordPayerNameWithUserMentionIsSanitized() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildPaymentPayload(
                     url = "https://discord.com/api/webhooks/12345/token",
                     message = "",
                     yearMonth = "2026-04",
@@ -229,7 +226,7 @@ class PaymentWebhookPayloadTest {
     fun discordAdminMessageMentionIsPreserved() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildPaymentPayload(
                     url = "https://discord.com/api/webhooks/12345/token",
                     message = "<@123456789> 入金確認お願い",
                     yearMonth = "2026-04",
@@ -246,7 +243,7 @@ class PaymentWebhookPayloadTest {
     fun slackPayerNameWithChannelIsSanitized() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildPaymentPayload(
                     url = "https://hooks.slack.com/services/T00/B00/xxx",
                     message = "",
                     yearMonth = "2026-04",
@@ -264,7 +261,7 @@ class PaymentWebhookPayloadTest {
     fun slackPayerNameWithUserMentionIsSanitized() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildPaymentPayload(
                     url = "https://hooks.slack.com/services/T00/B00/xxx",
                     message = "",
                     yearMonth = "2026-04",
@@ -284,7 +281,7 @@ class PaymentWebhookPayloadTest {
     fun caseInsensitiveDiscordDetection() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildPaymentPayload(
                     url = "https://DISCORD.COM/API/WEBHOOKS/12345/token",
                     message = "",
                     yearMonth = "2026-04",

--- a/server/src/test/kotlin/server/quest/QuestWebhookPayloadTest.kt
+++ b/server/src/test/kotlin/server/quest/QuestWebhookPayloadTest.kt
@@ -1,7 +1,5 @@
 package server.quest
 
-import com.google.cloud.firestore.Firestore
-import io.mockk.mockk
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -18,8 +16,6 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class QuestWebhookPayloadTest {
-    private val service = QuestWebhookService(firestore = mockk<Firestore>())
-
     private val sampleQuest =
         Quest(
             id = "q1",
@@ -41,7 +37,7 @@ class QuestWebhookPayloadTest {
     fun discordPayloadStructure() {
         val json =
             parseJson(
-                service.buildPayload("https://discord.com/api/webhooks/12345/token", "quest_created", sampleQuest),
+                buildQuestPayload("https://discord.com/api/webhooks/12345/token", "quest_created", sampleQuest),
             )
 
         val embeds = json["embeds"]
@@ -57,7 +53,7 @@ class QuestWebhookPayloadTest {
     fun discordPayloadFields() {
         val json =
             parseJson(
-                service.buildPayload("https://discord.com/api/webhooks/12345/token", "quest_created", sampleQuest),
+                buildQuestPayload("https://discord.com/api/webhooks/12345/token", "quest_created", sampleQuest),
             )
 
         val fields = json["embeds"]!!.jsonArray[0].jsonObject["fields"]!!.jsonArray
@@ -74,7 +70,7 @@ class QuestWebhookPayloadTest {
     fun discordAppUrlAlsoProducesDiscordPayload() {
         val json =
             parseJson(
-                service.buildPayload("https://discordapp.com/api/webhooks/12345/token", "quest_created", sampleQuest),
+                buildQuestPayload("https://discordapp.com/api/webhooks/12345/token", "quest_created", sampleQuest),
             )
         // Discord ペイロードは embeds を持つ
         assertIs<JsonArray>(json["embeds"])
@@ -86,7 +82,7 @@ class QuestWebhookPayloadTest {
     fun slackPayloadText() {
         val json =
             parseJson(
-                service.buildPayload("https://hooks.slack.com/services/T00/B00/xxx", "quest_created", sampleQuest),
+                buildQuestPayload("https://hooks.slack.com/services/T00/B00/xxx", "quest_created", sampleQuest),
             )
 
         val text = json["text"]!!.jsonPrimitive.content
@@ -102,7 +98,7 @@ class QuestWebhookPayloadTest {
     fun genericPayloadEventAndTimestamp() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildQuestPayload(
                     "https://example.com/webhook",
                     "quest_created",
                     sampleQuest,
@@ -118,7 +114,7 @@ class QuestWebhookPayloadTest {
     fun genericPayloadQuestData() {
         val json =
             parseJson(
-                service.buildPayload(
+                buildQuestPayload(
                     "https://example.com/webhook",
                     "quest_created",
                     sampleQuest,
@@ -145,7 +141,7 @@ class QuestWebhookPayloadTest {
             )
         val json =
             parseJson(
-                service.buildPayload("https://discord.com/api/webhooks/12345/token", "quest_created", maliciousQuest),
+                buildQuestPayload("https://discord.com/api/webhooks/12345/token", "quest_created", maliciousQuest),
             )
         val embed = json["embeds"]!!.jsonArray[0].jsonObject
         val title = embed["title"]!!.jsonPrimitive.content
@@ -171,7 +167,7 @@ class QuestWebhookPayloadTest {
             )
         val json =
             parseJson(
-                service.buildPayload("https://hooks.slack.com/services/T00/B00/xxx", "quest_created", maliciousQuest),
+                buildQuestPayload("https://hooks.slack.com/services/T00/B00/xxx", "quest_created", maliciousQuest),
             )
         val text = json["text"]!!.jsonPrimitive.content
         assertTrue(!text.contains("<!channel>"), "text should not contain raw <!channel>: $text")
@@ -188,7 +184,7 @@ class QuestWebhookPayloadTest {
     fun caseInsensitiveUrlDetection() {
         val json =
             parseJson(
-                service.buildPayload("https://DISCORD.COM/API/WEBHOOKS/12345/token", "quest_created", sampleQuest),
+                buildQuestPayload("https://DISCORD.COM/API/WEBHOOKS/12345/token", "quest_created", sampleQuest),
             )
         // Discord ペイロードは embeds を持つ
         assertIs<JsonArray>(json["embeds"])
@@ -200,7 +196,7 @@ class QuestWebhookPayloadTest {
     fun questCreatedEventContainsPrefix() {
         val json =
             parseJson(
-                service.buildPayload("https://discord.com/api/webhooks/12345/token", "quest_created", sampleQuest),
+                buildQuestPayload("https://discord.com/api/webhooks/12345/token", "quest_created", sampleQuest),
             )
         val title =
             json["embeds"]!!
@@ -214,7 +210,7 @@ class QuestWebhookPayloadTest {
     fun questVerifiedEventContainsPrefix() {
         val json =
             parseJson(
-                service.buildPayload("https://discord.com/api/webhooks/12345/token", "quest_verified", sampleQuest),
+                buildQuestPayload("https://discord.com/api/webhooks/12345/token", "quest_verified", sampleQuest),
             )
         val title =
             json["embeds"]!!

--- a/shared/src/commonMain/kotlin/model/MoneyModels.kt
+++ b/shared/src/commonMain/kotlin/model/MoneyModels.kt
@@ -159,14 +159,14 @@ fun Share.toSaveRequest(): ShareSaveRequest = ShareSaveRequest(uid = uid, amount
 
 @Serializable
 data class MoneyWebhookSettings(
-    val url: String = "",
-    val enabled: Boolean = false,
+    override val url: String = "",
+    override val enabled: Boolean = false,
     val message: String = "",
-)
+) : WebhookSettings
 
 @Serializable
 data class PaymentWebhookSettings(
-    val url: String = "",
-    val enabled: Boolean = false,
+    override val url: String = "",
+    override val enabled: Boolean = false,
     val message: String = "",
-)
+) : WebhookSettings

--- a/shared/src/commonMain/kotlin/model/QuestWebhookModels.kt
+++ b/shared/src/commonMain/kotlin/model/QuestWebhookModels.kt
@@ -4,10 +4,10 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class QuestWebhookSettings(
-    val url: String = "",
-    val enabled: Boolean = false,
+    override val url: String = "",
+    override val enabled: Boolean = false,
     val events: List<String> = emptyList(),
-)
+) : WebhookSettings
 
 object QuestWebhookEvent {
     const val QUEST_CREATED = "quest_created"

--- a/shared/src/commonMain/kotlin/model/WebhookSettings.kt
+++ b/shared/src/commonMain/kotlin/model/WebhookSettings.kt
@@ -1,0 +1,16 @@
+package model
+
+/**
+ * Webhook 設定モデルの共通契約。
+ *
+ * Money / Payment / Quest の各 Webhook 設定が最低限共有するフィールドを定義し、
+ * サーバー側の `AbstractWebhookService` で「enabled かつ url が空でないか」の
+ * 共通判定を型安全に行えるようにする。
+ *
+ * シリアライズには関与しないため `@Serializable` は付けない。
+ * 実装側の `@Serializable data class` が宣言済みプロパティをそのまま直列化する。
+ */
+interface WebhookSettings {
+    val url: String
+    val enabled: Boolean
+}

--- a/shared/src/commonMain/kotlin/model/WebhookSettings.kt
+++ b/shared/src/commonMain/kotlin/model/WebhookSettings.kt
@@ -3,9 +3,8 @@ package model
 /**
  * Webhook 設定モデルの共通契約。
  *
- * Money / Payment / Quest の各 Webhook 設定が最低限共有するフィールドを定義し、
- * サーバー側の `AbstractWebhookService` で「enabled かつ url が空でないか」の
- * 共通判定を型安全に行えるようにする。
+ * Money / Payment / Quest の各 Webhook 設定が共通して持つフィールド（url / enabled）を定義し、
+ * `AbstractWebhookService<S : WebhookSettings>` の型境界として settings 種別を制約する。
  *
  * シリアライズには関与しないため `@Serializable` は付けない。
  * 実装側の `@Serializable data class` が宣言済みプロパティをそのまま直列化する。


### PR DESCRIPTION
## 概要

Issue #204 の対応。PR #203 で `PaymentWebhookService` が追加され、`MoneyWebhookService` / `QuestWebhookService` と合わせて**ほぼ同型の webhook service が3つ並ぶ**状態になっていた重複を、サーバー側で共通化した。

**スコープはサーバー側のみ。** Issue が併記するクライアント側（`feature/settings/` の `MoneyWebhookViewModel`/`PaymentWebhookViewModel` と Card の統合）は、Compose for WASM の recomposition 感度と `SettingsScreen` ステートフル配線の変更範囲の大きさを考慮し、**別 Issue に切り出す**こととした。

## 変更内容（コミット単位）

1. **`WebhookSettings` interface 追加**（shared）
   - `url` / `enabled` を持つプレーン interface を新設し、`MoneyWebhookSettings` / `PaymentWebhookSettings` / `QuestWebhookSettings` に実装。`@Serializable` は付けないため JSON 形式は不変。
2. **`formatYearMonth` / `formatAmount` を `server.util` へ**
   - Money/Payment の companion で重複していた整形関数をトップレベル純粋関数に集約。
3. **payload 生成を Firestore 非依存のトップレベル関数へ抽出**
   - `buildMoneyPayload` / `buildPaymentPayload` / `buildQuestPayload`。`dashboardUrl` はデフォルト引数を廃止して必須化し、`APP_URL` の解決は service の notify 側に移動。payload テストは Firestore mock 不要になった。
4. **`AbstractWebhookService` 新設 + 3 service 継承 + ルート再 GET 廃止**
   - `getSettings` / `updateSettings` / logger / scope / HttpClient の初期化を基底クラスへ集約。各 service は設定モデル↔map 変換とドメイン固有 notify のみ。

## 付随する挙動変更（意図的）

- **`@Suppress("UNCHECKED_CAST")` のスコープ縮小**: 関数全体 → cast 文1行のみ。
- **scope を `SupervisorJob` 付きに統一**: fire-and-forget の各通知が独立して失敗を握り潰す。
- **Quest の HttpClient にも 10s タイムアウト付与**: 従来は素の `HttpClient()`（無制限）だった。Money/Payment と統一。
- **PUT 後の再 GET を廃止**: `updateSettings` が保存値をそのまま返す（toWebhookMap が常に全フィールドを返すため保存値と実体が一致）。

## キャッシュを入れなかった理由

Issue は `getSettings` の in-memory キャッシュを提案していたが、**導入しない**。invalidate-on-write キャッシュは将来のマルチインスタンス運用で「admin が webhook を無効化しても別インスタンスが旧設定で通知し続ける」永久 stale バグになり得る一方、webhook 設定の read 頻度は低く費用対効果が薄いため、即時反映性を優先した。

## 検証

- `./gradlew :server:test -PskipFrontend` ✅ 全 pass
- `./gradlew :shared:compileKotlinWasmJs :feature:settings:compileKotlinWasmJs :core:network:compileKotlinWasmJs` ✅
- `./gradlew ktlintCheck` ✅

## 残課題（別 Issue）

- クライアント側の `MoneyWebhookViewModel`/`PaymentWebhookViewModel` および Money/Payment 用 Card の統合。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

