### PR TITLE
feat: 設定画面のカテゴリを URL フラグメントでルーティング

### DIFF
--- a/app/src/wasmJsMain/kotlin/app/App.kt
+++ b/app/src/wasmJsMain/kotlin/app/App.kt
@@ -109,8 +109,8 @@ private fun ScreenContent(
         Screen.Quest -> QuestScreen()
         Screen.Settings ->
             SettingsScreen(
-                initialCategory = Navigator.fragment,
-                onCategoryChange = { Navigator.setFragment(it) },
+                categoryName = Navigator.fragment,
+                onCategoryNameChange = { Navigator.setFragment(it) },
             )
     }
 }

--- a/app/src/wasmJsMain/kotlin/app/App.kt
+++ b/app/src/wasmJsMain/kotlin/app/App.kt
@@ -107,7 +107,11 @@ private fun ScreenContent(
         Screen.Money -> MoneyScreen()
         Screen.Overpayment -> OverpaymentScreen()
         Screen.Quest -> QuestScreen()
-        Screen.Settings -> SettingsScreen()
+        Screen.Settings ->
+            SettingsScreen(
+                initialCategory = Navigator.fragment,
+                onCategoryChange = { Navigator.setFragment(it) },
+            )
     }
 }
 

--- a/app/src/wasmJsMain/kotlin/app/Navigator.kt
+++ b/app/src/wasmJsMain/kotlin/app/Navigator.kt
@@ -47,9 +47,11 @@ object Navigator {
 
     /** 画面遷移を伴わず、現在画面内のサブルート（URL フラグメント）のみ更新する。 */
     fun setFragment(value: String?) {
-        if (value == fragment) return
-        val url = if (value.isNullOrEmpty()) currentScreen.path else "${currentScreen.path}#$value"
+        // 空文字列は「該当なし」として null に正規化し、内部状態と URL のズレを防ぐ。
+        val normalized = value?.ifEmpty { null }
+        if (normalized == fragment) return
+        val url = if (normalized == null) currentScreen.path else "${currentScreen.path}#$normalized"
         window.history.pushState(null, "", url)
-        fragment = value
+        fragment = normalized
     }
 }

--- a/app/src/wasmJsMain/kotlin/app/Navigator.kt
+++ b/app/src/wasmJsMain/kotlin/app/Navigator.kt
@@ -15,18 +15,41 @@ object Navigator {
     var currentScreen by mutableStateOf(Screen.Dashboard)
         private set
 
-    /** Main.kt から一度だけ呼ぶ。URL から初期画面を決定し、popstate リスナーを登録する。 */
+    /**
+     * 現在画面内のサブルート（URL フラグメント、例: `/settings#Account` の `Account`）。
+     * 該当なしは null。各画面が自前の識別子を解釈する。
+     */
+    var fragment by mutableStateOf<String?>(null)
+        private set
+
+    /** Main.kt から一度だけ呼ぶ。URL から初期状態を決定し、popstate/hashchange リスナーを登録する。 */
     fun init() {
+        syncFromLocation()
+        window.addEventListener("popstate", { _: Event -> syncFromLocation() })
+        window.addEventListener("hashchange", { _: Event -> syncFromLocation() })
+    }
+
+    private fun syncFromLocation() {
         currentScreen = Screen.fromPath(window.location.pathname)
-        window.addEventListener("popstate", { _: Event ->
-            currentScreen = Screen.fromPath(window.location.pathname)
-        })
+        fragment =
+            window.location.hash
+                .removePrefix("#")
+                .ifEmpty { null }
     }
 
     fun navigateTo(screen: Screen) {
         if (screen != currentScreen) {
             window.history.pushState(null, "", screen.path)
             currentScreen = screen
+            fragment = null
         }
+    }
+
+    /** 画面遷移を伴わず、現在画面内のサブルート（URL フラグメント）のみ更新する。 */
+    fun setFragment(value: String?) {
+        if (value == fragment) return
+        val url = if (value.isNullOrEmpty()) currentScreen.path else "${currentScreen.path}#$value"
+        window.history.pushState(null, "", url)
+        fragment = value
     }
 }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -84,8 +84,8 @@ internal enum class SettingsCategory(
 
 @Composable
 fun SettingsScreen(
-    initialCategory: String? = null,
-    onCategoryChange: (String?) -> Unit = {},
+    categoryName: String? = null,
+    onCategoryNameChange: (String?) -> Unit = {},
     passwordVm: PasswordChangeViewModel = koinViewModel(),
     passkeyVm: PasskeyManagementViewModel = koinViewModel(),
     loginHistoryVm: LoginHistoryViewModel = koinViewModel(),
@@ -95,7 +95,7 @@ fun SettingsScreen(
 
     // URL フラグメント（enum 名）→ SettingsCategory。不正値・権限外は null（カテゴリ未選択）扱い。
     val selectedCategory =
-        initialCategory
+        categoryName
             ?.let { name -> SettingsCategory.entries.find { it.name == name } }
             ?.takeIf { !it.adminOnly || isAdmin }
     val koin = getKoin()
@@ -237,7 +237,7 @@ fun SettingsScreen(
         onTestFeedingReminder = { petSettingsVm?.onTestReminder() },
         windowSizeClass = windowSizeClass,
         selectedCategory = selectedCategory,
-        onSelectCategory = { onCategoryChange(it?.name) },
+        onSelectCategory = { onCategoryNameChange(it?.name) },
     )
 }
 

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -84,12 +84,20 @@ internal enum class SettingsCategory(
 
 @Composable
 fun SettingsScreen(
+    initialCategory: String? = null,
+    onCategoryChange: (String?) -> Unit = {},
     passwordVm: PasswordChangeViewModel = koinViewModel(),
     passkeyVm: PasskeyManagementViewModel = koinViewModel(),
     loginHistoryVm: LoginHistoryViewModel = koinViewModel(),
 ) {
     val authStateHolder = koinInject<AuthStateHolder>()
     val isAdmin = authStateHolder.isAdmin
+
+    // URL フラグメント（enum 名）→ SettingsCategory。不正値・権限外は null（カテゴリ未選択）扱い。
+    val selectedCategory =
+        initialCategory
+            ?.let { name -> SettingsCategory.entries.find { it.name == name } }
+            ?.takeIf { !it.adminOnly || isAdmin }
     val koin = getKoin()
     val userNameVm = remember(isAdmin) { if (isAdmin) koin.get<UserNameViewModel>() else null }
     val garbageVm = remember(isAdmin) { if (isAdmin) koin.get<GarbageScheduleViewModel>() else null }
@@ -228,6 +236,8 @@ fun SettingsScreen(
         onTestFeedingScheduled = { petSettingsVm?.onTestScheduled() },
         onTestFeedingReminder = { petSettingsVm?.onTestReminder() },
         windowSizeClass = windowSizeClass,
+        selectedCategory = selectedCategory,
+        onSelectCategory = { onCategoryChange(it?.name) },
     )
 }
 
@@ -360,26 +370,11 @@ internal fun SettingsContent(
     onTestFeedingScheduled: () -> Unit = {},
     onTestFeedingReminder: () -> Unit = {},
     windowSizeClass: WindowSizeClass = WindowSizeClass.Expanded,
+    selectedCategory: SettingsCategory? = null,
+    onSelectCategory: (SettingsCategory?) -> Unit = {},
 ) {
     val isCompact = windowSizeClass == WindowSizeClass.Compact
     val categories = SettingsCategory.entries.filter { !it.adminOnly || isAdmin }
-    var selectedCategory by remember { mutableStateOf<SettingsCategory?>(if (isCompact) null else categories.firstOrNull()) }
-
-    // Compact ↔ Expanded 切り替え時に selectedCategory を適切にリセット
-    LaunchedEffect(isCompact) {
-        if (isCompact) {
-            selectedCategory = null
-        } else if (selectedCategory == null) {
-            selectedCategory = categories.firstOrNull()
-        }
-    }
-
-    // isAdmin 変化等で categories から selectedCategory が除外された場合にリセット
-    LaunchedEffect(categories) {
-        if (selectedCategory != null && selectedCategory !in categories) {
-            selectedCategory = if (isCompact) null else categories.firstOrNull()
-        }
-    }
 
     val categoryContent: @Composable (SettingsCategory, Modifier) -> Unit = { category, cardModifier ->
         when (category) {
@@ -578,7 +573,7 @@ internal fun SettingsContent(
             CategoryListPane(
                 categories = categories,
                 selectedCategory = null,
-                onSelectCategory = { selectedCategory = it },
+                onSelectCategory = { onSelectCategory(it) },
                 modifier = Modifier.fillMaxSize().padding(16.dp),
             )
         } else {
@@ -588,7 +583,7 @@ internal fun SettingsContent(
                     category = selected,
                     scrollState = detailScrollState,
                     showBackButton = true,
-                    onBack = { selectedCategory = null },
+                    onBack = { onSelectCategory(null) },
                     modifier = Modifier.fillMaxSize(),
                     contentModifier = Modifier.fillMaxWidth(),
                 ) {
@@ -598,17 +593,18 @@ internal fun SettingsContent(
         }
     } else {
         // Medium / Expanded: 左カテゴリリスト + 右詳細の2ペイン
+        // フラグメント未指定時は先頭カテゴリを表示・ハイライトする（URL は変更しない）
+        val selected = selectedCategory ?: categories.firstOrNull()
         Row(modifier = Modifier.fillMaxSize()) {
             CategoryListPane(
                 categories = categories,
-                selectedCategory = selectedCategory,
-                onSelectCategory = { selectedCategory = it },
+                selectedCategory = selected,
+                onSelectCategory = { onSelectCategory(it) },
                 modifier = Modifier.width(320.dp).fillMaxHeight().padding(24.dp),
             )
 
             VerticalDivider()
 
-            val selected = selectedCategory ?: categories.firstOrNull()
             if (selected != null) {
                 key(selected) {
                     val detailScrollState = rememberScrollState()


### PR DESCRIPTION
## Summary

設定画面で開いているカテゴリを `/settings#<カテゴリ名>` の形式で URL に反映し、**リロード後も同じカテゴリを復元**できるようにしましたわ。共有・ブックマークした URL から特定のカテゴリを直接開くこと（ディープリンク）も可能になります。

`<カテゴリ名>` には `SettingsCategory` の enum 名（`Account`, `Pet`, `Garbage` など）を使用します。

## 変更内容

### `Navigator`（app）
- 画面内サブルートを表す `fragment` 状態を追加（汎用化。各画面が自前の識別子を解釈する設計）
- `init()` で `popstate` に加え `hashchange` も購読し、URL（pathname + hash）と状態を同期
- `setFragment(value)`: 画面遷移を伴わずフラグメントのみ更新（`pushState`）
- `navigateTo()`: 画面遷移時にフラグメントをクリア

### `SettingsScreen` / `SettingsContent`（feature/settings）
- `SettingsScreen` に `initialCategory: String?` / `onCategoryChange: (String?) -> Unit` を追加。`SettingsCategory` は `internal` のため、app 層とは enum 名（文字列）で受け渡しし、レイヤリングを保持
- 権限外（admin 専用）・不正なフラグメント値は未選択（null）扱い
- `SettingsContent` の選択状態を内部 `remember` から**制御コンポーネント化**（State Hoisting）。単一の真実の源を `Navigator.fragment` に統一

## 挙動

- `/settings#Account` でリロード → アカウントカテゴリを復元
- カテゴリ選択で URL が `/settings#<名前>` に更新（ブラウザの戻る/進むで前のカテゴリへ）
- Compact: 詳細表示中に戻ると一覧（フラグメントクリア）
- Expanded: フラグメント未指定時は先頭カテゴリを表示・ハイライト（URL は変更しない）

## 確認

- `./gradlew :app:compileKotlinWasmJs -PskipFrontend` → BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)