### PR TITLE
feat: OSS ライセンス一覧をクレジット画面に表示

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ out/
 # Compose / WASM
 kotlin-js-store/
 
+# AboutLibraries 生成物（ビルド時に自動生成されるため git 管理外）
+feature/settings/src/commonMain/composeResources/files/aboutlibraries.json
+
 # Environment variables
 .env
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.compose.multiplatform) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.ktor) apply false
+    alias(libs.plugins.aboutlibraries) apply false
     alias(libs.plugins.ktlint)
 }
 

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -1,5 +1,12 @@
 plugins {
     id("crabshell.feature")
+    alias(libs.plugins.aboutlibraries)
+}
+
+// OSS ライセンス一覧の JSON を compose-resources として読み込むためのリソースクラス生成
+compose.resources {
+    packageOfResClass = "feature.settings.generated"
+    generateResClass = always
 }
 
 kotlin {
@@ -10,6 +17,33 @@ kotlin {
             implementation(project(":core:network"))
             implementation(project(":core:ui"))
             implementation(project(":shared"))
+            // OSS ライセンス情報のパース。UI 同梱版 (compose-m3) は Popup を使うため core のみ採用
+            implementation(libs.aboutlibraries.core)
         }
     }
 }
+
+// 依存ライブラリのライセンス情報を composeResources へ書き出す。
+// outputFile を composeResources 配下に向けると自動メタデータ検出は無効化されるため、export を明示する。
+aboutLibraries {
+    // ブラウザへ配信される wasmJs バンドルに載る依存のみ収集（jvm/desktop variant を除外）
+    collect {
+        filterVariants.add("wasmJs")
+    }
+    export {
+        outputFile = file("src/commonMain/composeResources/files/aboutlibraries.json")
+        variant = "wasmJs"
+        prettyPrint = true
+    }
+}
+
+// compose-resources の取り込みより前に JSON を必ず生成し、依存追加時も自動反映させる
+// （生成物は git 管理外。タスク名は環境差を吸収するため接頭辞マッチで配線）
+tasks
+    .matching { task ->
+        task.name.startsWith("generateResourceAccessors") ||
+            task.name.startsWith("copyNonXmlValueResources") ||
+            task.name.startsWith("prepareComposeResources")
+    }.configureEach {
+        dependsOn("exportLibraryDefinitions")
+    }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/CreditsCard.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/CreditsCard.kt
@@ -2,6 +2,7 @@ package feature.settings
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -73,7 +74,7 @@ internal fun CreditsCard(
             Text(
                 text = "データ",
                 style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = MaterialTheme.colorScheme.primary,
             )
 
             CreditEntry(
@@ -90,10 +91,11 @@ internal fun CreditsCard(
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
 
             // OSS ライブラリ一覧
+            val sectionTitle = if (libraries.isNotEmpty()) "OSS ライブラリ (${libraries.size})" else "OSS ライブラリ"
             Text(
-                text = "OSS ライブラリ",
+                text = sectionTitle,
                 style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = MaterialTheme.colorScheme.primary,
             )
 
             when {
@@ -116,8 +118,16 @@ internal fun CreditsCard(
                 }
 
                 else -> {
-                    libraries.forEach { library ->
-                        LibraryEntry(library = library, linkStyles = linkStyles)
+                    Column(verticalArrangement = Arrangement.spacedBy(0.dp)) {
+                        libraries.forEachIndexed { index, library ->
+                            LibraryEntry(library = library, linkStyles = linkStyles)
+                            if (index < libraries.lastIndex) {
+                                HorizontalDivider(
+                                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+                                    thickness = 0.5.dp,
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -130,30 +140,49 @@ private fun LibraryEntry(
     library: Library,
     linkStyles: TextLinkStyles,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-        val nameText =
-            buildAnnotatedString {
-                val url = library.website?.takeIf { it.isNotBlank() } ?: library.scm?.url?.takeIf { it.isNotBlank() }
-                if (url != null) {
-                    withLink(
-                        LinkAnnotation.Url(
-                            url = url,
-                            styles = linkStyles,
-                            linkInteractionListener = ExternalUrlLinkInteractionListener,
-                        ),
-                    ) {
+    Column(
+        modifier = Modifier.padding(vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            val nameText =
+                buildAnnotatedString {
+                    val url =
+                        library.website?.takeIf { it.isNotBlank() }
+                            ?: library.scm?.url?.takeIf { it.isNotBlank() }
+                    if (url != null) {
+                        withLink(
+                            LinkAnnotation.Url(
+                                url = url,
+                                styles = linkStyles,
+                                linkInteractionListener = ExternalUrlLinkInteractionListener,
+                            ),
+                        ) {
+                            append(library.name)
+                        }
+                    } else {
                         append(library.name)
                     }
-                } else {
-                    append(library.name)
                 }
-                library.artifactVersion?.let { append(" $it") }
+            Text(
+                text = nameText,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.weight(1f),
+            )
+            library.artifactVersion?.let { version ->
+                Text(
+                    text = version,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                    modifier = Modifier.padding(start = 8.dp),
+                )
             }
-        Text(
-            text = nameText,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
+        }
 
         val licenseText =
             buildAnnotatedString {
@@ -164,7 +193,14 @@ private fun LibraryEntry(
                         withLink(
                             LinkAnnotation.Url(
                                 url = url,
-                                styles = linkStyles,
+                                styles =
+                                    TextLinkStyles(
+                                        style =
+                                            SpanStyle(
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                textDecoration = TextDecoration.Underline,
+                                            ),
+                                    ),
                                 linkInteractionListener = ExternalUrlLinkInteractionListener,
                             ),
                         ) {
@@ -178,7 +214,7 @@ private fun LibraryEntry(
         if (licenseText.isNotEmpty()) {
             Text(
                 text = licenseText,
-                style = MaterialTheme.typography.bodySmall,
+                style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/CreditsCard.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/CreditsCard.kt
@@ -122,7 +122,10 @@ internal fun CreditsCard(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.error,
                     )
-                    Button(onClick = onRetry) {
+                    Button(
+                        onClick = onRetry,
+                        modifier = Modifier.align(Alignment.CenterHorizontally),
+                    ) {
                         Text("再読み込み")
                     }
                 }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/CreditsCard.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/CreditsCard.kt
@@ -46,6 +46,17 @@ internal fun CreditsCard(
                     ),
             )
         }
+    val onSurfaceVariantColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val licenseLinkStyles =
+        remember(onSurfaceVariantColor) {
+            TextLinkStyles(
+                style =
+                    SpanStyle(
+                        color = onSurfaceVariantColor,
+                        textDecoration = TextDecoration.Underline,
+                    ),
+            )
+        }
 
     Card(
         modifier = modifier,
@@ -117,10 +128,22 @@ internal fun CreditsCard(
                     }
                 }
 
+                libraries.isEmpty() -> {
+                    Text(
+                        text = "ライセンス情報がありません",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
                 else -> {
-                    Column(verticalArrangement = Arrangement.spacedBy(0.dp)) {
+                    Column {
                         libraries.forEachIndexed { index, library ->
-                            LibraryEntry(library = library, linkStyles = linkStyles)
+                            LibraryEntry(
+                                library = library,
+                                linkStyles = linkStyles,
+                                licenseLinkStyles = licenseLinkStyles,
+                            )
                             if (index < libraries.lastIndex) {
                                 HorizontalDivider(
                                     color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
@@ -139,6 +162,7 @@ internal fun CreditsCard(
 private fun LibraryEntry(
     library: Library,
     linkStyles: TextLinkStyles,
+    licenseLinkStyles: TextLinkStyles,
 ) {
     Column(
         modifier = Modifier.padding(vertical = 8.dp),
@@ -193,14 +217,7 @@ private fun LibraryEntry(
                         withLink(
                             LinkAnnotation.Url(
                                 url = url,
-                                styles =
-                                    TextLinkStyles(
-                                        style =
-                                            SpanStyle(
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                textDecoration = TextDecoration.Underline,
-                                            ),
-                                    ),
+                                styles = licenseLinkStyles,
                                 linkInteractionListener = ExternalUrlLinkInteractionListener,
                             ),
                         ) {

--- a/feature/settings/src/commonMain/kotlin/feature/settings/CreditsCard.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/CreditsCard.kt
@@ -4,12 +4,17 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
@@ -18,10 +23,17 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
+import com.mikepenz.aboutlibraries.entity.Library
 import core.ui.util.ExternalUrlLinkInteractionListener
 
 @Composable
-internal fun CreditsCard(modifier: Modifier = Modifier) {
+internal fun CreditsCard(
+    isLoading: Boolean = false,
+    libraries: List<Library> = emptyList(),
+    error: String? = null,
+    onRetry: () -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
     val primaryColor = MaterialTheme.colorScheme.primary
     val linkStyles =
         remember(primaryColor) {
@@ -57,6 +69,13 @@ internal fun CreditsCard(modifier: Modifier = Modifier) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
+            // データクレジット
+            Text(
+                text = "データ",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
             CreditEntry(
                 name = "GeoLite2-City",
                 provider = "MaxMind",
@@ -66,6 +85,101 @@ internal fun CreditsCard(modifier: Modifier = Modifier) {
                 licenseUrl = "https://creativecommons.org/licenses/by-sa/4.0/",
                 attribution = "This product includes GeoLite2 Data created by MaxMind, available from https://www.maxmind.com.",
                 linkStyles = linkStyles,
+            )
+
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+
+            // OSS ライブラリ一覧
+            Text(
+                text = "OSS ライブラリ",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            when {
+                isLoading -> {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp).align(Alignment.CenterHorizontally),
+                        strokeWidth = 2.dp,
+                    )
+                }
+
+                error != null -> {
+                    Text(
+                        text = error,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                    Button(onClick = onRetry) {
+                        Text("再読み込み")
+                    }
+                }
+
+                else -> {
+                    libraries.forEach { library ->
+                        LibraryEntry(library = library, linkStyles = linkStyles)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LibraryEntry(
+    library: Library,
+    linkStyles: TextLinkStyles,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        val nameText =
+            buildAnnotatedString {
+                val url = library.website?.takeIf { it.isNotBlank() } ?: library.scm?.url?.takeIf { it.isNotBlank() }
+                if (url != null) {
+                    withLink(
+                        LinkAnnotation.Url(
+                            url = url,
+                            styles = linkStyles,
+                            linkInteractionListener = ExternalUrlLinkInteractionListener,
+                        ),
+                    ) {
+                        append(library.name)
+                    }
+                } else {
+                    append(library.name)
+                }
+                library.artifactVersion?.let { append(" $it") }
+            }
+        Text(
+            text = nameText,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+
+        val licenseText =
+            buildAnnotatedString {
+                library.licenses.forEachIndexed { index, license ->
+                    if (index > 0) append(" / ")
+                    val url = license.url?.takeIf { it.isNotBlank() }
+                    if (url != null) {
+                        withLink(
+                            LinkAnnotation.Url(
+                                url = url,
+                                styles = linkStyles,
+                                linkInteractionListener = ExternalUrlLinkInteractionListener,
+                            ),
+                        ) {
+                            append(license.name)
+                        }
+                    } else {
+                        append(license.name)
+                    }
+                }
+            }
+        if (licenseText.isNotEmpty()) {
+            Text(
+                text = licenseText,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/CreditsCard.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/CreditsCard.kt
@@ -101,10 +101,9 @@ internal fun CreditsCard(
 
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
 
-            // OSS ライブラリ一覧
-            val sectionTitle = if (libraries.isNotEmpty()) "OSS ライブラリ (${libraries.size})" else "OSS ライブラリ"
+            // OSS ライブラリ一覧（セクションラベルはロード中・エラー中も常時表示してコンテキストを提供）
             Text(
-                text = sectionTitle,
+                text = "OSS ライブラリ",
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.primary,
             )
@@ -137,6 +136,11 @@ internal fun CreditsCard(
                 }
 
                 else -> {
+                    Text(
+                        text = "${libraries.size} 件",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                     Column {
                         libraries.forEachIndexed { index, library ->
                             LibraryEntry(

--- a/feature/settings/src/commonMain/kotlin/feature/settings/LicensesViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/LicensesViewModel.kt
@@ -1,0 +1,47 @@
+package feature.settings
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.mikepenz.aboutlibraries.Libs
+import com.mikepenz.aboutlibraries.entity.Library
+import core.common.AppLogger
+import feature.settings.generated.Res
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+data class LicensesUiState(
+    val isLoading: Boolean = true,
+    val libraries: List<Library> = emptyList(),
+    val error: String? = null,
+)
+
+class LicensesViewModel : ViewModel() {
+    var uiState by mutableStateOf(LicensesUiState())
+        private set
+
+    init {
+        load()
+    }
+
+    @OptIn(ExperimentalResourceApi::class)
+    fun load() {
+        uiState = LicensesUiState(isLoading = true, error = null)
+        viewModelScope.launch {
+            try {
+                val json = Res.readBytes("files/aboutlibraries.json").decodeToString()
+                val libs = Libs.Builder().withJson(json).build()
+                uiState = LicensesUiState(isLoading = false, libraries = libs.libraries)
+            } catch (e: Exception) {
+                AppLogger.e("LicensesViewModel", "Failed to load licenses: ${e.message}")
+                uiState =
+                    LicensesUiState(
+                        isLoading = false,
+                        error = e.message ?: "ライセンス情報の読み込みに失敗しました",
+                    )
+            }
+        }
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/feature/settings/LicensesViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/LicensesViewModel.kt
@@ -35,7 +35,7 @@ class LicensesViewModel : ViewModel() {
                 val libs = Libs.Builder().withJson(json).build()
                 uiState = LicensesUiState(isLoading = false, libraries = libs.libraries)
             } catch (e: Exception) {
-                AppLogger.e("LicensesViewModel", "Failed to load licenses: ${e.message}")
+                AppLogger.e(TAG, "Failed to load licenses: ${e.message}")
                 uiState =
                     LicensesUiState(
                         isLoading = false,
@@ -43,5 +43,9 @@ class LicensesViewModel : ViewModel() {
                     )
             }
         }
+    }
+
+    companion object {
+        private const val TAG = "LicensesViewModel"
     }
 }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/LicensesViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/LicensesViewModel.kt
@@ -28,7 +28,7 @@ class LicensesViewModel : ViewModel() {
 
     @OptIn(ExperimentalResourceApi::class)
     fun loadLicenses() {
-        uiState = LicensesUiState(isLoading = true, error = null)
+        uiState = uiState.copy(isLoading = true, error = null)
         viewModelScope.launch {
             try {
                 val json = Res.readBytes("files/aboutlibraries.json").decodeToString()

--- a/feature/settings/src/commonMain/kotlin/feature/settings/LicensesViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/LicensesViewModel.kt
@@ -23,11 +23,11 @@ class LicensesViewModel : ViewModel() {
         private set
 
     init {
-        load()
+        loadLicenses()
     }
 
     @OptIn(ExperimentalResourceApi::class)
-    fun load() {
+    fun loadLicenses() {
         uiState = LicensesUiState(isLoading = true, error = null)
         viewModelScope.launch {
             try {

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.mikepenz.aboutlibraries.entity.Library
 import core.auth.AuthStateHolder
 import core.ui.LocalWindowSizeClass
 import core.ui.WindowSizeClass
@@ -89,6 +90,7 @@ fun SettingsScreen(
     passwordVm: PasswordChangeViewModel = koinViewModel(),
     passkeyVm: PasskeyManagementViewModel = koinViewModel(),
     loginHistoryVm: LoginHistoryViewModel = koinViewModel(),
+    licensesVm: LicensesViewModel = koinViewModel(),
 ) {
     val authStateHolder = koinInject<AuthStateHolder>()
     val isAdmin = authStateHolder.isAdmin
@@ -235,6 +237,10 @@ fun SettingsScreen(
         onSaveReminder = { petSettingsVm?.onSaveReminder() },
         onTestFeedingScheduled = { petSettingsVm?.onTestScheduled() },
         onTestFeedingReminder = { petSettingsVm?.onTestReminder() },
+        licensesLoading = licensesVm.uiState.isLoading,
+        libraries = licensesVm.uiState.libraries,
+        licensesError = licensesVm.uiState.error,
+        onRetryLicenses = licensesVm::load,
         windowSizeClass = windowSizeClass,
         selectedCategory = selectedCategory,
         onSelectCategory = { onCategoryNameChange(it?.name) },
@@ -341,6 +347,10 @@ internal fun SettingsContent(
     cacheClearing: Boolean = false,
     cacheMessage: String? = null,
     onClearCache: () -> Unit = {},
+    licensesLoading: Boolean = false,
+    libraries: List<Library> = emptyList(),
+    licensesError: String? = null,
+    onRetryLicenses: () -> Unit = {},
     petSettingsLoading: Boolean = false,
     pets: List<Pet> = emptyList(),
     editingPetNames: Map<String, String> = emptyMap(),
@@ -561,7 +571,13 @@ internal fun SettingsContent(
                 )
             }
             SettingsCategory.Credits -> {
-                CreditsCard(modifier = cardModifier)
+                CreditsCard(
+                    isLoading = licensesLoading,
+                    libraries = libraries,
+                    error = licensesError,
+                    onRetry = onRetryLicenses,
+                    modifier = cardModifier,
+                )
             }
         }
     }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -240,7 +240,7 @@ fun SettingsScreen(
         licensesLoading = licensesVm.uiState.isLoading,
         libraries = licensesVm.uiState.libraries,
         licensesError = licensesVm.uiState.error,
-        onRetryLicenses = licensesVm::load,
+        onRetryLicenses = licensesVm::loadLicenses,
         windowSizeClass = windowSizeClass,
         selectedCategory = selectedCategory,
         onSelectCategory = { onCategoryNameChange(it?.name) },

--- a/feature/settings/src/commonMain/kotlin/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/di/SettingsModule.kt
@@ -2,6 +2,7 @@ package feature.settings.di
 
 import feature.settings.CacheRefreshViewModel
 import feature.settings.GarbageScheduleViewModel
+import feature.settings.LicensesViewModel
 import feature.settings.LoginHistoryViewModel
 import feature.settings.MoneyWebhookViewModel
 import feature.settings.PasskeyManagementViewModel
@@ -18,6 +19,7 @@ val settingsModule =
         viewModel { PasswordChangeViewModel(get()) }
         viewModel { PasskeyManagementViewModel(get()) }
         viewModel { LoginHistoryViewModel(get()) }
+        viewModel { LicensesViewModel() }
         // Admin のみ条件付き生成
         factory { UserNameViewModel(get()) }
         factory { GarbageScheduleViewModel(get()) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ mockk = "1.14.9"
 kotlinx-coroutines = "1.11.0"
 kotlinx-browser = "0.5.0"
 maxmind-geoip2 = "4.3.0"
+aboutlibraries = "14.1.0"
 
 [libraries]
 # Koin DI
@@ -28,6 +29,9 @@ koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", ver
 
 # Lifecycle ViewModel (Compose Multiplatform)
 lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+
+# AboutLibraries (OSS ライセンス収集・JSON パーサ。Compose UI は使わず core のみ)
+aboutlibraries-core = { module = "com.mikepenz:aboutlibraries-core", version.ref = "aboutlibraries" }
 
 # Core Common
 kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser", version.ref = "kotlinx-browser" }
@@ -88,3 +92,4 @@ compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-m
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ktor = { id = "io.ktor.plugin", version.ref = "ktor" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }
+aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }


### PR DESCRIPTION
## Summary

- AboutLibraries プラグイン（v14.1.0）を `feature/settings` に導入し、ビルド時に wasmJs ターゲットの依存ライブラリ情報を `composeResources/files/aboutlibraries.json` に自動生成
- `LicensesViewModel` が起動時に JSON を非同期ロードし、`CreditsCard` に OSS ライブラリ一覧（名称・バージョン・ライセンス名、各リンク付き）を表示
- 既存「クレジット」カテゴリを拡張。GeoLite2 データクレジットの下に OSS ライブラリセクションを追加（カテゴリ追加なし）
- 同梱の `LibrariesContainer`（内部で Popup を使用）は使わず、Popup 禁止ルールに準拠したインライン Card で自前描画
- `exportLibraryDefinitions` タスクを compose-resources 生成タスクに `dependsOn` で配線し、依存追加時も自動反映。生成 JSON は git 管理外

## Test plan

- [ ] `/settings#Credits` でクレジット画面を開き、OSS ライブラリ一覧（72 件）が表示されること
- [ ] ライブラリ名クリックでプロジェクト URL へ遷移すること
- [ ] ライセンス名クリックで SPDX URL へ遷移すること
- [ ] ロード中はスピナーが表示されること
- [ ] GeoLite2 クレジットが引き続き表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)