### PR TITLE
refactor: SettingsScreen を各カテゴリ Screen に分割

### DIFF
--- a/feature/settings/src/commonMain/kotlin/feature/settings/AccountScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/AccountScreen.kt
@@ -1,0 +1,266 @@
+package feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Fingerprint
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+internal fun AccountScreen(modifier: Modifier = Modifier) {
+    val passwordVm: PasswordChangeViewModel = koinViewModel()
+    val passkeyVm: PasskeyManagementViewModel = koinViewModel()
+    val loginHistoryVm: LoginHistoryViewModel = koinViewModel()
+    val s = passwordVm.uiState
+    val pk = passkeyVm.uiState
+    val lh = loginHistoryVm.uiState
+
+    PasswordChangeCard(
+        currentPassword = s.currentPassword,
+        newPassword = s.newPassword,
+        confirmPassword = s.confirmPassword,
+        isLoading = s.isLoading,
+        errorMessage = s.errorMessage,
+        successMessage = s.successMessage,
+        onCurrentPasswordChanged = passwordVm::onCurrentPasswordChanged,
+        onNewPasswordChanged = passwordVm::onNewPasswordChanged,
+        onConfirmPasswordChanged = passwordVm::onConfirmPasswordChanged,
+        onChangePassword = passwordVm::onChangePassword,
+        modifier = modifier,
+    )
+
+    if (pk.isAvailable) {
+        PasskeyManagementCard(
+            credentialCount = pk.credentialCount,
+            isRegistering = pk.isRegistering,
+            errorMessage = pk.errorMessage,
+            successMessage = pk.successMessage,
+            onRegisterPasskey = passkeyVm::onRegisterPasskey,
+            modifier = modifier,
+        )
+    }
+
+    LoginHistoryCardContent(
+        isLoading = lh.isLoading,
+        loadError = lh.loadError,
+        loadErrorMessage = lh.loadErrorMessage,
+        events = lh.events,
+        onRetry = loginHistoryVm::loadHistory,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun PasswordChangeCard(
+    currentPassword: String,
+    newPassword: String,
+    confirmPassword: String,
+    isLoading: Boolean,
+    errorMessage: String?,
+    successMessage: String?,
+    onCurrentPasswordChanged: (String) -> Unit,
+    onNewPasswordChanged: (String) -> Unit,
+    onConfirmPasswordChanged: (String) -> Unit,
+    onChangePassword: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var currentPasswordVisible by remember { mutableStateOf(false) }
+    var newPasswordVisible by remember { mutableStateOf(false) }
+    var confirmPasswordVisible by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp).fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(imageVector = Icons.Default.Lock, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                Text(text = "パスワード変更", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+            }
+
+            OutlinedTextField(
+                value = currentPassword,
+                onValueChange = onCurrentPasswordChanged,
+                label = { Text("現在のパスワード") },
+                leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) },
+                trailingIcon = {
+                    IconButton(onClick = { currentPasswordVisible = !currentPasswordVisible }) {
+                        Icon(
+                            if (currentPasswordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                            contentDescription = if (currentPasswordVisible) "パスワードを隠す" else "パスワードを表示",
+                        )
+                    }
+                },
+                singleLine = true,
+                visualTransformation = if (currentPasswordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Next),
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !isLoading,
+            )
+
+            OutlinedTextField(
+                value = newPassword,
+                onValueChange = onNewPasswordChanged,
+                label = { Text("新しいパスワード") },
+                leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) },
+                trailingIcon = {
+                    IconButton(onClick = { newPasswordVisible = !newPasswordVisible }) {
+                        Icon(
+                            if (newPasswordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                            contentDescription = if (newPasswordVisible) "パスワードを隠す" else "パスワードを表示",
+                        )
+                    }
+                },
+                singleLine = true,
+                visualTransformation = if (newPasswordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Next),
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !isLoading,
+            )
+
+            OutlinedTextField(
+                value = confirmPassword,
+                onValueChange = onConfirmPasswordChanged,
+                label = { Text("新しいパスワード（確認）") },
+                leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) },
+                trailingIcon = {
+                    IconButton(onClick = { confirmPasswordVisible = !confirmPasswordVisible }) {
+                        Icon(
+                            if (confirmPasswordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                            contentDescription = if (confirmPasswordVisible) "パスワードを隠す" else "パスワードを表示",
+                        )
+                    }
+                },
+                singleLine = true,
+                visualTransformation = if (confirmPasswordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Done),
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !isLoading,
+            )
+
+            if (errorMessage != null) {
+                Text(text = errorMessage, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+            }
+
+            if (successMessage != null) {
+                Text(text = successMessage, color = MaterialTheme.colorScheme.primary, style = MaterialTheme.typography.bodySmall)
+            }
+
+            Button(
+                onClick = onChangePassword,
+                modifier = Modifier.height(48.dp),
+                enabled = !isLoading,
+            ) {
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                } else {
+                    Text("変更する")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PasskeyManagementCard(
+    credentialCount: Int,
+    isRegistering: Boolean,
+    errorMessage: String?,
+    successMessage: String?,
+    onRegisterPasskey: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp).fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(imageVector = Icons.Default.Fingerprint, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                Text(text = "パスキー管理", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+            }
+
+            Text(
+                text = "登録済み: $credentialCount 件",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Text(
+                text = "別の端末やブラウザからログインするには、パスキーを追加してください。",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            if (errorMessage != null) {
+                Text(text = errorMessage, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+            }
+
+            if (successMessage != null) {
+                Text(text = successMessage, color = MaterialTheme.colorScheme.primary, style = MaterialTheme.typography.bodySmall)
+            }
+
+            Button(
+                onClick = onRegisterPasskey,
+                modifier = Modifier.height(48.dp),
+                enabled = !isRegistering,
+            ) {
+                if (isRegistering) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                } else {
+                    Text("パスキーを追加")
+                }
+            }
+        }
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/feature/settings/AccountScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/AccountScreen.kt
@@ -41,17 +41,17 @@ internal fun AccountScreen(modifier: Modifier = Modifier) {
     val passwordVm: PasswordChangeViewModel = koinViewModel()
     val passkeyVm: PasskeyManagementViewModel = koinViewModel()
     val loginHistoryVm: LoginHistoryViewModel = koinViewModel()
-    val s = passwordVm.uiState
-    val pk = passkeyVm.uiState
-    val lh = loginHistoryVm.uiState
+    val passwordState = passwordVm.uiState
+    val passkeyState = passkeyVm.uiState
+    val loginHistoryState = loginHistoryVm.uiState
 
     PasswordChangeCard(
-        currentPassword = s.currentPassword,
-        newPassword = s.newPassword,
-        confirmPassword = s.confirmPassword,
-        isLoading = s.isLoading,
-        errorMessage = s.errorMessage,
-        successMessage = s.successMessage,
+        currentPassword = passwordState.currentPassword,
+        newPassword = passwordState.newPassword,
+        confirmPassword = passwordState.confirmPassword,
+        isLoading = passwordState.isLoading,
+        errorMessage = passwordState.errorMessage,
+        successMessage = passwordState.successMessage,
         onCurrentPasswordChanged = passwordVm::onCurrentPasswordChanged,
         onNewPasswordChanged = passwordVm::onNewPasswordChanged,
         onConfirmPasswordChanged = passwordVm::onConfirmPasswordChanged,
@@ -59,22 +59,22 @@ internal fun AccountScreen(modifier: Modifier = Modifier) {
         modifier = modifier,
     )
 
-    if (pk.isAvailable) {
+    if (passkeyState.isAvailable) {
         PasskeyManagementCard(
-            credentialCount = pk.credentialCount,
-            isRegistering = pk.isRegistering,
-            errorMessage = pk.errorMessage,
-            successMessage = pk.successMessage,
+            credentialCount = passkeyState.credentialCount,
+            isRegistering = passkeyState.isRegistering,
+            errorMessage = passkeyState.errorMessage,
+            successMessage = passkeyState.successMessage,
             onRegisterPasskey = passkeyVm::onRegisterPasskey,
             modifier = modifier,
         )
     }
 
     LoginHistoryCardContent(
-        isLoading = lh.isLoading,
-        loadError = lh.loadError,
-        loadErrorMessage = lh.loadErrorMessage,
-        events = lh.events,
+        isLoading = loginHistoryState.isLoading,
+        loadError = loginHistoryState.loadError,
+        loadErrorMessage = loginHistoryState.loadErrorMessage,
+        events = loginHistoryState.events,
         onRetry = loginHistoryVm::loadHistory,
         modifier = modifier,
     )

--- a/feature/settings/src/commonMain/kotlin/feature/settings/AccountScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/AccountScreen.kt
@@ -45,39 +45,41 @@ internal fun AccountScreen(modifier: Modifier = Modifier) {
     val passkeyState = passkeyVm.uiState
     val loginHistoryState = loginHistoryVm.uiState
 
-    PasswordChangeCard(
-        currentPassword = passwordState.currentPassword,
-        newPassword = passwordState.newPassword,
-        confirmPassword = passwordState.confirmPassword,
-        isLoading = passwordState.isLoading,
-        errorMessage = passwordState.errorMessage,
-        successMessage = passwordState.successMessage,
-        onCurrentPasswordChanged = passwordVm::onCurrentPasswordChanged,
-        onNewPasswordChanged = passwordVm::onNewPasswordChanged,
-        onConfirmPasswordChanged = passwordVm::onConfirmPasswordChanged,
-        onChangePassword = passwordVm::onChangePassword,
-        modifier = modifier,
-    )
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        PasswordChangeCard(
+            currentPassword = passwordState.currentPassword,
+            newPassword = passwordState.newPassword,
+            confirmPassword = passwordState.confirmPassword,
+            isLoading = passwordState.isLoading,
+            errorMessage = passwordState.errorMessage,
+            successMessage = passwordState.successMessage,
+            onCurrentPasswordChanged = passwordVm::onCurrentPasswordChanged,
+            onNewPasswordChanged = passwordVm::onNewPasswordChanged,
+            onConfirmPasswordChanged = passwordVm::onConfirmPasswordChanged,
+            onChangePassword = passwordVm::onChangePassword,
+            modifier = Modifier.fillMaxWidth(),
+        )
 
-    if (passkeyState.isAvailable) {
-        PasskeyManagementCard(
-            credentialCount = passkeyState.credentialCount,
-            isRegistering = passkeyState.isRegistering,
-            errorMessage = passkeyState.errorMessage,
-            successMessage = passkeyState.successMessage,
-            onRegisterPasskey = passkeyVm::onRegisterPasskey,
-            modifier = modifier,
+        if (passkeyState.isAvailable) {
+            PasskeyManagementCard(
+                credentialCount = passkeyState.credentialCount,
+                isRegistering = passkeyState.isRegistering,
+                errorMessage = passkeyState.errorMessage,
+                successMessage = passkeyState.successMessage,
+                onRegisterPasskey = passkeyVm::onRegisterPasskey,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+
+        LoginHistoryCardContent(
+            isLoading = loginHistoryState.isLoading,
+            loadError = loginHistoryState.loadError,
+            loadErrorMessage = loginHistoryState.loadErrorMessage,
+            events = loginHistoryState.events,
+            onRetry = loginHistoryVm::loadHistory,
+            modifier = Modifier.fillMaxWidth(),
         )
     }
-
-    LoginHistoryCardContent(
-        isLoading = loginHistoryState.isLoading,
-        loadError = loginHistoryState.loadError,
-        loadErrorMessage = loginHistoryState.loadErrorMessage,
-        events = loginHistoryState.events,
-        onRetry = loginHistoryVm::loadHistory,
-        modifier = modifier,
-    )
 }
 
 @Composable

--- a/feature/settings/src/commonMain/kotlin/feature/settings/CacheScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/CacheScreen.kt
@@ -1,0 +1,80 @@
+package feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+internal fun CacheScreen(modifier: Modifier = Modifier) {
+    val vm: CacheRefreshViewModel = koinViewModel()
+    CacheRefreshCard(
+        isClearing = vm.uiState.isClearing,
+        message = vm.uiState.message,
+        onClearCache = vm::onClearCache,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun CacheRefreshCard(
+    isClearing: Boolean,
+    message: String?,
+    onClearCache: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier,
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            ),
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp).fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = "データの不整合が疑われる場合に、サーバー側のキャッシュを手動でクリアします。",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            if (message != null) {
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+
+            Button(
+                onClick = onClearCache,
+                modifier = Modifier.height(48.dp),
+                enabled = !isClearing,
+            ) {
+                if (isClearing) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                } else {
+                    Text("キャッシュをクリア")
+                }
+            }
+        }
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/feature/settings/CreditsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/CreditsScreen.kt
@@ -1,0 +1,17 @@
+package feature.settings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+internal fun CreditsScreen(modifier: Modifier = Modifier) {
+    val vm: LicensesViewModel = koinViewModel()
+    CreditsCard(
+        isLoading = vm.uiState.isLoading,
+        libraries = vm.uiState.libraries,
+        error = vm.uiState.error,
+        onRetry = vm::loadLicenses,
+        modifier = modifier,
+    )
+}

--- a/feature/settings/src/commonMain/kotlin/feature/settings/GarbageScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/GarbageScreen.kt
@@ -46,39 +46,41 @@ internal fun GarbageScreen(modifier: Modifier = Modifier) {
     val vm: GarbageScheduleViewModel = koinViewModel()
     val s = vm.uiState
 
-    GarbageScheduleCard(
-        isLoading = s.isLoading,
-        loadError = s.loadError,
-        loadErrorMessage = s.loadErrorMessage,
-        schedules = s.schedules,
-        garbageMessage = s.message,
-        garbageSaving = s.isSaving,
-        onToggleDay = vm::onToggleDay,
-        onFrequencyChange = vm::onChangeFrequency,
-        onSaveClick = vm::onSaveSchedule,
-        onRetry = vm::loadSchedules,
-        modifier = modifier,
-    )
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        GarbageScheduleCard(
+            isLoading = s.isLoading,
+            loadError = s.loadError,
+            loadErrorMessage = s.loadErrorMessage,
+            schedules = s.schedules,
+            garbageMessage = s.message,
+            garbageSaving = s.isSaving,
+            onToggleDay = vm::onToggleDay,
+            onFrequencyChange = vm::onChangeFrequency,
+            onSaveClick = vm::onSaveSchedule,
+            onRetry = vm::loadSchedules,
+            modifier = Modifier.fillMaxWidth(),
+        )
 
-    GarbageNotificationCard(
-        isLoading = s.notificationLoading,
-        loadError = s.notificationLoadError,
-        loadErrorMessage = s.notificationLoadErrorMessage,
-        enabled = s.notificationEnabled,
-        webhookUrl = s.notificationWebhookUrl,
-        notifyHour = s.notificationHour,
-        prefix = s.notificationPrefix,
-        isSaving = s.notificationSaving,
-        isHourValid = s.isNotificationHourValid,
-        message = s.notificationMessage,
-        onEnabledChanged = vm::onNotificationEnabledChanged,
-        onWebhookUrlChanged = vm::onNotificationWebhookUrlChanged,
-        onNotifyHourChanged = vm::onNotificationHourChanged,
-        onPrefixChanged = vm::onNotificationPrefixChanged,
-        onSave = vm::onSaveNotificationSettings,
-        onRetry = vm::loadNotificationSettings,
-        modifier = modifier,
-    )
+        GarbageNotificationCard(
+            isLoading = s.notificationLoading,
+            loadError = s.notificationLoadError,
+            loadErrorMessage = s.notificationLoadErrorMessage,
+            enabled = s.notificationEnabled,
+            webhookUrl = s.notificationWebhookUrl,
+            notifyHour = s.notificationHour,
+            prefix = s.notificationPrefix,
+            isSaving = s.notificationSaving,
+            isHourValid = s.isNotificationHourValid,
+            message = s.notificationMessage,
+            onEnabledChanged = vm::onNotificationEnabledChanged,
+            onWebhookUrlChanged = vm::onNotificationWebhookUrlChanged,
+            onNotifyHourChanged = vm::onNotificationHourChanged,
+            onPrefixChanged = vm::onNotificationPrefixChanged,
+            onSave = vm::onSaveNotificationSettings,
+            onRetry = vm::loadNotificationSettings,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
 }
 
 @Composable

--- a/feature/settings/src/commonMain/kotlin/feature/settings/GarbageScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/GarbageScreen.kt
@@ -1,0 +1,240 @@
+package feature.settings
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import core.ui.components.LoadableCardContent
+import core.ui.extensions.color
+import core.ui.extensions.icon
+import core.ui.extensions.label
+import model.CollectionFrequency
+import model.GarbageType
+import model.GarbageTypeSchedule
+import org.koin.compose.viewmodel.koinViewModel
+
+private val dayLabels = listOf("日", "月", "火", "水", "木", "金", "土")
+
+@Composable
+internal fun GarbageScreen(modifier: Modifier = Modifier) {
+    val vm: GarbageScheduleViewModel = koinViewModel()
+    val s = vm.uiState
+
+    GarbageScheduleCard(
+        isLoading = s.isLoading,
+        loadError = s.loadError,
+        loadErrorMessage = s.loadErrorMessage,
+        schedules = s.schedules,
+        garbageMessage = s.message,
+        garbageSaving = s.isSaving,
+        onToggleDay = vm::onToggleDay,
+        onFrequencyChange = vm::onChangeFrequency,
+        onSaveClick = vm::onSaveSchedule,
+        onRetry = vm::loadSchedules,
+        modifier = modifier,
+    )
+
+    GarbageNotificationCard(
+        isLoading = s.notificationLoading,
+        loadError = s.notificationLoadError,
+        loadErrorMessage = s.notificationLoadErrorMessage,
+        enabled = s.notificationEnabled,
+        webhookUrl = s.notificationWebhookUrl,
+        notifyHour = s.notificationHour,
+        prefix = s.notificationPrefix,
+        isSaving = s.notificationSaving,
+        isHourValid = s.isNotificationHourValid,
+        message = s.notificationMessage,
+        onEnabledChanged = vm::onNotificationEnabledChanged,
+        onWebhookUrlChanged = vm::onNotificationWebhookUrlChanged,
+        onNotifyHourChanged = vm::onNotificationHourChanged,
+        onPrefixChanged = vm::onNotificationPrefixChanged,
+        onSave = vm::onSaveNotificationSettings,
+        onRetry = vm::loadNotificationSettings,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun GarbageScheduleCard(
+    isLoading: Boolean,
+    loadError: Boolean = false,
+    loadErrorMessage: String? = null,
+    schedules: List<GarbageTypeSchedule>,
+    garbageMessage: String?,
+    garbageSaving: Boolean,
+    onToggleDay: (GarbageType, Int) -> Unit,
+    onFrequencyChange: (GarbageType, CollectionFrequency) -> Unit,
+    onSaveClick: () -> Unit,
+    onRetry: () -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        LoadableCardContent(isLoading = isLoading, loadError = loadError, loadErrorMessage = loadErrorMessage, onRetry = onRetry) {
+            Column(
+                modifier = Modifier.padding(24.dp).fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                for (schedule in schedules) {
+                    val garbageType = schedule.garbageType
+                    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Icon(imageVector = garbageType.icon, contentDescription = null, tint = garbageType.color)
+                            Text(
+                                text = garbageType.label,
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                        }
+
+                        Text(
+                            text = "収集曜日",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                            for (dayIndex in 0..6) {
+                                val selected = dayIndex in schedule.daysOfWeek
+                                FilterChip(
+                                    selected = selected,
+                                    onClick = { onToggleDay(garbageType, dayIndex) },
+                                    label = { Text(dayLabels[dayIndex]) },
+                                    border =
+                                        if (selected) {
+                                            BorderStroke(1.dp, garbageType.color)
+                                        } else {
+                                            FilterChipDefaults.filterChipBorder(enabled = true, selected = false)
+                                        },
+                                )
+                            }
+                        }
+
+                        Text(
+                            text = "収集頻度",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        SingleChoiceSegmentedButtonRow {
+                            CollectionFrequency.entries.forEachIndexed { index, freq ->
+                                SegmentedButton(
+                                    selected = schedule.frequency == freq,
+                                    onClick = { onFrequencyChange(garbageType, freq) },
+                                    shape = SegmentedButtonDefaults.itemShape(index = index, count = CollectionFrequency.entries.size),
+                                ) {
+                                    Text(text = freq.label, style = MaterialTheme.typography.labelSmall)
+                                }
+                            }
+                        }
+                    }
+
+                    if (schedule != schedules.lastOrNull()) {
+                        HorizontalDivider(thickness = 1.dp, color = MaterialTheme.colorScheme.outlineVariant)
+                    }
+                }
+
+                if (garbageMessage != null) {
+                    Text(text = garbageMessage, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
+                }
+
+                Button(onClick = onSaveClick, modifier = Modifier.height(48.dp), enabled = !garbageSaving) {
+                    if (garbageSaving) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                        )
+                    } else {
+                        Text("保存する")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GarbageNotificationCard(
+    isLoading: Boolean,
+    loadError: Boolean = false,
+    loadErrorMessage: String? = null,
+    enabled: Boolean,
+    webhookUrl: String,
+    notifyHour: String,
+    prefix: String,
+    isSaving: Boolean,
+    isHourValid: Boolean,
+    message: String?,
+    onEnabledChanged: (Boolean) -> Unit,
+    onWebhookUrlChanged: (String) -> Unit,
+    onNotifyHourChanged: (String) -> Unit,
+    onPrefixChanged: (String) -> Unit,
+    onSave: () -> Unit,
+    onRetry: () -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    WebhookSettingsCard(
+        isLoading = isLoading,
+        title = "リマインダー通知",
+        featureEnabled = enabled,
+        url = webhookUrl,
+        onUrlChanged = onWebhookUrlChanged,
+        isSaving = isSaving,
+        onEnabledChanged = onEnabledChanged,
+        onSave = onSave,
+        modifier = modifier,
+        loadError = loadError,
+        loadErrorMessage = loadErrorMessage,
+        onRetry = onRetry,
+        description = "この時刻に翌日のゴミ出し情報を通知します。ダッシュボードの表示切替は毎日 10:00 固定です。",
+        message = prefix,
+        onMessageChanged = onPrefixChanged,
+        messagePlaceholder = "",
+        statusMessage = message,
+        saveEnabled = !isSaving && isHourValid,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(text = "通知時刻", style = MaterialTheme.typography.bodyMedium, modifier = Modifier.width(80.dp))
+            OutlinedTextField(
+                value = notifyHour,
+                onValueChange = { v -> onNotifyHourChanged(v.filter { it.isDigit() }.take(2)) },
+                label = { Text("時") },
+                singleLine = true,
+                isError = !isHourValid,
+                modifier = Modifier.width(72.dp),
+                enabled = !isSaving,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                textStyle = MaterialTheme.typography.bodyMedium.copy(textAlign = TextAlign.Center),
+            )
+            Text(": 00", style = MaterialTheme.typography.titleMedium)
+        }
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/feature/settings/MoneyScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/MoneyScreen.kt
@@ -1,0 +1,51 @@
+package feature.settings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+internal fun MoneyScreen(modifier: Modifier = Modifier) {
+    val moneyVm: MoneyWebhookViewModel = koinViewModel()
+    val paymentVm: PaymentWebhookViewModel = koinViewModel()
+    val m = moneyVm.uiState
+    val p = paymentVm.uiState
+
+    WebhookSettingsCard(
+        isLoading = m.isLoading,
+        title = "ステータス確定通知",
+        featureEnabled = m.enabled,
+        url = m.url,
+        onUrlChanged = moneyVm::onUrlChanged,
+        isSaving = m.isSaving,
+        onEnabledChanged = moneyVm::onEnabledChanged,
+        onSave = moneyVm::onSave,
+        modifier = modifier,
+        loadError = m.loadError,
+        loadErrorMessage = m.loadErrorMessage,
+        onRetry = moneyVm::loadSettings,
+        description = "月のお金ステータスを「確定済み」に切り替えた際に Webhook で通知します。",
+        message = m.message,
+        onMessageChanged = moneyVm::onMessageChanged,
+        statusMessage = m.statusMessage,
+    )
+
+    WebhookSettingsCard(
+        isLoading = p.isLoading,
+        title = "入金通知",
+        featureEnabled = p.enabled,
+        url = p.url,
+        onUrlChanged = paymentVm::onUrlChanged,
+        isSaving = p.isSaving,
+        onEnabledChanged = paymentVm::onEnabledChanged,
+        onSave = paymentVm::onSave,
+        modifier = modifier,
+        loadError = p.loadError,
+        loadErrorMessage = p.loadErrorMessage,
+        onRetry = paymentVm::loadSettings,
+        description = "ユーザーが入金を登録した際に Webhook で通知します。",
+        message = p.message,
+        onMessageChanged = paymentVm::onMessageChanged,
+        statusMessage = p.statusMessage,
+    )
+}

--- a/feature/settings/src/commonMain/kotlin/feature/settings/MoneyScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/MoneyScreen.kt
@@ -1,51 +1,57 @@
 package feature.settings
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 internal fun MoneyScreen(modifier: Modifier = Modifier) {
     val moneyVm: MoneyWebhookViewModel = koinViewModel()
     val paymentVm: PaymentWebhookViewModel = koinViewModel()
-    val m = moneyVm.uiState
-    val p = paymentVm.uiState
+    val moneyState = moneyVm.uiState
+    val paymentState = paymentVm.uiState
 
-    WebhookSettingsCard(
-        isLoading = m.isLoading,
-        title = "ステータス確定通知",
-        featureEnabled = m.enabled,
-        url = m.url,
-        onUrlChanged = moneyVm::onUrlChanged,
-        isSaving = m.isSaving,
-        onEnabledChanged = moneyVm::onEnabledChanged,
-        onSave = moneyVm::onSave,
-        modifier = modifier,
-        loadError = m.loadError,
-        loadErrorMessage = m.loadErrorMessage,
-        onRetry = moneyVm::loadSettings,
-        description = "月のお金ステータスを「確定済み」に切り替えた際に Webhook で通知します。",
-        message = m.message,
-        onMessageChanged = moneyVm::onMessageChanged,
-        statusMessage = m.statusMessage,
-    )
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        WebhookSettingsCard(
+            isLoading = moneyState.isLoading,
+            title = "ステータス確定通知",
+            featureEnabled = moneyState.enabled,
+            url = moneyState.url,
+            onUrlChanged = moneyVm::onUrlChanged,
+            isSaving = moneyState.isSaving,
+            onEnabledChanged = moneyVm::onEnabledChanged,
+            onSave = moneyVm::onSave,
+            modifier = Modifier.fillMaxWidth(),
+            loadError = moneyState.loadError,
+            loadErrorMessage = moneyState.loadErrorMessage,
+            onRetry = moneyVm::loadSettings,
+            description = "月のお金ステータスを「確定済み」に切り替えた際に Webhook で通知します。",
+            message = moneyState.message,
+            onMessageChanged = moneyVm::onMessageChanged,
+            statusMessage = moneyState.statusMessage,
+        )
 
-    WebhookSettingsCard(
-        isLoading = p.isLoading,
-        title = "入金通知",
-        featureEnabled = p.enabled,
-        url = p.url,
-        onUrlChanged = paymentVm::onUrlChanged,
-        isSaving = p.isSaving,
-        onEnabledChanged = paymentVm::onEnabledChanged,
-        onSave = paymentVm::onSave,
-        modifier = modifier,
-        loadError = p.loadError,
-        loadErrorMessage = p.loadErrorMessage,
-        onRetry = paymentVm::loadSettings,
-        description = "ユーザーが入金を登録した際に Webhook で通知します。",
-        message = p.message,
-        onMessageChanged = paymentVm::onMessageChanged,
-        statusMessage = p.statusMessage,
-    )
+        WebhookSettingsCard(
+            isLoading = paymentState.isLoading,
+            title = "入金通知",
+            featureEnabled = paymentState.enabled,
+            url = paymentState.url,
+            onUrlChanged = paymentVm::onUrlChanged,
+            isSaving = paymentState.isSaving,
+            onEnabledChanged = paymentVm::onEnabledChanged,
+            onSave = paymentVm::onSave,
+            modifier = Modifier.fillMaxWidth(),
+            loadError = paymentState.loadError,
+            loadErrorMessage = paymentState.loadErrorMessage,
+            onRetry = paymentVm::loadSettings,
+            description = "ユーザーが入金を登録した際に Webhook で通知します。",
+            message = paymentState.message,
+            onMessageChanged = paymentVm::onMessageChanged,
+            statusMessage = paymentState.statusMessage,
+        )
+    }
 }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/PetScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/PetScreen.kt
@@ -1,10 +1,14 @@
 package feature.settings
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -19,40 +23,42 @@ internal fun PetScreen(modifier: Modifier = Modifier) {
         return
     }
 
-    PetNameCard(
-        pets = s.pets,
-        editingPetNames = s.editingPetNames,
-        isSaving = s.petNameSaving,
-        message = s.petNameMessage,
-        onPetNameChanged = vm::onPetNameChanged,
-        onSavePetName = vm::onSavePetName,
-        modifier = modifier,
-    )
-    FeedingSettingsCard(
-        mealOrder = s.mealOrder,
-        mealTimes = s.mealTimes,
-        isSaving = s.feedingSaving,
-        message = s.feedingMessage,
-        onMealOrderChanged = vm::onMealOrderChanged,
-        onMealTimeChanged = vm::onMealTimeChanged,
-        onSave = vm::onSaveFeeding,
-        modifier = modifier,
-    )
-    FeedingReminderCard(
-        reminderEnabled = s.reminderEnabled,
-        reminderWebhookUrl = s.reminderWebhookUrl,
-        reminderDelayMinutes = s.reminderDelayMinutes,
-        reminderPrefix = s.reminderPrefix,
-        isSaving = s.reminderSaving,
-        testingPhase = s.testingPhase,
-        message = s.reminderMessage,
-        onReminderEnabledChanged = vm::onReminderEnabledChanged,
-        onReminderWebhookUrlChanged = vm::onReminderWebhookUrlChanged,
-        onReminderDelayMinutesChanged = vm::onReminderDelayMinutesChanged,
-        onReminderPrefixChanged = vm::onReminderPrefixChanged,
-        onSave = vm::onSaveReminder,
-        onTestScheduled = vm::onTestScheduled,
-        onTestReminder = vm::onTestReminder,
-        modifier = modifier,
-    )
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        PetNameCard(
+            pets = s.pets,
+            editingPetNames = s.editingPetNames,
+            isSaving = s.petNameSaving,
+            message = s.petNameMessage,
+            onPetNameChanged = vm::onPetNameChanged,
+            onSavePetName = vm::onSavePetName,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        FeedingSettingsCard(
+            mealOrder = s.mealOrder,
+            mealTimes = s.mealTimes,
+            isSaving = s.feedingSaving,
+            message = s.feedingMessage,
+            onMealOrderChanged = vm::onMealOrderChanged,
+            onMealTimeChanged = vm::onMealTimeChanged,
+            onSave = vm::onSaveFeeding,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        FeedingReminderCard(
+            reminderEnabled = s.reminderEnabled,
+            reminderWebhookUrl = s.reminderWebhookUrl,
+            reminderDelayMinutes = s.reminderDelayMinutes,
+            reminderPrefix = s.reminderPrefix,
+            isSaving = s.reminderSaving,
+            testingPhase = s.testingPhase,
+            message = s.reminderMessage,
+            onReminderEnabledChanged = vm::onReminderEnabledChanged,
+            onReminderWebhookUrlChanged = vm::onReminderWebhookUrlChanged,
+            onReminderDelayMinutesChanged = vm::onReminderDelayMinutesChanged,
+            onReminderPrefixChanged = vm::onReminderPrefixChanged,
+            onSave = vm::onSaveReminder,
+            onTestScheduled = vm::onTestScheduled,
+            onTestReminder = vm::onTestReminder,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
 }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/PetScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/PetScreen.kt
@@ -1,7 +1,9 @@
 package feature.settings
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -11,7 +13,9 @@ internal fun PetScreen(modifier: Modifier = Modifier) {
     val s = vm.uiState
 
     if (s.isLoading) {
-        CircularProgressIndicator()
+        Box(modifier = modifier, contentAlignment = Alignment.Center) {
+            CircularProgressIndicator()
+        }
         return
     }
 

--- a/feature/settings/src/commonMain/kotlin/feature/settings/PetScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/PetScreen.kt
@@ -1,0 +1,54 @@
+package feature.settings
+
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+internal fun PetScreen(modifier: Modifier = Modifier) {
+    val vm: PetSettingsViewModel = koinViewModel()
+    val s = vm.uiState
+
+    if (s.isLoading) {
+        CircularProgressIndicator()
+        return
+    }
+
+    PetNameCard(
+        pets = s.pets,
+        editingPetNames = s.editingPetNames,
+        isSaving = s.petNameSaving,
+        message = s.petNameMessage,
+        onPetNameChanged = vm::onPetNameChanged,
+        onSavePetName = vm::onSavePetName,
+        modifier = modifier,
+    )
+    FeedingSettingsCard(
+        mealOrder = s.mealOrder,
+        mealTimes = s.mealTimes,
+        isSaving = s.feedingSaving,
+        message = s.feedingMessage,
+        onMealOrderChanged = vm::onMealOrderChanged,
+        onMealTimeChanged = vm::onMealTimeChanged,
+        onSave = vm::onSaveFeeding,
+        modifier = modifier,
+    )
+    FeedingReminderCard(
+        reminderEnabled = s.reminderEnabled,
+        reminderWebhookUrl = s.reminderWebhookUrl,
+        reminderDelayMinutes = s.reminderDelayMinutes,
+        reminderPrefix = s.reminderPrefix,
+        isSaving = s.reminderSaving,
+        testingPhase = s.testingPhase,
+        message = s.reminderMessage,
+        onReminderEnabledChanged = vm::onReminderEnabledChanged,
+        onReminderWebhookUrlChanged = vm::onReminderWebhookUrlChanged,
+        onReminderDelayMinutesChanged = vm::onReminderDelayMinutesChanged,
+        onReminderPrefixChanged = vm::onReminderPrefixChanged,
+        onSave = vm::onSaveReminder,
+        onTestScheduled = vm::onTestScheduled,
+        onTestReminder = vm::onTestReminder,
+        modifier = modifier,
+    )
+}

--- a/feature/settings/src/commonMain/kotlin/feature/settings/QuestScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/QuestScreen.kt
@@ -1,0 +1,81 @@
+package feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import model.QuestWebhookEvent
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+internal fun QuestScreen(modifier: Modifier = Modifier) {
+    val vm: QuestWebhookViewModel = koinViewModel()
+    val s = vm.uiState
+
+    QuestWebhookSettingsCard(
+        isLoading = s.isLoading,
+        loadError = s.loadError,
+        loadErrorMessage = s.loadErrorMessage,
+        url = s.url,
+        enabled = s.enabled,
+        events = s.events,
+        isSaving = s.isSaving,
+        message = s.message,
+        onUrlChanged = vm::onUrlChanged,
+        onEnabledChanged = vm::onEnabledChanged,
+        onToggleEvent = vm::onToggleEvent,
+        onSave = vm::onSave,
+        onRetry = vm::loadSettings,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun QuestWebhookSettingsCard(
+    isLoading: Boolean,
+    loadError: Boolean = false,
+    loadErrorMessage: String? = null,
+    url: String,
+    enabled: Boolean,
+    events: List<String>,
+    isSaving: Boolean,
+    message: String?,
+    onUrlChanged: (String) -> Unit,
+    onEnabledChanged: (Boolean) -> Unit,
+    onToggleEvent: (String) -> Unit,
+    onSave: () -> Unit,
+    onRetry: () -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    WebhookSettingsCard(
+        isLoading = isLoading,
+        title = "Webhook 通知",
+        featureEnabled = enabled,
+        url = url,
+        onUrlChanged = onUrlChanged,
+        isSaving = isSaving,
+        onEnabledChanged = onEnabledChanged,
+        onSave = onSave,
+        modifier = modifier,
+        loadError = loadError,
+        loadErrorMessage = loadErrorMessage,
+        onRetry = onRetry,
+        statusMessage = message,
+    ) {
+        Text("通知するイベント", style = androidx.compose.material3.MaterialTheme.typography.labelMedium)
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            QuestWebhookEvent.all.forEach { event ->
+                FilterChip(
+                    selected = event in events,
+                    onClick = { onToggleEvent(event) },
+                    label = { Text(QuestWebhookEvent.label(event)) },
+                )
+            }
+        }
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/feature/settings/QuestScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/QuestScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -67,7 +68,7 @@ private fun QuestWebhookSettingsCard(
         onRetry = onRetry,
         statusMessage = message,
     ) {
-        Text("通知するイベント", style = androidx.compose.material3.MaterialTheme.typography.labelMedium)
+        Text("通知するイベント", style = MaterialTheme.typography.labelMedium)
         FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             QuestWebhookEvent.all.forEach { event ->
                 FilterChip(

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -1,8 +1,23 @@
 package feature.settings
 
-import androidx.compose.foundation.*
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.ScrollbarStyle
+import androidx.compose.foundation.VerticalScrollbar
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.rememberScrollbarAdapter
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccountBalance
@@ -10,60 +25,28 @@ import androidx.compose.material.icons.filled.Cached
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Copyright
 import androidx.compose.material.icons.filled.DeleteSweep
-import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.Group
-import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Pets
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.filled.VisibilityOff
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.mikepenz.aboutlibraries.entity.Library
 import core.auth.AuthStateHolder
 import core.ui.LocalWindowSizeClass
 import core.ui.WindowSizeClass
 import core.ui.components.AdminBadge
-import core.ui.components.LoadableCardContent
-import core.ui.extensions.color
-import core.ui.extensions.icon
-import core.ui.extensions.label
-import model.CollectionFrequency
-import model.FeedingSettings
-import model.GarbageType
-import model.GarbageTypeSchedule
-import model.LoginEvent
-import model.MealTime
-import model.Pet
-import model.QuestWebhookEvent
-import model.User
-import org.koin.compose.getKoin
 import org.koin.compose.koinInject
-import org.koin.compose.viewmodel.koinViewModel
-
-private val dayLabels = listOf("日", "月", "火", "水", "木", "金", "土")
-
-@Composable
-private fun settingsScrollbarStyle() =
-    ScrollbarStyle(
-        minimalHeight = 48.dp,
-        thickness = 8.dp,
-        shape = MaterialTheme.shapes.small,
-        hoverDurationMillis = 300,
-        unhoverColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
-        hoverColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
-    )
 
 internal enum class SettingsCategory(
     val title: String,
@@ -87,160 +70,17 @@ internal enum class SettingsCategory(
 fun SettingsScreen(
     categoryName: String? = null,
     onCategoryNameChange: (String?) -> Unit = {},
-    passwordVm: PasswordChangeViewModel = koinViewModel(),
-    passkeyVm: PasskeyManagementViewModel = koinViewModel(),
-    loginHistoryVm: LoginHistoryViewModel = koinViewModel(),
-    licensesVm: LicensesViewModel = koinViewModel(),
 ) {
     val authStateHolder = koinInject<AuthStateHolder>()
     val isAdmin = authStateHolder.isAdmin
-
-    // URL フラグメント（enum 名）→ SettingsCategory。不正値・権限外は null（カテゴリ未選択）扱い。
     val selectedCategory =
         categoryName
             ?.let { name -> SettingsCategory.entries.find { it.name == name } }
             ?.takeIf { !it.adminOnly || isAdmin }
-    val koin = getKoin()
-    val userNameVm = remember(isAdmin) { if (isAdmin) koin.get<UserNameViewModel>() else null }
-    val garbageVm = remember(isAdmin) { if (isAdmin) koin.get<GarbageScheduleViewModel>() else null }
-    val questWebhookVm = remember(isAdmin) { if (isAdmin) koin.get<QuestWebhookViewModel>() else null }
-    val moneyWebhookVm = remember(isAdmin) { if (isAdmin) koin.get<MoneyWebhookViewModel>() else null }
-    val paymentWebhookVm = remember(isAdmin) { if (isAdmin) koin.get<PaymentWebhookViewModel>() else null }
-    val cacheVm = remember(isAdmin) { if (isAdmin) koin.get<CacheRefreshViewModel>() else null }
-    val petSettingsVm = remember(isAdmin) { if (isAdmin) koin.get<PetSettingsViewModel>() else null }
     val windowSizeClass = LocalWindowSizeClass.current
 
     SettingsContent(
         isAdmin = isAdmin,
-        loginHistoryLoading = loginHistoryVm.uiState.isLoading,
-        loginHistoryLoadError = loginHistoryVm.uiState.loadError,
-        loginHistoryLoadErrorMessage = loginHistoryVm.uiState.loadErrorMessage,
-        loginHistoryEvents = loginHistoryVm.uiState.events,
-        onRetryLoginHistory = loginHistoryVm::loadHistory,
-        currentPassword = passwordVm.uiState.currentPassword,
-        newPassword = passwordVm.uiState.newPassword,
-        confirmPassword = passwordVm.uiState.confirmPassword,
-        isLoading = passwordVm.uiState.isLoading,
-        errorMessage = passwordVm.uiState.errorMessage,
-        successMessage = passwordVm.uiState.successMessage,
-        onCurrentPasswordChanged = passwordVm::onCurrentPasswordChanged,
-        onNewPasswordChanged = passwordVm::onNewPasswordChanged,
-        onConfirmPasswordChanged = passwordVm::onConfirmPasswordChanged,
-        onChangePassword = passwordVm::onChangePassword,
-        passkeyAvailable = passkeyVm.uiState.isAvailable,
-        passkeyRegistering = passkeyVm.uiState.isRegistering,
-        credentialCount = passkeyVm.uiState.credentialCount,
-        passkeyError = passkeyVm.uiState.errorMessage,
-        passkeySuccess = passkeyVm.uiState.successMessage,
-        onRegisterPasskey = passkeyVm::onRegisterPasskey,
-        usersLoading = userNameVm?.uiState?.isLoading ?: false,
-        usersLoadError = userNameVm?.uiState?.loadError ?: false,
-        users = userNameVm?.uiState?.users ?: emptyList(),
-        usersSaving = userNameVm?.uiState?.isSaving ?: false,
-        usersMessage = userNameVm?.uiState?.message,
-        onUpdateDisplayName = { uid, name -> userNameVm?.onUpdateDisplayName(uid, name) },
-        onRetryUsers = { userNameVm?.loadUsers() },
-        usersLoadErrorMessage = userNameVm?.uiState?.loadErrorMessage,
-        garbageLoading = garbageVm?.uiState?.isLoading ?: false,
-        garbageLoadError = garbageVm?.uiState?.loadError ?: false,
-        garbageLoadErrorMessage = garbageVm?.uiState?.loadErrorMessage,
-        garbageSchedules = garbageVm?.uiState?.schedules ?: emptyList(),
-        garbageMessage = garbageVm?.uiState?.message,
-        garbageSaving = garbageVm?.uiState?.isSaving ?: false,
-        onToggleDay = { type, day -> garbageVm?.onToggleDay(type, day) },
-        onFrequencyChange = { type, freq -> garbageVm?.onChangeFrequency(type, freq) },
-        onSaveGarbageSchedule = { garbageVm?.onSaveSchedule() },
-        onRetryGarbageSchedule = { garbageVm?.loadSchedules() },
-        garbageNotificationLoading = garbageVm?.uiState?.notificationLoading ?: false,
-        garbageNotificationLoadError = garbageVm?.uiState?.notificationLoadError ?: false,
-        garbageNotificationLoadErrorMessage = garbageVm?.uiState?.notificationLoadErrorMessage,
-        garbageNotificationEnabled = garbageVm?.uiState?.notificationEnabled ?: false,
-        garbageNotificationWebhookUrl = garbageVm?.uiState?.notificationWebhookUrl ?: "",
-        garbageNotificationHour = garbageVm?.uiState?.notificationHour ?: "10",
-        garbageNotificationPrefix = garbageVm?.uiState?.notificationPrefix ?: "",
-        garbageNotificationSaving = garbageVm?.uiState?.notificationSaving ?: false,
-        garbageNotificationHourValid = garbageVm?.uiState?.isNotificationHourValid ?: true,
-        garbageNotificationMessage = garbageVm?.uiState?.notificationMessage,
-        onGarbageNotificationEnabledChanged = { garbageVm?.onNotificationEnabledChanged(it) },
-        onGarbageNotificationWebhookUrlChanged = { garbageVm?.onNotificationWebhookUrlChanged(it) },
-        onGarbageNotificationHourChanged = { garbageVm?.onNotificationHourChanged(it) },
-        onGarbageNotificationPrefixChanged = { garbageVm?.onNotificationPrefixChanged(it) },
-        onSaveGarbageNotification = { garbageVm?.onSaveNotificationSettings() },
-        onRetryGarbageNotification = { garbageVm?.loadNotificationSettings() },
-        questWebhookLoading = questWebhookVm?.uiState?.isLoading ?: false,
-        questWebhookLoadError = questWebhookVm?.uiState?.loadError ?: false,
-        questWebhookLoadErrorMessage = questWebhookVm?.uiState?.loadErrorMessage,
-        questWebhookUrl = questWebhookVm?.uiState?.url ?: "",
-        questWebhookEnabled = questWebhookVm?.uiState?.enabled ?: false,
-        questWebhookEvents = questWebhookVm?.uiState?.events ?: emptyList(),
-        questWebhookSaving = questWebhookVm?.uiState?.isSaving ?: false,
-        questWebhookMessage = questWebhookVm?.uiState?.message,
-        onQuestWebhookUrlChanged = { questWebhookVm?.onUrlChanged(it) },
-        onQuestWebhookEnabledChanged = { questWebhookVm?.onEnabledChanged(it) },
-        onQuestWebhookToggleEvent = { questWebhookVm?.onToggleEvent(it) },
-        onSaveQuestWebhook = { questWebhookVm?.onSave() },
-        onRetryQuestWebhook = { questWebhookVm?.loadSettings() },
-        moneyWebhookLoading = moneyWebhookVm?.uiState?.isLoading ?: false,
-        moneyWebhookLoadError = moneyWebhookVm?.uiState?.loadError ?: false,
-        moneyWebhookLoadErrorMessage = moneyWebhookVm?.uiState?.loadErrorMessage,
-        moneyWebhookUrl = moneyWebhookVm?.uiState?.url ?: "",
-        moneyWebhookEnabled = moneyWebhookVm?.uiState?.enabled ?: false,
-        moneyWebhookMessage = moneyWebhookVm?.uiState?.message ?: "",
-        moneyWebhookSaving = moneyWebhookVm?.uiState?.isSaving ?: false,
-        moneyWebhookStatusMessage = moneyWebhookVm?.uiState?.statusMessage,
-        onMoneyWebhookUrlChanged = { moneyWebhookVm?.onUrlChanged(it) },
-        onMoneyWebhookEnabledChanged = { moneyWebhookVm?.onEnabledChanged(it) },
-        onMoneyWebhookMessageChanged = { moneyWebhookVm?.onMessageChanged(it) },
-        onSaveMoneyWebhook = { moneyWebhookVm?.onSave() },
-        onRetryMoneyWebhook = { moneyWebhookVm?.loadSettings() },
-        paymentWebhookLoading = paymentWebhookVm?.uiState?.isLoading ?: false,
-        paymentWebhookLoadError = paymentWebhookVm?.uiState?.loadError ?: false,
-        paymentWebhookLoadErrorMessage = paymentWebhookVm?.uiState?.loadErrorMessage,
-        paymentWebhookUrl = paymentWebhookVm?.uiState?.url ?: "",
-        paymentWebhookEnabled = paymentWebhookVm?.uiState?.enabled ?: false,
-        paymentWebhookMessage = paymentWebhookVm?.uiState?.message ?: "",
-        paymentWebhookSaving = paymentWebhookVm?.uiState?.isSaving ?: false,
-        paymentWebhookStatusMessage = paymentWebhookVm?.uiState?.statusMessage,
-        onPaymentWebhookUrlChanged = { paymentWebhookVm?.onUrlChanged(it) },
-        onPaymentWebhookEnabledChanged = { paymentWebhookVm?.onEnabledChanged(it) },
-        onPaymentWebhookMessageChanged = { paymentWebhookVm?.onMessageChanged(it) },
-        onSavePaymentWebhook = { paymentWebhookVm?.onSave() },
-        onRetryPaymentWebhook = { paymentWebhookVm?.loadSettings() },
-        cacheClearing = cacheVm?.uiState?.isClearing ?: false,
-        cacheMessage = cacheVm?.uiState?.message,
-        onClearCache = { cacheVm?.onClearCache() },
-        petSettingsLoading = petSettingsVm?.uiState?.isLoading ?: false,
-        pets = petSettingsVm?.uiState?.pets ?: emptyList(),
-        editingPetNames = petSettingsVm?.uiState?.editingPetNames ?: emptyMap(),
-        mealOrder = petSettingsVm?.uiState?.mealOrder ?: FeedingSettings.DEFAULT_MEAL_ORDER,
-        mealTimes = petSettingsVm?.uiState?.mealTimes ?: emptyMap(),
-        feedingReminderEnabled = petSettingsVm?.uiState?.reminderEnabled ?: false,
-        feedingReminderWebhookUrl = petSettingsVm?.uiState?.reminderWebhookUrl ?: "",
-        feedingReminderDelayMinutes = petSettingsVm?.uiState?.reminderDelayMinutes ?: 30,
-        feedingReminderPrefix = petSettingsVm?.uiState?.reminderPrefix ?: "",
-        petNameSaving = petSettingsVm?.uiState?.petNameSaving ?: false,
-        feedingSaving = petSettingsVm?.uiState?.feedingSaving ?: false,
-        reminderSaving = petSettingsVm?.uiState?.reminderSaving ?: false,
-        petSettingsTesting = petSettingsVm?.uiState?.testingPhase,
-        petNameMessage = petSettingsVm?.uiState?.petNameMessage,
-        feedingMessage = petSettingsVm?.uiState?.feedingMessage,
-        reminderMessage = petSettingsVm?.uiState?.reminderMessage,
-        onPetNameChanged = { id, name -> petSettingsVm?.onPetNameChanged(id, name) },
-        onSavePetName = { petSettingsVm?.onSavePetName(it) },
-        onMealOrderChanged = { petSettingsVm?.onMealOrderChanged(it) },
-        onMealTimeChanged = { t, v -> petSettingsVm?.onMealTimeChanged(t, v) },
-        onFeedingReminderEnabledChanged = { petSettingsVm?.onReminderEnabledChanged(it) },
-        onFeedingReminderWebhookUrlChanged = { petSettingsVm?.onReminderWebhookUrlChanged(it) },
-        onFeedingReminderDelayMinutesChanged = { petSettingsVm?.onReminderDelayMinutesChanged(it) },
-        onFeedingReminderPrefixChanged = { petSettingsVm?.onReminderPrefixChanged(it) },
-        onSaveFeeding = { petSettingsVm?.onSaveFeeding() },
-        onSaveReminder = { petSettingsVm?.onSaveReminder() },
-        onTestFeedingScheduled = { petSettingsVm?.onTestScheduled() },
-        onTestFeedingReminder = { petSettingsVm?.onTestReminder() },
-        licensesLoading = licensesVm.uiState.isLoading,
-        libraries = licensesVm.uiState.libraries,
-        licensesError = licensesVm.uiState.error,
-        onRetryLicenses = licensesVm::loadLicenses,
         windowSizeClass = windowSizeClass,
         selectedCategory = selectedCategory,
         onSelectCategory = { onCategoryNameChange(it?.name) },
@@ -250,135 +90,6 @@ fun SettingsScreen(
 @Composable
 internal fun SettingsContent(
     isAdmin: Boolean,
-    loginHistoryLoading: Boolean,
-    loginHistoryLoadError: Boolean,
-    loginHistoryLoadErrorMessage: String?,
-    loginHistoryEvents: List<LoginEvent>,
-    onRetryLoginHistory: () -> Unit,
-    currentPassword: String,
-    newPassword: String,
-    confirmPassword: String,
-    isLoading: Boolean,
-    errorMessage: String?,
-    successMessage: String?,
-    onCurrentPasswordChanged: (String) -> Unit,
-    onNewPasswordChanged: (String) -> Unit,
-    onConfirmPasswordChanged: (String) -> Unit,
-    onChangePassword: () -> Unit,
-    passkeyAvailable: Boolean = false,
-    passkeyRegistering: Boolean = false,
-    credentialCount: Int = 0,
-    passkeyError: String? = null,
-    passkeySuccess: String? = null,
-    onRegisterPasskey: () -> Unit = {},
-    usersLoading: Boolean = false,
-    usersLoadError: Boolean = false,
-    usersLoadErrorMessage: String? = null,
-    users: List<User>,
-    usersSaving: Boolean,
-    usersMessage: String?,
-    onUpdateDisplayName: (String, String) -> Unit,
-    onRetryUsers: () -> Unit = {},
-    garbageLoading: Boolean,
-    garbageLoadError: Boolean = false,
-    garbageLoadErrorMessage: String? = null,
-    garbageSchedules: List<GarbageTypeSchedule>,
-    garbageMessage: String?,
-    garbageSaving: Boolean,
-    onToggleDay: (GarbageType, Int) -> Unit,
-    onFrequencyChange: (GarbageType, CollectionFrequency) -> Unit,
-    onSaveGarbageSchedule: () -> Unit,
-    onRetryGarbageSchedule: () -> Unit = {},
-    garbageNotificationLoading: Boolean = false,
-    garbageNotificationLoadError: Boolean = false,
-    garbageNotificationLoadErrorMessage: String? = null,
-    garbageNotificationEnabled: Boolean = false,
-    garbageNotificationWebhookUrl: String = "",
-    garbageNotificationHour: String = "10",
-    garbageNotificationPrefix: String = "",
-    garbageNotificationSaving: Boolean = false,
-    garbageNotificationHourValid: Boolean = true,
-    garbageNotificationMessage: String? = null,
-    onGarbageNotificationEnabledChanged: (Boolean) -> Unit = {},
-    onGarbageNotificationWebhookUrlChanged: (String) -> Unit = {},
-    onGarbageNotificationHourChanged: (String) -> Unit = {},
-    onGarbageNotificationPrefixChanged: (String) -> Unit = {},
-    onSaveGarbageNotification: () -> Unit = {},
-    onRetryGarbageNotification: () -> Unit = {},
-    questWebhookLoading: Boolean = false,
-    questWebhookLoadError: Boolean = false,
-    questWebhookLoadErrorMessage: String? = null,
-    questWebhookUrl: String = "",
-    questWebhookEnabled: Boolean = false,
-    questWebhookEvents: List<String> = emptyList(),
-    questWebhookSaving: Boolean = false,
-    questWebhookMessage: String? = null,
-    onQuestWebhookUrlChanged: (String) -> Unit = {},
-    onQuestWebhookEnabledChanged: (Boolean) -> Unit = {},
-    onQuestWebhookToggleEvent: (String) -> Unit = {},
-    onSaveQuestWebhook: () -> Unit = {},
-    onRetryQuestWebhook: () -> Unit = {},
-    moneyWebhookLoading: Boolean = false,
-    moneyWebhookLoadError: Boolean = false,
-    moneyWebhookLoadErrorMessage: String? = null,
-    moneyWebhookUrl: String = "",
-    moneyWebhookEnabled: Boolean = false,
-    moneyWebhookMessage: String = "",
-    moneyWebhookSaving: Boolean = false,
-    moneyWebhookStatusMessage: String? = null,
-    onMoneyWebhookUrlChanged: (String) -> Unit = {},
-    onMoneyWebhookEnabledChanged: (Boolean) -> Unit = {},
-    onMoneyWebhookMessageChanged: (String) -> Unit = {},
-    onSaveMoneyWebhook: () -> Unit = {},
-    onRetryMoneyWebhook: () -> Unit = {},
-    paymentWebhookLoading: Boolean = false,
-    paymentWebhookLoadError: Boolean = false,
-    paymentWebhookLoadErrorMessage: String? = null,
-    paymentWebhookUrl: String = "",
-    paymentWebhookEnabled: Boolean = false,
-    paymentWebhookMessage: String = "",
-    paymentWebhookSaving: Boolean = false,
-    paymentWebhookStatusMessage: String? = null,
-    onPaymentWebhookUrlChanged: (String) -> Unit = {},
-    onPaymentWebhookEnabledChanged: (Boolean) -> Unit = {},
-    onPaymentWebhookMessageChanged: (String) -> Unit = {},
-    onSavePaymentWebhook: () -> Unit = {},
-    onRetryPaymentWebhook: () -> Unit = {},
-    cacheClearing: Boolean = false,
-    cacheMessage: String? = null,
-    onClearCache: () -> Unit = {},
-    licensesLoading: Boolean = false,
-    libraries: List<Library> = emptyList(),
-    licensesError: String? = null,
-    onRetryLicenses: () -> Unit = {},
-    petSettingsLoading: Boolean = false,
-    pets: List<Pet> = emptyList(),
-    editingPetNames: Map<String, String> = emptyMap(),
-    mealOrder: List<MealTime> = FeedingSettings.DEFAULT_MEAL_ORDER,
-    mealTimes: Map<MealTime, String> = emptyMap(),
-    feedingReminderEnabled: Boolean = false,
-    feedingReminderWebhookUrl: String = "",
-    feedingReminderDelayMinutes: Int = 30,
-    feedingReminderPrefix: String = "",
-    petNameSaving: Boolean = false,
-    feedingSaving: Boolean = false,
-    reminderSaving: Boolean = false,
-    petSettingsTesting: FeedingTestPhase? = null,
-    petNameMessage: String? = null,
-    feedingMessage: String? = null,
-    reminderMessage: String? = null,
-    onPetNameChanged: (String, String) -> Unit = { _, _ -> },
-    onSavePetName: (String) -> Unit = {},
-    onMealOrderChanged: (List<MealTime>) -> Unit = {},
-    onMealTimeChanged: (MealTime, String) -> Unit = { _, _ -> },
-    onFeedingReminderEnabledChanged: (Boolean) -> Unit = {},
-    onFeedingReminderWebhookUrlChanged: (String) -> Unit = {},
-    onFeedingReminderDelayMinutesChanged: (Int) -> Unit = {},
-    onFeedingReminderPrefixChanged: (String) -> Unit = {},
-    onSaveFeeding: () -> Unit = {},
-    onSaveReminder: () -> Unit = {},
-    onTestFeedingScheduled: () -> Unit = {},
-    onTestFeedingReminder: () -> Unit = {},
     windowSizeClass: WindowSizeClass = WindowSizeClass.Expanded,
     selectedCategory: SettingsCategory? = null,
     onSelectCategory: (SettingsCategory?) -> Unit = {},
@@ -388,202 +99,18 @@ internal fun SettingsContent(
 
     val categoryContent: @Composable (SettingsCategory, Modifier) -> Unit = { category, cardModifier ->
         when (category) {
-            SettingsCategory.Account -> {
-                PasswordChangeCard(
-                    currentPassword = currentPassword,
-                    newPassword = newPassword,
-                    confirmPassword = confirmPassword,
-                    isLoading = isLoading,
-                    errorMessage = errorMessage,
-                    successMessage = successMessage,
-                    onCurrentPasswordChanged = onCurrentPasswordChanged,
-                    onNewPasswordChanged = onNewPasswordChanged,
-                    onConfirmPasswordChanged = onConfirmPasswordChanged,
-                    onChangePassword = onChangePassword,
-                    modifier = cardModifier,
-                )
-                if (passkeyAvailable) {
-                    PasskeyManagementCard(
-                        credentialCount = credentialCount,
-                        isRegistering = passkeyRegistering,
-                        errorMessage = passkeyError,
-                        successMessage = passkeySuccess,
-                        onRegisterPasskey = onRegisterPasskey,
-                        modifier = cardModifier,
-                    )
-                }
-                LoginHistoryCardContent(
-                    isLoading = loginHistoryLoading,
-                    loadError = loginHistoryLoadError,
-                    loadErrorMessage = loginHistoryLoadErrorMessage,
-                    events = loginHistoryEvents,
-                    onRetry = onRetryLoginHistory,
-                    modifier = cardModifier,
-                )
-            }
-            SettingsCategory.UserManagement -> {
-                UserNameManagementCard(
-                    isLoading = usersLoading,
-                    loadError = usersLoadError,
-                    loadErrorMessage = usersLoadErrorMessage,
-                    users = users,
-                    usersSaving = usersSaving,
-                    usersMessage = usersMessage,
-                    onUpdateDisplayName = onUpdateDisplayName,
-                    onRetry = onRetryUsers,
-                    modifier = cardModifier,
-                )
-            }
-            SettingsCategory.Pet -> {
-                if (petSettingsLoading) {
-                    CircularProgressIndicator()
-                } else {
-                    PetNameCard(
-                        pets = pets,
-                        editingPetNames = editingPetNames,
-                        isSaving = petNameSaving,
-                        message = petNameMessage,
-                        onPetNameChanged = onPetNameChanged,
-                        onSavePetName = onSavePetName,
-                        modifier = cardModifier,
-                    )
-                    FeedingSettingsCard(
-                        mealOrder = mealOrder,
-                        mealTimes = mealTimes,
-                        isSaving = feedingSaving,
-                        message = feedingMessage,
-                        onMealOrderChanged = onMealOrderChanged,
-                        onMealTimeChanged = onMealTimeChanged,
-                        onSave = onSaveFeeding,
-                        modifier = cardModifier,
-                    )
-                    FeedingReminderCard(
-                        reminderEnabled = feedingReminderEnabled,
-                        reminderWebhookUrl = feedingReminderWebhookUrl,
-                        reminderDelayMinutes = feedingReminderDelayMinutes,
-                        reminderPrefix = feedingReminderPrefix,
-                        isSaving = reminderSaving,
-                        testingPhase = petSettingsTesting,
-                        message = reminderMessage,
-                        onReminderEnabledChanged = onFeedingReminderEnabledChanged,
-                        onReminderWebhookUrlChanged = onFeedingReminderWebhookUrlChanged,
-                        onReminderDelayMinutesChanged = onFeedingReminderDelayMinutesChanged,
-                        onReminderPrefixChanged = onFeedingReminderPrefixChanged,
-                        onSave = onSaveReminder,
-                        onTestScheduled = onTestFeedingScheduled,
-                        onTestReminder = onTestFeedingReminder,
-                        modifier = cardModifier,
-                    )
-                }
-            }
-            SettingsCategory.Garbage -> {
-                GarbageScheduleCard(
-                    isLoading = garbageLoading,
-                    loadError = garbageLoadError,
-                    loadErrorMessage = garbageLoadErrorMessage,
-                    schedules = garbageSchedules,
-                    garbageMessage = garbageMessage,
-                    garbageSaving = garbageSaving,
-                    onToggleDay = onToggleDay,
-                    onFrequencyChange = onFrequencyChange,
-                    onSaveClick = onSaveGarbageSchedule,
-                    onRetry = onRetryGarbageSchedule,
-                    modifier = cardModifier,
-                )
-                GarbageNotificationCard(
-                    isLoading = garbageNotificationLoading,
-                    loadError = garbageNotificationLoadError,
-                    loadErrorMessage = garbageNotificationLoadErrorMessage,
-                    enabled = garbageNotificationEnabled,
-                    webhookUrl = garbageNotificationWebhookUrl,
-                    notifyHour = garbageNotificationHour,
-                    prefix = garbageNotificationPrefix,
-                    isSaving = garbageNotificationSaving,
-                    isHourValid = garbageNotificationHourValid,
-                    message = garbageNotificationMessage,
-                    onEnabledChanged = onGarbageNotificationEnabledChanged,
-                    onWebhookUrlChanged = onGarbageNotificationWebhookUrlChanged,
-                    onNotifyHourChanged = onGarbageNotificationHourChanged,
-                    onPrefixChanged = onGarbageNotificationPrefixChanged,
-                    onSave = onSaveGarbageNotification,
-                    onRetry = onRetryGarbageNotification,
-                    modifier = cardModifier,
-                )
-            }
-            SettingsCategory.Quest -> {
-                QuestWebhookSettingsCard(
-                    isLoading = questWebhookLoading,
-                    loadError = questWebhookLoadError,
-                    loadErrorMessage = questWebhookLoadErrorMessage,
-                    url = questWebhookUrl,
-                    enabled = questWebhookEnabled,
-                    events = questWebhookEvents,
-                    isSaving = questWebhookSaving,
-                    message = questWebhookMessage,
-                    onUrlChanged = onQuestWebhookUrlChanged,
-                    onEnabledChanged = onQuestWebhookEnabledChanged,
-                    onToggleEvent = onQuestWebhookToggleEvent,
-                    onSave = onSaveQuestWebhook,
-                    onRetry = onRetryQuestWebhook,
-                    modifier = cardModifier,
-                )
-            }
-            SettingsCategory.Money -> {
-                MoneyWebhookSettingsCard(
-                    isLoading = moneyWebhookLoading,
-                    loadError = moneyWebhookLoadError,
-                    loadErrorMessage = moneyWebhookLoadErrorMessage,
-                    url = moneyWebhookUrl,
-                    enabled = moneyWebhookEnabled,
-                    message = moneyWebhookMessage,
-                    isSaving = moneyWebhookSaving,
-                    statusMessage = moneyWebhookStatusMessage,
-                    onUrlChanged = onMoneyWebhookUrlChanged,
-                    onEnabledChanged = onMoneyWebhookEnabledChanged,
-                    onMessageChanged = onMoneyWebhookMessageChanged,
-                    onSave = onSaveMoneyWebhook,
-                    onRetry = onRetryMoneyWebhook,
-                    modifier = cardModifier,
-                )
-                PaymentWebhookSettingsCard(
-                    isLoading = paymentWebhookLoading,
-                    loadError = paymentWebhookLoadError,
-                    loadErrorMessage = paymentWebhookLoadErrorMessage,
-                    url = paymentWebhookUrl,
-                    enabled = paymentWebhookEnabled,
-                    message = paymentWebhookMessage,
-                    isSaving = paymentWebhookSaving,
-                    statusMessage = paymentWebhookStatusMessage,
-                    onUrlChanged = onPaymentWebhookUrlChanged,
-                    onEnabledChanged = onPaymentWebhookEnabledChanged,
-                    onMessageChanged = onPaymentWebhookMessageChanged,
-                    onSave = onSavePaymentWebhook,
-                    onRetry = onRetryPaymentWebhook,
-                    modifier = cardModifier,
-                )
-            }
-            SettingsCategory.Cache -> {
-                CacheRefreshCard(
-                    isClearing = cacheClearing,
-                    message = cacheMessage,
-                    onClearCache = onClearCache,
-                    modifier = cardModifier,
-                )
-            }
-            SettingsCategory.Credits -> {
-                CreditsCard(
-                    isLoading = licensesLoading,
-                    libraries = libraries,
-                    error = licensesError,
-                    onRetry = onRetryLicenses,
-                    modifier = cardModifier,
-                )
-            }
+            SettingsCategory.Account -> AccountScreen(modifier = cardModifier)
+            SettingsCategory.Credits -> CreditsScreen(modifier = cardModifier)
+            SettingsCategory.UserManagement -> UserManagementScreen(modifier = cardModifier)
+            SettingsCategory.Pet -> PetScreen(modifier = cardModifier)
+            SettingsCategory.Garbage -> GarbageScreen(modifier = cardModifier)
+            SettingsCategory.Quest -> QuestScreen(modifier = cardModifier)
+            SettingsCategory.Money -> MoneyScreen(modifier = cardModifier)
+            SettingsCategory.Cache -> CacheScreen(modifier = cardModifier)
         }
     }
 
     if (isCompact) {
-        // Compact: カテゴリリスト ↔ カテゴリ詳細の切り替え
         val selected = selectedCategory
         if (selected == null) {
             CategoryListPane(
@@ -608,8 +135,6 @@ internal fun SettingsContent(
             }
         }
     } else {
-        // Medium / Expanded: 左カテゴリリスト + 右詳細の2ペイン
-        // フラグメント未指定時は先頭カテゴリを表示・ハイライトする（URL は変更しない）
         val selected = selectedCategory ?: categories.firstOrNull()
         Row(modifier = Modifier.fillMaxSize()) {
             CategoryListPane(
@@ -639,6 +164,17 @@ internal fun SettingsContent(
         }
     }
 }
+
+@Composable
+private fun settingsScrollbarStyle() =
+    ScrollbarStyle(
+        minimalHeight = 48.dp,
+        thickness = 8.dp,
+        shape = MaterialTheme.shapes.small,
+        hoverDurationMillis = 300,
+        unhoverColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+        hoverColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+    )
 
 @Composable
 private fun CategoryListPane(
@@ -678,18 +214,8 @@ private fun CategoryItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val containerColor =
-        if (isSelected) {
-            MaterialTheme.colorScheme.primaryContainer
-        } else {
-            MaterialTheme.colorScheme.surface
-        }
-    val contentColor =
-        if (isSelected) {
-            MaterialTheme.colorScheme.onPrimaryContainer
-        } else {
-            MaterialTheme.colorScheme.onSurface
-        }
+    val containerColor = if (isSelected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surface
+    val contentColor = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface
 
     Surface(
         onClick = onClick,
@@ -702,31 +228,12 @@ private fun CategoryItem(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Icon(
-                imageVector = category.icon,
-                contentDescription = null,
-                tint = contentColor,
-                modifier = Modifier.size(24.dp),
-            )
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                Text(
-                    text = category.title,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = contentColor,
-                )
-                if (category.adminOnly) {
-                    AdminBadge()
-                }
+            Icon(imageVector = category.icon, contentDescription = null, tint = contentColor, modifier = Modifier.size(24.dp))
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(text = category.title, style = MaterialTheme.typography.bodyLarge, color = contentColor)
+                if (category.adminOnly) AdminBadge()
             }
-            Icon(
-                imageVector = Icons.Default.ChevronRight,
-                contentDescription = null,
-                tint = contentColor,
-                modifier = Modifier.size(20.dp),
-            )
+            Icon(imageVector = Icons.Default.ChevronRight, contentDescription = null, tint = contentColor, modifier = Modifier.size(20.dp))
         }
     }
 }
@@ -743,15 +250,10 @@ private fun CategoryDetailPane(
 ) {
     Box(modifier = modifier) {
         Column(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(24.dp)
-                    .verticalScroll(scrollState),
+            modifier = Modifier.fillMaxSize().padding(24.dp).verticalScroll(scrollState),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            // ヘッダー（戻るボタン + タイトル）
             Row(
                 modifier = contentModifier,
                 verticalAlignment = Alignment.CenterVertically,
@@ -759,10 +261,7 @@ private fun CategoryDetailPane(
             ) {
                 if (showBackButton) {
                     IconButton(onClick = onBack) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "戻る",
-                        )
+                        Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "戻る")
                     }
                 }
                 Icon(
@@ -777,9 +276,7 @@ private fun CategoryDetailPane(
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.primary,
                 )
-                if (category.adminOnly) {
-                    AdminBadge()
-                }
+                if (category.adminOnly) AdminBadge()
             }
             content()
         }
@@ -789,699 +286,5 @@ private fun CategoryDetailPane(
             modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
             style = settingsScrollbarStyle(),
         )
-    }
-}
-
-@Composable
-private fun UserNameManagementCard(
-    isLoading: Boolean = false,
-    loadError: Boolean = false,
-    loadErrorMessage: String? = null,
-    users: List<User>,
-    usersSaving: Boolean,
-    usersMessage: String?,
-    onUpdateDisplayName: (String, String) -> Unit,
-    onRetry: () -> Unit = {},
-    modifier: Modifier = Modifier,
-) {
-    // ローカル編集状態: uid -> 入力中の displayName
-    var editedNames by remember(users) {
-        mutableStateOf(users.associate { it.uid to (it.displayName ?: "") })
-    }
-
-    Card(
-        modifier = modifier,
-        colors =
-            CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceVariant,
-            ),
-    ) {
-        LoadableCardContent(
-            isLoading = isLoading,
-            loadError = loadError,
-            loadErrorMessage = loadErrorMessage,
-            onRetry = onRetry,
-        ) {
-            Column(
-                modifier = Modifier.padding(24.dp).fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-            ) {
-                for (user in users) {
-                    OutlinedTextField(
-                        value = editedNames[user.uid] ?: "",
-                        onValueChange = { value ->
-                            editedNames =
-                                editedNames.toMutableMap().apply {
-                                    put(user.uid, value)
-                                }
-                        },
-                        label = { Text(user.uid) },
-                        modifier = Modifier.fillMaxWidth(),
-                        singleLine = true,
-                        enabled = !usersSaving,
-                    )
-                }
-
-                if (usersMessage != null) {
-                    Text(
-                        text = usersMessage,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                }
-
-                Button(
-                    onClick = {
-                        for (user in users) {
-                            val newName = editedNames[user.uid] ?: ""
-                            val oldName = user.displayName ?: ""
-                            if (newName != oldName) {
-                                onUpdateDisplayName(user.uid, newName)
-                            }
-                        }
-                    },
-                    modifier = Modifier.height(48.dp),
-                    enabled = !usersSaving,
-                ) {
-                    if (usersSaving) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(20.dp),
-                            strokeWidth = 2.dp,
-                            color = MaterialTheme.colorScheme.onPrimary,
-                        )
-                    } else {
-                        Text("保存する")
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun GarbageScheduleCard(
-    isLoading: Boolean,
-    loadError: Boolean = false,
-    loadErrorMessage: String? = null,
-    schedules: List<GarbageTypeSchedule>,
-    garbageMessage: String?,
-    garbageSaving: Boolean,
-    onToggleDay: (GarbageType, Int) -> Unit,
-    onFrequencyChange: (GarbageType, CollectionFrequency) -> Unit,
-    onSaveClick: () -> Unit,
-    onRetry: () -> Unit = {},
-    modifier: Modifier = Modifier,
-) {
-    Card(
-        modifier = modifier,
-        colors =
-            CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceVariant,
-            ),
-    ) {
-        LoadableCardContent(
-            isLoading = isLoading,
-            loadError = loadError,
-            loadErrorMessage = loadErrorMessage,
-            onRetry = onRetry,
-        ) {
-            Column(
-                modifier = Modifier.padding(24.dp).fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-            ) {
-                for (schedule in schedules) {
-                    val garbageType = schedule.garbageType
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalArrangement = Arrangement.spacedBy(16.dp),
-                    ) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        ) {
-                            Icon(
-                                imageVector = garbageType.icon,
-                                contentDescription = null,
-                                tint = garbageType.color,
-                            )
-                            Text(
-                                text = garbageType.label,
-                                style = MaterialTheme.typography.titleSmall,
-                                color = MaterialTheme.colorScheme.onSurface,
-                            )
-                        }
-
-                        // 曜日チップ
-                        Text(
-                            text = "収集曜日",
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                            for (dayIndex in 0..6) {
-                                val selected = dayIndex in schedule.daysOfWeek
-                                FilterChip(
-                                    selected = selected,
-                                    onClick = { onToggleDay(garbageType, dayIndex) },
-                                    label = { Text(dayLabels[dayIndex]) },
-                                    border =
-                                        if (selected) {
-                                            BorderStroke(1.dp, garbageType.color)
-                                        } else {
-                                            FilterChipDefaults.filterChipBorder(enabled = true, selected = false)
-                                        },
-                                )
-                            }
-                        }
-
-                        // 頻度セレクタ
-                        Text(
-                            text = "収集頻度",
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        SingleChoiceSegmentedButtonRow {
-                            CollectionFrequency.entries.forEachIndexed { index, freq ->
-                                SegmentedButton(
-                                    selected = schedule.frequency == freq,
-                                    onClick = { onFrequencyChange(garbageType, freq) },
-                                    shape =
-                                        SegmentedButtonDefaults.itemShape(
-                                            index = index,
-                                            count = CollectionFrequency.entries.size,
-                                        ),
-                                ) {
-                                    Text(
-                                        text = freq.label,
-                                        style = MaterialTheme.typography.labelSmall,
-                                    )
-                                }
-                            }
-                        }
-                    }
-
-                    if (schedule != schedules.lastOrNull()) {
-                        HorizontalDivider(thickness = 1.dp, color = MaterialTheme.colorScheme.outlineVariant)
-                    }
-                }
-
-                if (garbageMessage != null) {
-                    Text(
-                        text = garbageMessage,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                }
-
-                Button(
-                    onClick = onSaveClick,
-                    modifier = Modifier.height(48.dp),
-                    enabled = !garbageSaving,
-                ) {
-                    if (garbageSaving) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(20.dp),
-                            strokeWidth = 2.dp,
-                            color = MaterialTheme.colorScheme.onPrimary,
-                        )
-                    } else {
-                        Text("保存する")
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun PasswordChangeCard(
-    currentPassword: String,
-    newPassword: String,
-    confirmPassword: String,
-    isLoading: Boolean,
-    errorMessage: String?,
-    successMessage: String?,
-    onCurrentPasswordChanged: (String) -> Unit,
-    onNewPasswordChanged: (String) -> Unit,
-    onConfirmPasswordChanged: (String) -> Unit,
-    onChangePassword: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    var currentPasswordVisible by remember { mutableStateOf(false) }
-    var newPasswordVisible by remember { mutableStateOf(false) }
-    var confirmPasswordVisible by remember { mutableStateOf(false) }
-
-    Card(
-        modifier = modifier,
-        colors =
-            CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceVariant,
-            ),
-    ) {
-        Column(
-            modifier = Modifier.padding(24.dp).fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Lock,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-                Text(
-                    text = "パスワード変更",
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-            }
-
-            OutlinedTextField(
-                value = currentPassword,
-                onValueChange = onCurrentPasswordChanged,
-                label = { Text("現在のパスワード") },
-                leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) },
-                trailingIcon = {
-                    IconButton(onClick = { currentPasswordVisible = !currentPasswordVisible }) {
-                        Icon(
-                            if (currentPasswordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                            contentDescription = if (currentPasswordVisible) "パスワードを隠す" else "パスワードを表示",
-                        )
-                    }
-                },
-                singleLine = true,
-                visualTransformation = if (currentPasswordVisible) VisualTransformation.None else PasswordVisualTransformation(),
-                keyboardOptions =
-                    KeyboardOptions(
-                        keyboardType = KeyboardType.Password,
-                        imeAction = ImeAction.Next,
-                    ),
-                modifier = Modifier.fillMaxWidth(),
-                enabled = !isLoading,
-            )
-
-            OutlinedTextField(
-                value = newPassword,
-                onValueChange = onNewPasswordChanged,
-                label = { Text("新しいパスワード") },
-                leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) },
-                trailingIcon = {
-                    IconButton(onClick = { newPasswordVisible = !newPasswordVisible }) {
-                        Icon(
-                            if (newPasswordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                            contentDescription = if (newPasswordVisible) "パスワードを隠す" else "パスワードを表示",
-                        )
-                    }
-                },
-                singleLine = true,
-                visualTransformation = if (newPasswordVisible) VisualTransformation.None else PasswordVisualTransformation(),
-                keyboardOptions =
-                    KeyboardOptions(
-                        keyboardType = KeyboardType.Password,
-                        imeAction = ImeAction.Next,
-                    ),
-                modifier = Modifier.fillMaxWidth(),
-                enabled = !isLoading,
-            )
-
-            OutlinedTextField(
-                value = confirmPassword,
-                onValueChange = onConfirmPasswordChanged,
-                label = { Text("新しいパスワード（確認）") },
-                leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) },
-                trailingIcon = {
-                    IconButton(onClick = { confirmPasswordVisible = !confirmPasswordVisible }) {
-                        Icon(
-                            if (confirmPasswordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                            contentDescription = if (confirmPasswordVisible) "パスワードを隠す" else "パスワードを表示",
-                        )
-                    }
-                },
-                singleLine = true,
-                visualTransformation = if (confirmPasswordVisible) VisualTransformation.None else PasswordVisualTransformation(),
-                keyboardOptions =
-                    KeyboardOptions(
-                        keyboardType = KeyboardType.Password,
-                        imeAction = ImeAction.Done,
-                    ),
-                modifier = Modifier.fillMaxWidth(),
-                enabled = !isLoading,
-            )
-
-            if (errorMessage != null) {
-                Text(
-                    text = errorMessage,
-                    color = MaterialTheme.colorScheme.error,
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
-
-            if (successMessage != null) {
-                Text(
-                    text = successMessage,
-                    color = MaterialTheme.colorScheme.primary,
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
-
-            Button(
-                onClick = onChangePassword,
-                modifier = Modifier.height(48.dp),
-                enabled = !isLoading,
-            ) {
-                if (isLoading) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(20.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.onPrimary,
-                    )
-                } else {
-                    Text("変更する")
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun PasskeyManagementCard(
-    credentialCount: Int,
-    isRegistering: Boolean,
-    errorMessage: String?,
-    successMessage: String?,
-    onRegisterPasskey: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Card(
-        modifier = modifier,
-        colors =
-            CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceVariant,
-            ),
-    ) {
-        Column(
-            modifier = Modifier.padding(24.dp).fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Fingerprint,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-                Text(
-                    text = "パスキー管理",
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-            }
-
-            Text(
-                text = "登録済み: $credentialCount 件",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-
-            Text(
-                text = "別の端末やブラウザからログインするには、パスキーを追加してください。",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-
-            if (errorMessage != null) {
-                Text(
-                    text = errorMessage,
-                    color = MaterialTheme.colorScheme.error,
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
-
-            if (successMessage != null) {
-                Text(
-                    text = successMessage,
-                    color = MaterialTheme.colorScheme.primary,
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
-
-            Button(
-                onClick = onRegisterPasskey,
-                modifier = Modifier.height(48.dp),
-                enabled = !isRegistering,
-            ) {
-                if (isRegistering) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(20.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.onPrimary,
-                    )
-                } else {
-                    Text("パスキーを追加")
-                }
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun QuestWebhookSettingsCard(
-    isLoading: Boolean,
-    loadError: Boolean = false,
-    loadErrorMessage: String? = null,
-    url: String,
-    enabled: Boolean,
-    events: List<String>,
-    isSaving: Boolean,
-    message: String?,
-    onUrlChanged: (String) -> Unit,
-    onEnabledChanged: (Boolean) -> Unit,
-    onToggleEvent: (String) -> Unit,
-    onSave: () -> Unit,
-    onRetry: () -> Unit = {},
-    modifier: Modifier = Modifier,
-) {
-    WebhookSettingsCard(
-        isLoading = isLoading,
-        title = "Webhook 通知",
-        featureEnabled = enabled,
-        url = url,
-        onUrlChanged = onUrlChanged,
-        isSaving = isSaving,
-        onEnabledChanged = onEnabledChanged,
-        onSave = onSave,
-        modifier = modifier,
-        loadError = loadError,
-        loadErrorMessage = loadErrorMessage,
-        onRetry = onRetry,
-        statusMessage = message,
-    ) {
-        Text("通知するイベント", style = MaterialTheme.typography.labelMedium)
-        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            QuestWebhookEvent.all.forEach { event ->
-                FilterChip(
-                    selected = event in events,
-                    onClick = { onToggleEvent(event) },
-                    label = { Text(QuestWebhookEvent.label(event)) },
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun MoneyWebhookSettingsCard(
-    isLoading: Boolean,
-    loadError: Boolean = false,
-    loadErrorMessage: String? = null,
-    url: String,
-    enabled: Boolean,
-    message: String,
-    isSaving: Boolean,
-    statusMessage: String?,
-    onUrlChanged: (String) -> Unit,
-    onEnabledChanged: (Boolean) -> Unit,
-    onMessageChanged: (String) -> Unit,
-    onSave: () -> Unit,
-    onRetry: () -> Unit = {},
-    modifier: Modifier = Modifier,
-) {
-    WebhookSettingsCard(
-        isLoading = isLoading,
-        title = "ステータス確定通知",
-        featureEnabled = enabled,
-        url = url,
-        onUrlChanged = onUrlChanged,
-        isSaving = isSaving,
-        onEnabledChanged = onEnabledChanged,
-        onSave = onSave,
-        modifier = modifier,
-        loadError = loadError,
-        loadErrorMessage = loadErrorMessage,
-        onRetry = onRetry,
-        description = "月のお金ステータスを「確定済み」に切り替えた際に Webhook で通知します。",
-        message = message,
-        onMessageChanged = onMessageChanged,
-        statusMessage = statusMessage,
-    )
-}
-
-@Composable
-private fun PaymentWebhookSettingsCard(
-    isLoading: Boolean,
-    loadError: Boolean = false,
-    loadErrorMessage: String? = null,
-    url: String,
-    enabled: Boolean,
-    message: String,
-    isSaving: Boolean,
-    statusMessage: String?,
-    onUrlChanged: (String) -> Unit,
-    onEnabledChanged: (Boolean) -> Unit,
-    onMessageChanged: (String) -> Unit,
-    onSave: () -> Unit,
-    onRetry: () -> Unit = {},
-    modifier: Modifier = Modifier,
-) {
-    WebhookSettingsCard(
-        isLoading = isLoading,
-        title = "入金通知",
-        featureEnabled = enabled,
-        url = url,
-        onUrlChanged = onUrlChanged,
-        isSaving = isSaving,
-        onEnabledChanged = onEnabledChanged,
-        onSave = onSave,
-        modifier = modifier,
-        loadError = loadError,
-        loadErrorMessage = loadErrorMessage,
-        onRetry = onRetry,
-        description = "ユーザーが入金を登録した際に Webhook で通知します。",
-        message = message,
-        onMessageChanged = onMessageChanged,
-        statusMessage = statusMessage,
-    )
-}
-
-@Composable
-private fun CacheRefreshCard(
-    isClearing: Boolean,
-    message: String?,
-    onClearCache: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Card(
-        modifier = modifier,
-        colors =
-            CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceVariant,
-            ),
-    ) {
-        Column(
-            modifier = Modifier.padding(24.dp).fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            Text(
-                text = "データの不整合が疑われる場合に、サーバー側のキャッシュを手動でクリアします。",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-
-            if (message != null) {
-                Text(
-                    text = message,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-            }
-
-            Button(
-                onClick = onClearCache,
-                modifier = Modifier.height(48.dp),
-                enabled = !isClearing,
-            ) {
-                if (isClearing) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(20.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.onPrimary,
-                    )
-                } else {
-                    Text("キャッシュをクリア")
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun GarbageNotificationCard(
-    isLoading: Boolean,
-    loadError: Boolean = false,
-    loadErrorMessage: String? = null,
-    enabled: Boolean,
-    webhookUrl: String,
-    notifyHour: String,
-    prefix: String,
-    isSaving: Boolean,
-    isHourValid: Boolean,
-    message: String?,
-    onEnabledChanged: (Boolean) -> Unit,
-    onWebhookUrlChanged: (String) -> Unit,
-    onNotifyHourChanged: (String) -> Unit,
-    onPrefixChanged: (String) -> Unit,
-    onSave: () -> Unit,
-    onRetry: () -> Unit = {},
-    modifier: Modifier = Modifier,
-) {
-    WebhookSettingsCard(
-        isLoading = isLoading,
-        title = "リマインダー通知",
-        featureEnabled = enabled,
-        url = webhookUrl,
-        onUrlChanged = onWebhookUrlChanged,
-        isSaving = isSaving,
-        onEnabledChanged = onEnabledChanged,
-        onSave = onSave,
-        modifier = modifier,
-        loadError = loadError,
-        loadErrorMessage = loadErrorMessage,
-        onRetry = onRetry,
-        description = "この時刻に翌日のゴミ出し情報を通知します。ダッシュボードの表示切替は毎日 10:00 固定です。",
-        message = prefix,
-        onMessageChanged = onPrefixChanged,
-        statusMessage = message,
-        saveEnabled = !isSaving && isHourValid,
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Text(
-                text = "通知時刻",
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.width(80.dp),
-            )
-            OutlinedTextField(
-                value = notifyHour,
-                onValueChange = { v ->
-                    val filtered = v.filter { it.isDigit() }.take(2)
-                    onNotifyHourChanged(filtered)
-                },
-                label = { Text("時") },
-                singleLine = true,
-                isError = !isHourValid,
-                modifier = Modifier.width(72.dp),
-                enabled = !isSaving,
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                textStyle = MaterialTheme.typography.bodyMedium.copy(textAlign = TextAlign.Center),
-            )
-            Text(": 00", style = MaterialTheme.typography.titleMedium)
-        }
     }
 }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/UserManagementScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/UserManagementScreen.kt
@@ -1,0 +1,116 @@
+package feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import core.ui.components.LoadableCardContent
+import model.User
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+internal fun UserManagementScreen(modifier: Modifier = Modifier) {
+    val vm: UserNameViewModel = koinViewModel()
+    val s = vm.uiState
+
+    UserNameManagementCard(
+        isLoading = s.isLoading,
+        loadError = s.loadError,
+        loadErrorMessage = s.loadErrorMessage,
+        users = s.users,
+        usersSaving = s.isSaving,
+        usersMessage = s.message,
+        onUpdateDisplayName = vm::onUpdateDisplayName,
+        onRetry = vm::loadUsers,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun UserNameManagementCard(
+    isLoading: Boolean = false,
+    loadError: Boolean = false,
+    loadErrorMessage: String? = null,
+    users: List<User>,
+    usersSaving: Boolean,
+    usersMessage: String?,
+    onUpdateDisplayName: (String, String) -> Unit,
+    onRetry: () -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    var editedNames by remember(users) {
+        mutableStateOf(users.associate { it.uid to (it.displayName ?: "") })
+    }
+
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        LoadableCardContent(
+            isLoading = isLoading,
+            loadError = loadError,
+            loadErrorMessage = loadErrorMessage,
+            onRetry = onRetry,
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp).fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                for (user in users) {
+                    OutlinedTextField(
+                        value = editedNames[user.uid] ?: "",
+                        onValueChange = { value ->
+                            editedNames = editedNames.toMutableMap().apply { put(user.uid, value) }
+                        },
+                        label = { Text(user.uid) },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        enabled = !usersSaving,
+                    )
+                }
+
+                if (usersMessage != null) {
+                    Text(text = usersMessage, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
+                }
+
+                Button(
+                    onClick = {
+                        for (user in users) {
+                            val newName = editedNames[user.uid] ?: ""
+                            val oldName = user.displayName ?: ""
+                            if (newName != oldName) onUpdateDisplayName(user.uid, newName)
+                        }
+                    },
+                    modifier = Modifier.height(48.dp),
+                    enabled = !usersSaving,
+                ) {
+                    if (usersSaving) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                        )
+                    } else {
+                        Text("保存する")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/di/SettingsModule.kt
@@ -20,12 +20,11 @@ val settingsModule =
         viewModel { PasskeyManagementViewModel(get()) }
         viewModel { LoginHistoryViewModel(get()) }
         viewModel { LicensesViewModel() }
-        // Admin のみ条件付き生成
-        factory { UserNameViewModel(get()) }
-        factory { GarbageScheduleViewModel(get()) }
-        factory { QuestWebhookViewModel(get()) }
-        factory { MoneyWebhookViewModel(get()) }
-        factory { PaymentWebhookViewModel(get()) }
-        factory { CacheRefreshViewModel(get()) }
-        factory { PetSettingsViewModel(get(), get(), get()) }
+        viewModel { UserNameViewModel(get()) }
+        viewModel { GarbageScheduleViewModel(get()) }
+        viewModel { QuestWebhookViewModel(get()) }
+        viewModel { MoneyWebhookViewModel(get()) }
+        viewModel { PaymentWebhookViewModel(get()) }
+        viewModel { CacheRefreshViewModel(get()) }
+        viewModel { PetSettingsViewModel(get(), get(), get()) }
     }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/di/SettingsModule.kt
@@ -20,6 +20,9 @@ val settingsModule =
         viewModel { PasskeyManagementViewModel(get()) }
         viewModel { LoginHistoryViewModel(get()) }
         viewModel { LicensesViewModel() }
+        // 管理者専用カテゴリ。SettingsContent が isAdmin フィルタを通じてアクセスを制限するため、
+        // 非管理者が各 Screen の koinViewModel() に到達することはない。
+        // factory ではなく viewModel で登録することで ViewModel.viewModelScope を正しく管理する。
         viewModel { UserNameViewModel(get()) }
         viewModel { GarbageScheduleViewModel(get()) }
         viewModel { QuestWebhookViewModel(get()) }


### PR DESCRIPTION
## Summary

- 各設定カテゴリを独立した Screen composable として切り出し、`SettingsScreen` / `SettingsContent` はナビゲーション（カテゴリ一覧・2ペインレイアウト・URL フラグメント管理）のみに徹する構成に変更
- 各 Screen が自分の ViewModel を `koinViewModel()` で直接注入するため、`SettingsContent` のシグネチャが 70+ パラメータ → 4 パラメータに削減
- 多カード Screen（`AccountScreen`/`PetScreen`/`GarbageScreen`/`MoneyScreen`）が自身で `Column` を持ち、呼び出し側が `ColumnScope` であることを前提としない設計に
- `SettingsModule` の admin ViewModel 登録を `factory` → `viewModel` に変更（`viewModelScope` が適切に管理される）

### 新規ファイル
| ファイル | 内容 |
|---------|------|
| `AccountScreen.kt` | パスワード変更・パスキー管理・ログイン履歴 |
| `CreditsScreen.kt` | OSS ライセンス・データクレジット |
| `UserManagementScreen.kt` | ユーザー名管理（admin） |
| `PetScreen.kt` | ペット名・ごはん設定・リマインダー（admin） |
| `GarbageScreen.kt` | ゴミ出しスケジュール・通知（admin） |
| `QuestScreen.kt` | Quest Webhook 設定（admin） |
| `MoneyScreen.kt` | お金・入金 Webhook 設定（admin） |
| `CacheScreen.kt` | サーバーキャッシュ（admin） |

## Test plan

- [ ] 各設定カテゴリを開いて正常に表示されること
- [ ] 管理者権限のないユーザーに admin カテゴリが表示されないこと
- [ ] URL フラグメント（`/settings#Account` 等）でのカテゴリ直接遷移が動作すること
- [ ] Compact レイアウトで前後のナビゲーションが動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)