### PR TITLE
fix: ステータス更新とフォーム保存の isSaving フラグを分離 (close #189)

### DIFF
--- a/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
+++ b/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyScreen.kt
@@ -49,6 +49,7 @@ fun MoneyScreen(vm: MoneyViewModel = koinViewModel()) {
         currentYearMonth = vm.uiState.currentYearMonth,
         loading = vm.uiState.isLoading,
         saving = vm.uiState.isSaving,
+        statusSaving = vm.uiState.isStatusSaving,
         error = vm.uiState.error,
         users = vm.uiState.users,
         editingItem = vm.uiState.editingItem,
@@ -72,6 +73,7 @@ internal fun MoneyContent(
     currentYearMonth: String,
     loading: Boolean,
     saving: Boolean,
+    statusSaving: Boolean,
     error: String?,
     users: List<User>,
     editingItem: MoneyItem?,
@@ -159,6 +161,7 @@ internal fun MoneyContent(
                     MonthStatusSelector(
                         status = status,
                         onStatusChange = onUpdateStatus,
+                        enabled = !statusSaving,
                     )
                     Spacer(modifier = Modifier.height(8.dp))
 
@@ -232,6 +235,7 @@ internal fun MoneyContent(
                     MonthStatusSelector(
                         status = status,
                         onStatusChange = onUpdateStatus,
+                        enabled = !statusSaving,
                     )
                     if (!frozen && !loading && error == null) {
                         OutlinedButton(
@@ -628,6 +632,7 @@ private fun MonthSelector(
 private fun MonthStatusSelector(
     status: MonthlyMoneyStatus,
     onStatusChange: (MonthlyMoneyStatus) -> Unit,
+    enabled: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
     FlowRow(
@@ -641,6 +646,7 @@ private fun MonthStatusSelector(
                 selected = selected,
                 onClick = { if (!selected) onStatusChange(candidate) },
                 label = { Text(candidate.displayName, style = MaterialTheme.typography.labelMedium) },
+                enabled = enabled,
                 leadingIcon = {
                     Icon(
                         candidate.icon,

--- a/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyViewModel.kt
+++ b/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyViewModel.kt
@@ -53,6 +53,7 @@ data class MoneyUiState(
     val currentYearMonth: String = "",
     val isLoading: Boolean = true,
     val isSaving: Boolean = false,
+    val isStatusSaving: Boolean = false,
     val error: String? = null,
     val users: List<User> = emptyList(),
     val editingItem: MoneyItem? = null,
@@ -122,13 +123,16 @@ class MoneyViewModel(
     }
 
     fun onUpdateStatus(status: MonthlyMoneyStatus) {
-        if (uiState.monthlyMoney.status == status) return
+        if (uiState.monthlyMoney.status == status || uiState.isStatusSaving) return
+        uiState = uiState.copy(isStatusSaving = true)
         viewModelScope.launch {
             try {
                 val updated = moneyRepository.updateStatus(uiState.currentYearMonth, status)
                 uiState = uiState.copy(monthlyMoney = updated)
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
+            } finally {
+                uiState = uiState.copy(isStatusSaving = false)
             }
         }
     }


### PR DESCRIPTION
## Summary

- `MoneyUiState` に `isStatusSaving` フラグを追加
- `onUpdateStatus` に `isStatusSaving` ガードを追加（連打防止 + try/finally で確実にリセット）
- `MonthStatusSelector` に `enabled` パラメータを追加し、`isStatusSaving` 中は FilterChip を無効化
- フォーム側の `saving`（`isSaving`）とステータス側の `statusSaving`（`isStatusSaving`）を独立して管理するため、一方の操作中に他方の UI がブロックされなくなった

close #189

## Test plan

- [ ] ステータス切替中（低速回線を想定）にフォームの保存ボタンが操作できること
- [ ] フォーム保存中にステータス切替 FilterChip が操作できること
- [ ] ステータス切替中は FilterChip が `enabled = false` になること
- [ ] ステータス切替が完了すると FilterChip が再び操作できること
- [ ] エラー発生時も `isStatusSaving` が確実に `false` に戻ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)