### PR TITLE
fix: TabResumedEvent を collector 不在耐性のある設定に変更 (close #193)

### DIFF
--- a/core/common/src/commonMain/kotlin/core/common/TabResumedEvent.kt
+++ b/core/common/src/commonMain/kotlin/core/common/TabResumedEvent.kt
@@ -1,5 +1,6 @@
 package core.common
 
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -8,12 +9,19 @@ import kotlinx.coroutines.flow.asSharedFlow
  * バックグラウンド復帰時のイベントバス。
  * AuthenticatedApp がトークンリフレッシュ完了後に emit し、
  * 各 ViewModel が collect してデータを再取得する。
+ *
+ * subscriber が未生成の状態（Dashboard/Feeding 画面を未訪問）でも emit が hang しないよう、
+ * `extraBufferCapacity=1` + `DROP_OLDEST` で最新 1 件のみ保持する。
  */
 class TabResumedEvent {
-    private val _events = MutableSharedFlow<Unit>()
+    private val _events =
+        MutableSharedFlow<Unit>(
+            extraBufferCapacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
     val events: SharedFlow<Unit> = _events.asSharedFlow()
 
-    suspend fun emit() {
-        _events.emit(Unit)
+    fun emit() {
+        _events.tryEmit(Unit)
     }
 }


### PR DESCRIPTION
## Summary

- `TabResumedEvent` の `MutableSharedFlow` を `FeedingSettingsChangedEvent` と同じ設定（`extraBufferCapacity=1`、`onBufferOverflow=DROP_OLDEST`）に揃えた
- `suspend fun emit()` → `fun emit() = _events.tryEmit(Unit)` に変更し、subscriber 不在時に呼び出し元コルーチンが hang するリスクを排除
- issue #193 フェーズA の TabResumedEvent 部分のみ対応

close #193

## Test plan

- [ ] Dashboard/Feeding 画面を未訪問の状態でタブをバックグラウンド→復帰しても UI がフリーズしないこと
- [ ] Dashboard/Feeding 画面訪問後にタブを復帰したとき、データが再取得されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)