### PR TITLE
chore: gradle/actions と eclipse-temurin を更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
       - name: ktlint check
         run: chmod +x gradlew && ./gradlew ktlintCheck
 
@@ -28,7 +28,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
       - name: Unit tests (shared + core + feature)
         run: chmod +x gradlew && ./gradlew jvmTest
       - name: Server unit tests
@@ -72,6 +72,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
       - name: Build fat JAR (server + WASM frontend)
         run: chmod +x gradlew && ./gradlew :server:buildFatJar

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ git tag v1.x.x && git push origin v1.x.x
 
 ## Docker
 
-Dockerfile はマルチステージビルド（Gradle でビルド → JRE Alpine で実行）。ビルドステージで WASM フロントエンド + fat JAR を生成し、実行ステージは `eclipse-temurin:21-jre-alpine` 上で `app.jar` を起動する。ポート 8080 を公開。GHCR 経由で本番デプロイする（リバースプロキシ前提）。HEALTHCHECK 付き。詳細は README.md の「Docker」セクションを参照。
+Dockerfile はマルチステージビルド（Gradle でビルド → JRE で実行）。ビルドステージで WASM フロントエンド + fat JAR を生成し、実行ステージは `eclipse-temurin:25-jre-noble` 上で `app.jar` を起動する。ポート 8080 を公開。GHCR 経由で本番デプロイする（リバースプロキシ前提）。HEALTHCHECK 付き。詳細は README.md の「Docker」セクションを参照。
 
 ビルドステージでは CI runner の OOM 回避のため Gradle daemon `-Xmx2g`（Dockerfile 側で指定） + `parallel=false`（Dockerfile 側で指定）で起動する。`compileProductionExecutableKotlinWasmJs` は別プロセス（Kotlin compiler daemon）で動くため、heap は `gradle.properties` の `kotlin.daemon.jvmargs=-Xmx4096M` で指定する必要がある（`-D` のシステムプロパティでは Kotlin Gradle Plugin が拾わない）。
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN gradle :server:buildFatJar --no-daemon \
     -Dorg.gradle.jvmargs="-Xmx2g -Dfile.encoding=UTF-8" \
     -Dorg.gradle.parallel=false
 
-FROM eclipse-temurin:21.0.10_7-jre-noble
+FROM eclipse-temurin:25.0.2_10-jre-noble
 WORKDIR /app
 COPY --from=build /app/server/build/libs/*-all.jar app.jar
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ eval "$(./dev.sh --completions)"
 
 ### 本番（GHCR デプロイ）
 
-Dockerfile はマルチステージビルド（Gradle でビルド → JRE Alpine で実行）。ビルド済みイメージを GHCR から pull して実行する。リバースプロキシ（Traefik 等）が外部ネットワーク上で TLS 終端・ポート公開を担当する前提。HEALTHCHECK 付き。
+Dockerfile はマルチステージビルド（Gradle でビルド → JRE で実行）。ビルド済みイメージを GHCR から pull して実行する。リバースプロキシ（Traefik 等）が外部ネットワーク上で TLS 終端・ポート公開を担当する前提。HEALTHCHECK 付き。
 
 #### デプロイ方法
 


### PR DESCRIPTION
## Summary
- `gradle/actions/setup-gradle` を v4 → v5 に更新
- Docker 実行ステージのベースイメージを `eclipse-temurin:21.0.10_7-jre-noble` → `25.0.2_10-jre-noble` に更新
- 上記に伴い CLAUDE.md / README.md の Docker 関連記述を実態に合わせて修正
- `org.jetbrains.exposed` は既に 1.1.1 まで更新済みのため対応不要（gradle/libs.versions.toml で確認）

## Test plan
- [ ] CI が正常に完了することを確認（lint / test / build）
- [ ] Docker イメージのビルドが正常に完了することを確認