### PR TITLE
feat: 支払い項目に支払期日と期日リマインダー通知を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ shared/              → Kotlin Multiplatform library
 
 server/              → Ktor server (Netty, JVM)
                        Depends on :shared
-                       Routes: /api/{firebase-config,users,pets,feeding,garbage,money,money-webhook,payment-webhook,report,quest,point,quest-webhook,cache,login-history,passkey}
+                       Routes: /api/{firebase-config,users,pets,feeding,garbage,money,money-webhook,money-due-date-notification,payment-webhook,report,quest,point,quest-webhook,cache,login-history,passkey}
                        IP ジオロケーション: server/geo/ (MaxMind GeoLite2-City オフライン DB、ファイル不在時は NoOp)
                        Firebase Auth verification
                        Koin DI でリポジトリ注入（ServerModule）

--- a/core/network/src/commonMain/kotlin/core/network/AuthHttpClient.kt
+++ b/core/network/src/commonMain/kotlin/core/network/AuthHttpClient.kt
@@ -1,5 +1,6 @@
 package core.network
 
+import config.HttpTimeouts
 import core.auth.AuthRepository
 import core.auth.AuthStateHolder
 import core.common.AppLogger
@@ -33,6 +34,9 @@ private suspend fun HttpResponse.extractErrorMessage(): String {
 
 fun createUnauthenticatedClient(): HttpClient =
     HttpClient {
+        install(HttpTimeout) {
+            requestTimeoutMillis = HttpTimeouts.DEFAULT_REQUEST_TIMEOUT_MILLIS
+        }
         install(ContentNegotiation) {
             json(Json { ignoreUnknownKeys = true })
         }
@@ -50,6 +54,9 @@ fun createAuthenticatedClient(
     authStateHolder: AuthStateHolder,
 ): HttpClient =
     HttpClient {
+        install(HttpTimeout) {
+            requestTimeoutMillis = HttpTimeouts.DEFAULT_REQUEST_TIMEOUT_MILLIS
+        }
         install(ContentNegotiation) {
             json(Json { ignoreUnknownKeys = true })
         }

--- a/core/network/src/commonMain/kotlin/core/network/MoneyDueDateNotificationRepository.kt
+++ b/core/network/src/commonMain/kotlin/core/network/MoneyDueDateNotificationRepository.kt
@@ -1,0 +1,26 @@
+package core.network
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import model.MoneyDueDateNotificationSettings
+
+interface MoneyDueDateNotificationRepository {
+    suspend fun getSettings(): MoneyDueDateNotificationSettings
+
+    suspend fun updateSettings(settings: MoneyDueDateNotificationSettings): MoneyDueDateNotificationSettings
+}
+
+class MoneyDueDateNotificationRepositoryImpl(
+    private val client: HttpClient,
+) : MoneyDueDateNotificationRepository {
+    override suspend fun getSettings(): MoneyDueDateNotificationSettings = client.get("/api/money/due-date-notification-settings").body()
+
+    override suspend fun updateSettings(settings: MoneyDueDateNotificationSettings): MoneyDueDateNotificationSettings =
+        client
+            .put("/api/money/due-date-notification-settings") {
+                contentType(ContentType.Application.Json)
+                setBody(settings)
+            }.body()
+}

--- a/core/network/src/commonMain/kotlin/core/network/MoneyDueDateNotificationRepository.kt
+++ b/core/network/src/commonMain/kotlin/core/network/MoneyDueDateNotificationRepository.kt
@@ -10,6 +10,8 @@ interface MoneyDueDateNotificationRepository {
     suspend fun getSettings(): MoneyDueDateNotificationSettings
 
     suspend fun updateSettings(settings: MoneyDueDateNotificationSettings): MoneyDueDateNotificationSettings
+
+    suspend fun test()
 }
 
 class MoneyDueDateNotificationRepositoryImpl(
@@ -23,4 +25,8 @@ class MoneyDueDateNotificationRepositoryImpl(
                 contentType(ContentType.Application.Json)
                 setBody(settings)
             }.body()
+
+    override suspend fun test() {
+        client.post("/api/money/due-date-notification-settings/test")
+    }
 }

--- a/core/network/src/wasmJsMain/kotlin/core/network/di/NetworkModule.kt
+++ b/core/network/src/wasmJsMain/kotlin/core/network/di/NetworkModule.kt
@@ -10,6 +10,8 @@ import core.network.GarbageScheduleRepository
 import core.network.GarbageScheduleRepositoryImpl
 import core.network.LoginHistoryRepository
 import core.network.LoginHistoryRepositoryImpl
+import core.network.MoneyDueDateNotificationRepository
+import core.network.MoneyDueDateNotificationRepositoryImpl
 import core.network.MoneyRepository
 import core.network.MoneyRepositoryImpl
 import core.network.MoneyWebhookRepository
@@ -44,6 +46,7 @@ val networkModule =
         single<FeedingSettingsRepository> { FeedingSettingsRepositoryImpl(get()) }
         single<GarbageScheduleRepository> { GarbageScheduleRepositoryImpl(get()) }
         single<MoneyRepository> { MoneyRepositoryImpl(get()) }
+        single<MoneyDueDateNotificationRepository> { MoneyDueDateNotificationRepositoryImpl(get()) }
         single<ReportRepository> { ReportRepositoryImpl(get()) }
         single<PointRepository> { PointRepositoryImpl(get()) }
         single<QuestRepository> { QuestRepositoryImpl(get()) }

--- a/core/ui/src/commonMain/kotlin/core/ui/util/DateUtils.kt
+++ b/core/ui/src/commonMain/kotlin/core/ui/util/DateUtils.kt
@@ -119,6 +119,9 @@ fun toJstMonthDay(iso: String): String = jstFromIso(iso).let { "${it.month.numbe
 /** "YYYY-MM-DD" 形式の日付文字列を "M月D日" 形式に変換 */
 fun formatDueDate(dateStr: String): String = parseDate(dateStr).let { "${it.month.number}月${it.day}日" }
 
+/** 支払期日のグループ見出し。null（未設定）は「期日無し」。 */
+fun dueDateGroupLabel(dueDate: String?): String = dueDate?.let(::formatDueDate) ?: "期日無し"
+
 private fun deadlineToInstant(deadline: String): Instant {
     val date = parseDate(deadline)
     val time =

--- a/core/ui/src/commonMain/kotlin/core/ui/util/DateUtils.kt
+++ b/core/ui/src/commonMain/kotlin/core/ui/util/DateUtils.kt
@@ -116,6 +116,9 @@ fun toJstMinute(iso: String): String = jstFromIso(iso).minute.toString().padStar
 /** ISO タイムスタンプを JST の "M/D" 形式に変換 */
 fun toJstMonthDay(iso: String): String = jstFromIso(iso).let { "${it.month.number}/${it.day}" }
 
+/** "YYYY-MM-DD" 形式の日付文字列を "M月D日" 形式に変換 */
+fun formatDueDate(dateStr: String): String = parseDate(dateStr).let { "${it.month.number}月${it.day}日" }
+
 private fun deadlineToInstant(deadline: String): Instant {
     val date = parseDate(deadline)
     val time =

--- a/core/ui/src/commonMain/kotlin/core/ui/util/DateUtils.kt
+++ b/core/ui/src/commonMain/kotlin/core/ui/util/DateUtils.kt
@@ -119,8 +119,11 @@ fun toJstMonthDay(iso: String): String = jstFromIso(iso).let { "${it.month.numbe
 /** "YYYY-MM-DD" 形式の日付文字列を "M月D日" 形式に変換 */
 fun formatDueDate(dateStr: String): String = parseDate(dateStr).let { "${it.month.number}月${it.day}日" }
 
-/** 支払期日のグループ見出し。null（未設定）は「期日無し」。 */
-fun dueDateGroupLabel(dueDate: String?): String = dueDate?.let(::formatDueDate) ?: "期日無し"
+/**
+ * 支払期日のグループ見出し。null（未設定）は「支払期日なし」。
+ * 日付だけだと項目の入力日と誤読されるため、「支払期日:」プレフィックスを必ず付ける。
+ */
+fun dueDateGroupLabel(dueDate: String?): String = dueDate?.let { "支払期日: ${formatDueDate(it)}" } ?: "支払期日なし"
 
 private fun deadlineToInstant(deadline: String): Instant {
     val date = parseDate(deadline)

--- a/feature/money/src/commonMain/kotlin/feature/money/MoneyContent.kt
+++ b/feature/money/src/commonMain/kotlin/feature/money/MoneyContent.kt
@@ -33,7 +33,7 @@ import core.ui.components.CalendarView
 import core.ui.extensions.displayName
 import core.ui.extensions.icon
 import core.ui.formatYen
-import core.ui.util.formatDueDate
+import core.ui.util.dueDateGroupLabel
 import core.ui.util.todayDate
 import model.MoneyItem
 import model.MoneyTags
@@ -42,20 +42,7 @@ import model.MonthlyMoneyStatus
 import model.Payment
 import model.Share
 import model.User
-
-/**
- * 項目を支払期日でグルーピングする。期日昇順、未設定（null）は最後。
- * グループ内の順序は元の並び順を維持する。
- */
-private fun groupItemsByDueDate(items: List<MoneyItem>): List<Pair<String?, List<MoneyItem>>> {
-    val grouped = items.groupBy { it.dueDate }
-    val dueDates = grouped.keys.filterNotNull().sorted()
-    val ordered = dueDates.map { it to grouped.getValue(it) }
-    val withoutDueDate = grouped[null]
-    return if (withoutDueDate != null) ordered + (null to withoutDueDate) else ordered
-}
-
-private fun dueDateGroupLabel(dueDate: String?): String = dueDate?.let(::formatDueDate) ?: "期日無し"
+import model.groupedByDueDate
 
 @Composable
 internal fun MoneyContent(
@@ -337,7 +324,7 @@ private fun MoneyListContent(
                 }
 
                 val sortedItems = monthlyMoney.items.sortedByDescending { it.tags.isNotEmpty() }
-                for ((dueDate, groupItems) in groupItemsByDueDate(sortedItems)) {
+                for ((dueDate, groupItems) in sortedItems.groupedByDueDate()) {
                     item(key = "due-header-${dueDate ?: "none"}") {
                         Text(
                             text = dueDateGroupLabel(dueDate),
@@ -893,13 +880,6 @@ private fun MoneyItemCard(
                         style = MaterialTheme.typography.headlineSmall,
                         color = MaterialTheme.colorScheme.primary,
                     )
-                    item.dueDate?.let { dueDate ->
-                        Text(
-                            text = "期日: ${formatDueDate(dueDate)}",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
                 }
 
                 Row {

--- a/feature/money/src/commonMain/kotlin/feature/money/MoneyContent.kt
+++ b/feature/money/src/commonMain/kotlin/feature/money/MoneyContent.kt
@@ -1,5 +1,6 @@
 package feature.money
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -11,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Warning
@@ -27,9 +29,12 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import core.ui.WindowSizeClass
+import core.ui.components.CalendarView
 import core.ui.extensions.displayName
 import core.ui.extensions.icon
 import core.ui.formatYen
+import core.ui.util.formatDueDate
+import core.ui.util.todayDate
 import model.MoneyItem
 import model.MoneyTags
 import model.MonthlyMoney
@@ -37,6 +42,20 @@ import model.MonthlyMoneyStatus
 import model.Payment
 import model.Share
 import model.User
+
+/**
+ * 項目を支払期日でグルーピングする。期日昇順、未設定（null）は最後。
+ * グループ内の順序は元の並び順を維持する。
+ */
+private fun groupItemsByDueDate(items: List<MoneyItem>): List<Pair<String?, List<MoneyItem>>> {
+    val grouped = items.groupBy { it.dueDate }
+    val dueDates = grouped.keys.filterNotNull().sorted()
+    val ordered = dueDates.map { it to grouped.getValue(it) }
+    val withoutDueDate = grouped[null]
+    return if (withoutDueDate != null) ordered + (null to withoutDueDate) else ordered
+}
+
+private fun dueDateGroupLabel(dueDate: String?): String = dueDate?.let(::formatDueDate) ?: "期日無し"
 
 @Composable
 internal fun MoneyContent(
@@ -55,7 +74,7 @@ internal fun MoneyContent(
     onClearForm: () -> Unit,
     onDeleteItem: (MoneyItem) -> Unit,
     onMoveItem: (MoneyItem, Int) -> Unit,
-    onSaveItem: (String, Long, String, List<Share>, List<String>) -> Unit,
+    onSaveItem: (String, Long, String, String?, List<Share>, List<String>) -> Unit,
     onUpdateStatus: (MonthlyMoneyStatus) -> Unit,
     onImportRecurringItems: () -> Unit,
     windowSizeClass: WindowSizeClass = WindowSizeClass.Expanded,
@@ -318,17 +337,27 @@ private fun MoneyListContent(
                 }
 
                 val sortedItems = monthlyMoney.items.sortedByDescending { it.tags.isNotEmpty() }
-                items(sortedItems, key = { it.id }) { item ->
-                    MoneyItemCard(
-                        item = item,
-                        users = users,
-                        onEdit = { onEditItem(item) },
-                        onDelete = { onDeleteItem(item) },
-                        onMovePrev = { onMoveItem(item, -1) },
-                        onMoveNext = { onMoveItem(item, 1) },
-                        isCompact = isCompact,
-                        frozen = frozen,
-                    )
+                for ((dueDate, groupItems) in groupItemsByDueDate(sortedItems)) {
+                    item(key = "due-header-${dueDate ?: "none"}") {
+                        Text(
+                            text = dueDateGroupLabel(dueDate),
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(top = 4.dp),
+                        )
+                    }
+                    items(groupItems, key = { it.id }) { item ->
+                        MoneyItemCard(
+                            item = item,
+                            users = users,
+                            onEdit = { onEditItem(item) },
+                            onDelete = { onDeleteItem(item) },
+                            onMovePrev = { onMoveItem(item, -1) },
+                            onMoveNext = { onMoveItem(item, 1) },
+                            isCompact = isCompact,
+                            frozen = frozen,
+                        )
+                    }
                 }
             }
         }
@@ -342,7 +371,7 @@ private fun MoneyItemForm(
     users: List<User>,
     saving: Boolean,
     frozen: Boolean,
-    onSave: (String, Long, String, List<Share>, List<String>) -> Unit,
+    onSave: (String, Long, String, String?, List<Share>, List<String>) -> Unit,
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -352,6 +381,8 @@ private fun MoneyItemForm(
     var amountText by remember(key) { mutableStateOf(item?.amount?.toString() ?: "") }
     var note by remember(key) { mutableStateOf(item?.note ?: "") }
     var selectedTags by remember(key) { mutableStateOf(item?.tags ?: emptyList()) }
+    var dueDate by remember(key) { mutableStateOf(item?.dueDate ?: "") }
+    var showCalendar by remember(key) { mutableStateOf(false) }
     var shareAmounts by remember(key) {
         mutableStateOf(
             users.associate { user ->
@@ -440,6 +471,52 @@ private fun MoneyItemForm(
                         },
                         label = { Text(tag) },
                         enabled = !saving,
+                    )
+                }
+            }
+
+            Column {
+                Text(
+                    text = "支払期日（任意）",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    OutlinedButton(
+                        onClick = { showCalendar = !showCalendar },
+                        enabled = !saving,
+                    ) {
+                        Icon(
+                            Icons.Default.CalendarMonth,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(dueDate.ifBlank { "日付を選択" })
+                    }
+                    if (dueDate.isNotBlank()) {
+                        TextButton(onClick = {
+                            dueDate = ""
+                            showCalendar = false
+                        }, enabled = !saving) {
+                            Text("クリア")
+                        }
+                    }
+                }
+                AnimatedVisibility(visible = showCalendar) {
+                    val today = remember { todayDate() }
+                    CalendarView(
+                        selectedDate = dueDate.ifBlank { today },
+                        today = today,
+                        onDateSelected = { selected ->
+                            dueDate = selected
+                            showCalendar = false
+                        },
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
                     )
                 }
             }
@@ -563,7 +640,7 @@ private fun MoneyItemForm(
                 }
                 Spacer(modifier = Modifier.width(8.dp))
                 Button(
-                    onClick = { onSave(name, amount, note, shares, selectedTags) },
+                    onClick = { onSave(name, amount, note, dueDate.ifBlank { null }, shares, selectedTags) },
                     enabled = name.isNotBlank() && isAmountValid && !saving && !frozen,
                 ) {
                     Text(if (isEditing) "保存" else "追加")
@@ -816,6 +893,13 @@ private fun MoneyItemCard(
                         style = MaterialTheme.typography.headlineSmall,
                         color = MaterialTheme.colorScheme.primary,
                     )
+                    item.dueDate?.let { dueDate ->
+                        Text(
+                            text = "期日: ${formatDueDate(dueDate)}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 }
 
                 Row {

--- a/feature/money/src/jvmTest/kotlin/feature/money/PreviewScreenshotGeneratorTest.kt
+++ b/feature/money/src/jvmTest/kotlin/feature/money/PreviewScreenshotGeneratorTest.kt
@@ -39,7 +39,14 @@ class PreviewScreenshotGeneratorTest {
                             id = "item1",
                             name = "電気代",
                             amount = 8000,
+                            dueDate = "2026-07-25",
                             shares = listOf(Share("user1", 4000), Share("user2", 4000)),
+                        ),
+                        MoneyItem(
+                            id = "item2",
+                            name = "食費",
+                            amount = 5000,
+                            shares = listOf(Share("user1", 2500), Share("user2", 2500)),
                         ),
                     ),
             )
@@ -71,7 +78,7 @@ class PreviewScreenshotGeneratorTest {
                             onClearForm = {},
                             onDeleteItem = {},
                             onMoveItem = { _, _ -> },
-                            onSaveItem = { _, _, _, _, _ -> },
+                            onSaveItem = { _, _, _, _, _, _ -> },
                             onUpdateStatus = {},
                             onImportRecurringItems = {},
                             windowSizeClass = pattern.windowSizeClass,

--- a/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyViewModel.kt
+++ b/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyViewModel.kt
@@ -149,6 +149,7 @@ class MoneyViewModel(
         name: String,
         amount: Long,
         note: String,
+        dueDate: String?,
         shares: List<Share>,
         tags: List<String>,
     ) {
@@ -156,13 +157,14 @@ class MoneyViewModel(
 
         val newItem =
             if (existing != null) {
-                existing.copy(name = name, amount = amount, note = note, shares = shares, tags = tags)
+                existing.copy(name = name, amount = amount, note = note, dueDate = dueDate, shares = shares, tags = tags)
             } else {
                 MoneyItem(
                     id = randomUUID().toString(),
                     name = name,
                     amount = amount,
                     note = note,
+                    dueDate = dueDate,
                     shares = shares,
                     tags = tags,
                 )

--- a/feature/payment/src/commonMain/kotlin/feature/payment/PaymentContent.kt
+++ b/feature/payment/src/commonMain/kotlin/feature/payment/PaymentContent.kt
@@ -19,12 +19,27 @@ import core.ui.WindowSizeClass
 import core.ui.extensions.displayName
 import core.ui.extensions.icon
 import core.ui.formatYen
+import core.ui.util.formatDueDate
 import core.ui.util.toJstMonthDay
 import model.MoneyItem
 import model.MonthlyMoney
 import model.MonthlyMoneyStatus
 import model.Payment
 import model.User
+
+/**
+ * 項目を支払期日でグルーピングする。期日昇順、未設定（null）は最後。
+ * グループ内の順序は元の並び順を維持する。
+ */
+private fun groupItemsByDueDate(items: List<MoneyItem>): List<Pair<String?, List<MoneyItem>>> {
+    val grouped = items.groupBy { it.dueDate }
+    val dueDates = grouped.keys.filterNotNull().sorted()
+    val ordered = dueDates.map { it to grouped.getValue(it) }
+    val withoutDueDate = grouped[null]
+    return if (withoutDueDate != null) ordered + (null to withoutDueDate) else ordered
+}
+
+private fun dueDateGroupLabel(dueDate: String?): String = dueDate?.let(::formatDueDate) ?: "期日無し"
 
 @Composable
 internal fun PaymentContent(
@@ -266,7 +281,7 @@ private fun PaymentListContent(
                     }
                 }
 
-                // 項目内訳
+                // 項目内訳（支払期日ごとにグルーピング）
                 if (monthlyMoney.items.isNotEmpty()) {
                     item(key = "items-header") {
                         Text(
@@ -275,12 +290,21 @@ private fun PaymentListContent(
                             modifier = Modifier.padding(top = 8.dp),
                         )
                     }
-                    items(monthlyMoney.items, key = { it.id }) { item ->
-                        ItemBreakdownCard(
-                            item = item,
-                            currentUid = currentUid,
-                            isCompact = isCompact,
-                        )
+                    for ((dueDate, groupItems) in groupItemsByDueDate(monthlyMoney.items)) {
+                        item(key = "due-header-${dueDate ?: "none"}") {
+                            Text(
+                                text = dueDateGroupLabel(dueDate),
+                                style = MaterialTheme.typography.labelLarge,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        items(groupItems, key = { it.id }) { item ->
+                            ItemBreakdownCard(
+                                item = item,
+                                currentUid = currentUid,
+                                isCompact = isCompact,
+                            )
+                        }
                     }
                 }
 
@@ -632,10 +656,19 @@ private fun ItemBreakdownCard(
                     )
                 }
             }
-            Text(
-                text = formatYen(myAllocation),
-                style = MaterialTheme.typography.bodyMedium,
-            )
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = formatYen(myAllocation),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                item.dueDate?.let { dueDate ->
+                    Text(
+                        text = "期日: ${formatDueDate(dueDate)}",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
         }
     }
 }

--- a/feature/payment/src/commonMain/kotlin/feature/payment/PaymentContent.kt
+++ b/feature/payment/src/commonMain/kotlin/feature/payment/PaymentContent.kt
@@ -19,27 +19,14 @@ import core.ui.WindowSizeClass
 import core.ui.extensions.displayName
 import core.ui.extensions.icon
 import core.ui.formatYen
-import core.ui.util.formatDueDate
+import core.ui.util.dueDateGroupLabel
 import core.ui.util.toJstMonthDay
 import model.MoneyItem
 import model.MonthlyMoney
 import model.MonthlyMoneyStatus
 import model.Payment
 import model.User
-
-/**
- * 項目を支払期日でグルーピングする。期日昇順、未設定（null）は最後。
- * グループ内の順序は元の並び順を維持する。
- */
-private fun groupItemsByDueDate(items: List<MoneyItem>): List<Pair<String?, List<MoneyItem>>> {
-    val grouped = items.groupBy { it.dueDate }
-    val dueDates = grouped.keys.filterNotNull().sorted()
-    val ordered = dueDates.map { it to grouped.getValue(it) }
-    val withoutDueDate = grouped[null]
-    return if (withoutDueDate != null) ordered + (null to withoutDueDate) else ordered
-}
-
-private fun dueDateGroupLabel(dueDate: String?): String = dueDate?.let(::formatDueDate) ?: "期日無し"
+import model.groupedByDueDate
 
 @Composable
 internal fun PaymentContent(
@@ -290,7 +277,7 @@ private fun PaymentListContent(
                             modifier = Modifier.padding(top = 8.dp),
                         )
                     }
-                    for ((dueDate, groupItems) in groupItemsByDueDate(monthlyMoney.items)) {
+                    for ((dueDate, groupItems) in monthlyMoney.items.groupedByDueDate()) {
                         item(key = "due-header-${dueDate ?: "none"}") {
                             Text(
                                 text = dueDateGroupLabel(dueDate),
@@ -656,19 +643,10 @@ private fun ItemBreakdownCard(
                     )
                 }
             }
-            Column(horizontalAlignment = Alignment.End) {
-                Text(
-                    text = formatYen(myAllocation),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-                item.dueDate?.let { dueDate ->
-                    Text(
-                        text = "期日: ${formatDueDate(dueDate)}",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
+            Text(
+                text = formatYen(myAllocation),
+                style = MaterialTheme.typography.bodyMedium,
+            )
         }
     }
 }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/MoneyDueDateNotificationViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/MoneyDueDateNotificationViewModel.kt
@@ -1,0 +1,111 @@
+package feature.settings
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import core.network.MoneyDueDateNotificationRepository
+import kotlinx.coroutines.launch
+import model.MoneyDueDateNotificationSettings
+
+data class MoneyDueDateNotificationUiState(
+    val enabled: Boolean = false,
+    val webhookUrl: String = "",
+    val daysBefore: String = "1",
+    val notifyHour: String = "23",
+    val prefix: String = "",
+    val isLoading: Boolean = true,
+    val loadError: Boolean = false,
+    val loadErrorMessage: String? = null,
+    val isSaving: Boolean = false,
+    val statusMessage: String? = null,
+) {
+    val isDaysBeforeValid: Boolean
+        get() = (daysBefore.toIntOrNull() ?: -1) >= 0
+
+    val isNotifyHourValid: Boolean
+        get() {
+            val h = notifyHour.toIntOrNull() ?: return false
+            return h in 0..23
+        }
+}
+
+class MoneyDueDateNotificationViewModel(
+    private val moneyDueDateNotificationRepository: MoneyDueDateNotificationRepository,
+) : ViewModel() {
+    var uiState by mutableStateOf(MoneyDueDateNotificationUiState())
+        private set
+
+    init {
+        loadSettings()
+    }
+
+    fun loadSettings() {
+        uiState =
+            uiState.copy(
+                isLoading = true,
+                loadError = false,
+                loadErrorMessage = null,
+                statusMessage = null,
+            )
+        viewModelScope.launch {
+            try {
+                val settings = moneyDueDateNotificationRepository.getSettings()
+                uiState =
+                    uiState.copy(
+                        enabled = settings.enabled,
+                        webhookUrl = settings.webhookUrl,
+                        daysBefore = settings.daysBefore.toString(),
+                        notifyHour = settings.notifyHour.toString(),
+                        prefix = settings.prefix,
+                        isLoading = false,
+                    )
+            } catch (e: Exception) {
+                uiState = uiState.copy(isLoading = false, loadError = true, loadErrorMessage = e.message)
+            }
+        }
+    }
+
+    fun onEnabledChanged(enabled: Boolean) {
+        uiState = uiState.copy(enabled = enabled, statusMessage = null)
+    }
+
+    fun onWebhookUrlChanged(url: String) {
+        uiState = uiState.copy(webhookUrl = url, statusMessage = null)
+    }
+
+    fun onDaysBeforeChanged(daysBefore: String) {
+        uiState = uiState.copy(daysBefore = daysBefore.filter { it.isDigit() }.take(3), statusMessage = null)
+    }
+
+    fun onNotifyHourChanged(notifyHour: String) {
+        uiState = uiState.copy(notifyHour = notifyHour.filter { it.isDigit() }.take(2), statusMessage = null)
+    }
+
+    fun onPrefixChanged(prefix: String) {
+        uiState = uiState.copy(prefix = prefix, statusMessage = null)
+    }
+
+    fun onSave() {
+        val daysBefore = uiState.daysBefore.toIntOrNull() ?: return
+        val notifyHour = uiState.notifyHour.toIntOrNull() ?: return
+        uiState = uiState.copy(isSaving = true, statusMessage = null)
+        viewModelScope.launch {
+            try {
+                moneyDueDateNotificationRepository.updateSettings(
+                    MoneyDueDateNotificationSettings(
+                        enabled = uiState.enabled,
+                        webhookUrl = uiState.webhookUrl,
+                        daysBefore = daysBefore,
+                        notifyHour = notifyHour,
+                        prefix = uiState.prefix,
+                    ),
+                )
+                uiState = uiState.copy(isSaving = false, statusMessage = "保存しました")
+            } catch (e: Exception) {
+                uiState = uiState.copy(isSaving = false, statusMessage = "保存に失敗しました: ${e.message}")
+            }
+        }
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/feature/settings/MoneyDueDateNotificationViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/MoneyDueDateNotificationViewModel.kt
@@ -19,6 +19,7 @@ data class MoneyDueDateNotificationUiState(
     val loadError: Boolean = false,
     val loadErrorMessage: String? = null,
     val isSaving: Boolean = false,
+    val isTesting: Boolean = false,
     val statusMessage: String? = null,
 ) {
     val isDaysBeforeValid: Boolean
@@ -105,6 +106,18 @@ class MoneyDueDateNotificationViewModel(
                 uiState = uiState.copy(isSaving = false, statusMessage = "保存しました")
             } catch (e: Exception) {
                 uiState = uiState.copy(isSaving = false, statusMessage = "保存に失敗しました: ${e.message}")
+            }
+        }
+    }
+
+    fun onTest() {
+        uiState = uiState.copy(isTesting = true, statusMessage = null)
+        viewModelScope.launch {
+            try {
+                moneyDueDateNotificationRepository.test()
+                uiState = uiState.copy(isTesting = false, statusMessage = "テスト送信しました")
+            } catch (e: Exception) {
+                uiState = uiState.copy(isTesting = false, statusMessage = "テスト送信失敗: ${e.message}")
             }
         }
     }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/MoneyScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/MoneyScreen.kt
@@ -2,9 +2,18 @@ package feature.settings
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -12,6 +21,7 @@ import org.koin.compose.viewmodel.koinViewModel
 internal fun MoneyScreen(modifier: Modifier = Modifier) {
     val moneyVm: MoneyWebhookViewModel = koinViewModel()
     val paymentVm: PaymentWebhookViewModel = koinViewModel()
+    val dueDateVm: MoneyDueDateNotificationViewModel = koinViewModel()
 
     MoneyContent(
         moneyState = moneyVm.uiState,
@@ -26,6 +36,14 @@ internal fun MoneyScreen(modifier: Modifier = Modifier) {
         onPaymentSave = paymentVm::onSave,
         onPaymentMessageChanged = paymentVm::onMessageChanged,
         onRetryPayment = paymentVm::loadSettings,
+        dueDateState = dueDateVm.uiState,
+        onDueDateUrlChanged = dueDateVm::onWebhookUrlChanged,
+        onDueDateEnabledChanged = dueDateVm::onEnabledChanged,
+        onDueDateSave = dueDateVm::onSave,
+        onDueDatePrefixChanged = dueDateVm::onPrefixChanged,
+        onDueDateDaysBeforeChanged = dueDateVm::onDaysBeforeChanged,
+        onDueDateNotifyHourChanged = dueDateVm::onNotifyHourChanged,
+        onRetryDueDate = dueDateVm::loadSettings,
         modifier = modifier,
     )
 }
@@ -44,6 +62,14 @@ internal fun MoneyContent(
     onPaymentSave: () -> Unit,
     onPaymentMessageChanged: (String) -> Unit,
     onRetryPayment: () -> Unit = {},
+    dueDateState: MoneyDueDateNotificationUiState,
+    onDueDateUrlChanged: (String) -> Unit,
+    onDueDateEnabledChanged: (Boolean) -> Unit,
+    onDueDateSave: () -> Unit,
+    onDueDatePrefixChanged: (String) -> Unit,
+    onDueDateDaysBeforeChanged: (String) -> Unit,
+    onDueDateNotifyHourChanged: (String) -> Unit,
+    onRetryDueDate: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -84,5 +110,55 @@ internal fun MoneyContent(
             onMessageChanged = onPaymentMessageChanged,
             statusMessage = paymentState.statusMessage,
         )
+
+        WebhookSettingsCard(
+            isLoading = dueDateState.isLoading,
+            title = "支払期日リマインダー",
+            featureEnabled = dueDateState.enabled,
+            url = dueDateState.webhookUrl,
+            onUrlChanged = onDueDateUrlChanged,
+            isSaving = dueDateState.isSaving,
+            onEnabledChanged = onDueDateEnabledChanged,
+            onSave = onDueDateSave,
+            modifier = Modifier.fillMaxWidth(),
+            loadError = dueDateState.loadError,
+            loadErrorMessage = dueDateState.loadErrorMessage,
+            onRetry = onRetryDueDate,
+            description = "支払期日が設定された項目を、期日の指定日数前・指定時刻に Webhook で通知します。",
+            message = dueDateState.prefix,
+            onMessageChanged = onDueDatePrefixChanged,
+            messagePlaceholder = "",
+            statusMessage = dueDateState.statusMessage,
+            saveEnabled = !dueDateState.isSaving && dueDateState.isDaysBeforeValid && dueDateState.isNotifyHourValid,
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(text = "通知タイミング", style = MaterialTheme.typography.bodyMedium, modifier = Modifier.width(96.dp))
+                Text(text = "期日の", style = MaterialTheme.typography.bodyMedium)
+                OutlinedTextField(
+                    value = dueDateState.daysBefore,
+                    onValueChange = onDueDateDaysBeforeChanged,
+                    label = { Text("日前") },
+                    singleLine = true,
+                    isError = !dueDateState.isDaysBeforeValid,
+                    modifier = Modifier.width(72.dp),
+                    enabled = !dueDateState.isSaving,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(textAlign = TextAlign.Center),
+                )
+                Text(text = "の", style = MaterialTheme.typography.bodyMedium)
+                OutlinedTextField(
+                    value = dueDateState.notifyHour,
+                    onValueChange = onDueDateNotifyHourChanged,
+                    label = { Text("時") },
+                    singleLine = true,
+                    isError = !dueDateState.isNotifyHourValid,
+                    modifier = Modifier.width(72.dp),
+                    enabled = !dueDateState.isSaving,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(textAlign = TextAlign.Center),
+                )
+                Text(": 00", style = MaterialTheme.typography.titleMedium)
+            }
+        }
     }
 }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/MoneyScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/MoneyScreen.kt
@@ -4,9 +4,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -43,6 +47,7 @@ internal fun MoneyScreen(modifier: Modifier = Modifier) {
         onDueDatePrefixChanged = dueDateVm::onPrefixChanged,
         onDueDateDaysBeforeChanged = dueDateVm::onDaysBeforeChanged,
         onDueDateNotifyHourChanged = dueDateVm::onNotifyHourChanged,
+        onDueDateTest = dueDateVm::onTest,
         onRetryDueDate = dueDateVm::loadSettings,
         modifier = modifier,
     )
@@ -69,6 +74,7 @@ internal fun MoneyContent(
     onDueDatePrefixChanged: (String) -> Unit,
     onDueDateDaysBeforeChanged: (String) -> Unit,
     onDueDateNotifyHourChanged: (String) -> Unit,
+    onDueDateTest: () -> Unit,
     onRetryDueDate: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
@@ -129,7 +135,8 @@ internal fun MoneyContent(
             onMessageChanged = onDueDatePrefixChanged,
             messagePlaceholder = "",
             statusMessage = dueDateState.statusMessage,
-            saveEnabled = !dueDateState.isSaving && dueDateState.isDaysBeforeValid && dueDateState.isNotifyHourValid,
+            saveEnabled =
+                !dueDateState.isSaving && !dueDateState.isTesting && dueDateState.isDaysBeforeValid && dueDateState.isNotifyHourValid,
         ) {
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text(text = "通知タイミング", style = MaterialTheme.typography.bodyMedium, modifier = Modifier.width(96.dp))
@@ -158,6 +165,24 @@ internal fun MoneyContent(
                     textStyle = MaterialTheme.typography.bodyMedium.copy(textAlign = TextAlign.Center),
                 )
                 Text(": 00", style = MaterialTheme.typography.titleMedium)
+            }
+            OutlinedButton(
+                onClick = onDueDateTest,
+                modifier = Modifier.height(48.dp),
+                enabled =
+                    !dueDateState.isSaving &&
+                        !dueDateState.isTesting &&
+                        dueDateState.enabled &&
+                        dueDateState.webhookUrl.isNotBlank(),
+            ) {
+                if (dueDateState.isTesting) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                    )
+                } else {
+                    Text("テスト送信")
+                }
             }
         }
     }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/di/SettingsModule.kt
@@ -4,6 +4,7 @@ import feature.settings.CacheRefreshViewModel
 import feature.settings.GarbageScheduleViewModel
 import feature.settings.LicensesViewModel
 import feature.settings.LoginHistoryViewModel
+import feature.settings.MoneyDueDateNotificationViewModel
 import feature.settings.MoneyWebhookViewModel
 import feature.settings.PasskeyManagementViewModel
 import feature.settings.PasswordChangeViewModel
@@ -28,6 +29,7 @@ val settingsModule =
         viewModel { QuestWebhookViewModel(get()) }
         viewModel { MoneyWebhookViewModel(get()) }
         viewModel { PaymentWebhookViewModel(get()) }
+        viewModel { MoneyDueDateNotificationViewModel(get()) }
         viewModel { CacheRefreshViewModel(get()) }
         viewModel { PetSettingsViewModel(get(), get(), get()) }
     }

--- a/feature/settings/src/jvmTest/kotlin/feature/settings/MoneyDueDateNotificationViewModelTest.kt
+++ b/feature/settings/src/jvmTest/kotlin/feature/settings/MoneyDueDateNotificationViewModelTest.kt
@@ -1,0 +1,157 @@
+package feature.settings
+
+import core.network.MoneyDueDateNotificationRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import model.MoneyDueDateNotificationSettings
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MoneyDueDateNotificationViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var repository: MoneyDueDateNotificationRepository
+
+    private val testSettings =
+        MoneyDueDateNotificationSettings(
+            enabled = true,
+            webhookUrl = "https://hooks.example.com/webhook",
+            daysBefore = 1,
+            notifyHour = 23,
+            prefix = "@everyone",
+        )
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        repository = mockk()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(): MoneyDueDateNotificationViewModel {
+        coEvery { repository.getSettings() } returns testSettings
+        return MoneyDueDateNotificationViewModel(repository)
+    }
+
+    @Test
+    fun `init loads settings`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.isLoading)
+            assertTrue(viewModel.uiState.enabled)
+            assertEquals("https://hooks.example.com/webhook", viewModel.uiState.webhookUrl)
+            assertEquals("1", viewModel.uiState.daysBefore)
+            assertEquals("23", viewModel.uiState.notifyHour)
+            assertEquals("@everyone", viewModel.uiState.prefix)
+        }
+
+    @Test
+    fun `init load failure shows error`() =
+        runTest {
+            coEvery { repository.getSettings() } throws RuntimeException("load error")
+            val viewModel = MoneyDueDateNotificationViewModel(repository)
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.isLoading)
+            assertTrue(viewModel.uiState.loadError)
+            assertEquals("load error", viewModel.uiState.loadErrorMessage)
+        }
+
+    @Test
+    fun `onDaysBeforeChanged strips non-digits`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.onDaysBeforeChanged("2a")
+
+            assertEquals("2", viewModel.uiState.daysBefore)
+            assertNull(viewModel.uiState.statusMessage)
+        }
+
+    @Test
+    fun `isDaysBeforeValid rejects negative and non-numeric values`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.onDaysBeforeChanged("0")
+            assertTrue(viewModel.uiState.isDaysBeforeValid)
+
+            viewModel.onDaysBeforeChanged("")
+            assertFalse(viewModel.uiState.isDaysBeforeValid)
+        }
+
+    @Test
+    fun `isNotifyHourValid rejects out-of-range values`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.onNotifyHourChanged("23")
+            assertTrue(viewModel.uiState.isNotifyHourValid)
+
+            viewModel.onNotifyHourChanged("24")
+            assertFalse(viewModel.uiState.isNotifyHourValid)
+        }
+
+    @Test
+    fun `save success shows status message`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            coEvery { repository.updateSettings(any()) } returns testSettings
+
+            viewModel.onSave()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.isSaving)
+            assertEquals("保存しました", viewModel.uiState.statusMessage)
+            coVerify {
+                repository.updateSettings(
+                    MoneyDueDateNotificationSettings(
+                        enabled = true,
+                        webhookUrl = "https://hooks.example.com/webhook",
+                        daysBefore = 1,
+                        notifyHour = 23,
+                        prefix = "@everyone",
+                    ),
+                )
+            }
+        }
+
+    @Test
+    fun `save failure shows error in status message`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            coEvery { repository.updateSettings(any()) } throws RuntimeException("save error")
+
+            viewModel.onSave()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.isSaving)
+            assertEquals("保存に失敗しました: save error", viewModel.uiState.statusMessage)
+        }
+}

--- a/feature/settings/src/jvmTest/kotlin/feature/settings/MoneyDueDateNotificationViewModelTest.kt
+++ b/feature/settings/src/jvmTest/kotlin/feature/settings/MoneyDueDateNotificationViewModelTest.kt
@@ -154,4 +154,35 @@ class MoneyDueDateNotificationViewModelTest {
             assertFalse(viewModel.uiState.isSaving)
             assertEquals("保存に失敗しました: save error", viewModel.uiState.statusMessage)
         }
+
+    @Test
+    fun `test success shows status message`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            coEvery { repository.test() } returns Unit
+
+            viewModel.onTest()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.isTesting)
+            assertEquals("テスト送信しました", viewModel.uiState.statusMessage)
+            coVerify { repository.test() }
+        }
+
+    @Test
+    fun `test failure shows error in status message`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            coEvery { repository.test() } throws RuntimeException("test error")
+
+            viewModel.onTest()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.isTesting)
+            assertEquals("テスト送信失敗: test error", viewModel.uiState.statusMessage)
+        }
 }

--- a/feature/settings/src/jvmTest/kotlin/feature/settings/PreviewScreenshotGeneratorTest.kt
+++ b/feature/settings/src/jvmTest/kotlin/feature/settings/PreviewScreenshotGeneratorTest.kt
@@ -113,6 +113,7 @@ class PreviewScreenshotGeneratorTest {
                     onDueDatePrefixChanged = {},
                     onDueDateDaysBeforeChanged = {},
                     onDueDateNotifyHourChanged = {},
+                    onDueDateTest = {},
                     modifier = modifier,
                 )
             SettingsCategory.Cache ->

--- a/feature/settings/src/jvmTest/kotlin/feature/settings/PreviewScreenshotGeneratorTest.kt
+++ b/feature/settings/src/jvmTest/kotlin/feature/settings/PreviewScreenshotGeneratorTest.kt
@@ -106,6 +106,13 @@ class PreviewScreenshotGeneratorTest {
                     onPaymentEnabledChanged = {},
                     onPaymentSave = {},
                     onPaymentMessageChanged = {},
+                    dueDateState = MoneyDueDateNotificationUiState(isLoading = false),
+                    onDueDateUrlChanged = {},
+                    onDueDateEnabledChanged = {},
+                    onDueDateSave = {},
+                    onDueDatePrefixChanged = {},
+                    onDueDateDaysBeforeChanged = {},
+                    onDueDateNotifyHourChanged = {},
                     modifier = modifier,
                 )
             SettingsCategory.Cache ->

--- a/server/src/main/kotlin/server/Application.kt
+++ b/server/src/main/kotlin/server/Application.kt
@@ -44,6 +44,8 @@ import server.garbage.GarbageNotificationService
 import server.garbage.garbageRoutes
 import server.loginhistory.loginHistoryRoutes
 import server.migration.FirestoreMigrations
+import server.money.MoneyDueDateNotificationService
+import server.money.moneyDueDateNotificationRoutes
 import server.money.moneyRoutes
 import server.money.moneyWebhookRoutes
 import server.money.paymentWebhookRoutes
@@ -102,6 +104,9 @@ fun Application.module() {
 
     val garbageNotificationService by inject<GarbageNotificationService>()
     launch { garbageNotificationService.runPollingLoop() }
+
+    val moneyDueDateNotificationService by inject<MoneyDueDateNotificationService>()
+    launch { moneyDueDateNotificationService.runPollingLoop() }
 
     configureAuth()
     install(CallLogging) {
@@ -198,6 +203,7 @@ fun Application.module() {
             garbageRoutes()
             moneyRoutes()
             moneyWebhookRoutes()
+            moneyDueDateNotificationRoutes()
             paymentWebhookRoutes()
             reportRoutes()
             questRoutes()

--- a/server/src/main/kotlin/server/di/ServerModule.kt
+++ b/server/src/main/kotlin/server/di/ServerModule.kt
@@ -23,6 +23,7 @@ import server.loginhistory.FirestoreLoginHistoryRepository
 import server.loginhistory.LoginHistoryRepository
 import server.migration.FirestoreMigrations
 import server.money.FirestoreMoneyRepository
+import server.money.MoneyDueDateNotificationService
 import server.money.MoneyRepository
 import server.money.MoneyWebhookService
 import server.money.PaymentWebhookService
@@ -75,6 +76,7 @@ val serverModule =
         single { QuestWebhookService(get()) }
         single { MoneyWebhookService(get()) }
         single { PaymentWebhookService(get()) }
+        single { MoneyDueDateNotificationService(get()) }
         single { QuestService(get(), get(), get()) }
         single { FeedingNotificationService(get(), get(), get()) }
         single { GarbageNotificationService(get()) }

--- a/server/src/main/kotlin/server/feeding/FeedingNotificationService.kt
+++ b/server/src/main/kotlin/server/feeding/FeedingNotificationService.kt
@@ -1,7 +1,6 @@
 package server.feeding
 
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
@@ -16,6 +15,7 @@ import server.config.EnvConfig
 import server.pet.PetRepository
 import server.util.DISCORD_EMBED_COLOR
 import server.util.WebhookServiceType
+import server.util.defaultHttpClient
 import server.util.detectWebhookService
 import server.util.sanitizeForDiscord
 import server.util.sanitizeForSlack
@@ -33,12 +33,7 @@ class FeedingNotificationService(
     private val feedingRepository: FeedingRepository,
     private val feedingSettingsRepository: FeedingSettingsRepository,
     private val petRepository: PetRepository,
-    private val client: HttpClient =
-        HttpClient {
-            install(HttpTimeout) {
-                requestTimeoutMillis = 10_000
-            }
-        },
+    private val client: HttpClient = defaultHttpClient(),
 ) {
     private val logger = LoggerFactory.getLogger(FeedingNotificationService::class.java)
     private val json = Json

--- a/server/src/main/kotlin/server/garbage/GarbageNotificationService.kt
+++ b/server/src/main/kotlin/server/garbage/GarbageNotificationService.kt
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory
 import server.config.EnvConfig
 import server.util.DISCORD_EMBED_COLOR
 import server.util.WebhookServiceType
+import server.util.defaultHttpClient
 import server.util.detectWebhookService
 import java.time.Instant
 import java.time.ZoneId
@@ -24,7 +25,7 @@ private val JST = ZoneId.of("Asia/Tokyo")
 
 class GarbageNotificationService(
     private val garbageRepository: GarbageRepository,
-    private val client: HttpClient = HttpClient(),
+    private val client: HttpClient = defaultHttpClient(),
 ) {
     private val logger = LoggerFactory.getLogger(GarbageNotificationService::class.java)
     private val json = Json

--- a/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
+++ b/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
@@ -2,6 +2,7 @@ package server.money
 
 import com.google.cloud.firestore.DocumentSnapshot
 import com.google.cloud.firestore.Firestore
+import model.MoneyDueDateNotificationSettings
 import model.MoneyItem
 import model.MoneyTags
 import model.MonthlyMoney
@@ -17,6 +18,8 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 
 private const val MONEY_COLLECTION = "money"
+private const val SETTINGS_COLLECTION = "settings"
+private const val DUE_DATE_NOTIFICATION_DOC = "money_due_date_notification"
 
 class FirestoreMoneyRepository(
     private val firestore: Firestore,
@@ -71,6 +74,7 @@ class FirestoreMoneyRepository(
                     "amount" to item.amount,
                     "note" to item.note,
                     "tags" to item.tags,
+                    "dueDate" to item.dueDate,
                     "shares" to
                         item.shares.map { s ->
                             mapOf("uid" to s.uid, "amount" to s.amount)
@@ -199,6 +203,7 @@ class FirestoreMoneyRepository(
                 amount = (entry["amount"] as Number).toLong(),
                 note = entry["note"] as? String ?: "",
                 tags = tags,
+                dueDate = entry["dueDate"] as? String,
                 shares =
                     sharesRaw.map { s ->
                         Share(
@@ -226,5 +231,39 @@ class FirestoreMoneyRepository(
                 isRedemption = p["isRedemption"] as? Boolean ?: false,
             )
         }
+    }
+
+    override suspend fun getDueDateNotificationSettings(): MoneyDueDateNotificationSettings {
+        val doc =
+            firestore
+                .collection(SETTINGS_COLLECTION)
+                .document(DUE_DATE_NOTIFICATION_DOC)
+                .get()
+                .await()
+
+        if (!doc.exists()) return MoneyDueDateNotificationSettings()
+
+        return MoneyDueDateNotificationSettings(
+            enabled = doc.getBoolean("enabled") ?: false,
+            webhookUrl = doc.getString("webhookUrl") ?: "",
+            daysBefore = (doc.getLong("daysBefore") ?: 1L).toInt(),
+            notifyHour = (doc.getLong("notifyHour") ?: 23L).toInt(),
+            prefix = doc.getString("prefix") ?: "",
+        )
+    }
+
+    override suspend fun saveDueDateNotificationSettings(settings: MoneyDueDateNotificationSettings) {
+        firestore
+            .collection(SETTINGS_COLLECTION)
+            .document(DUE_DATE_NOTIFICATION_DOC)
+            .set(
+                mapOf(
+                    "enabled" to settings.enabled,
+                    "webhookUrl" to settings.webhookUrl,
+                    "daysBefore" to settings.daysBefore,
+                    "notifyHour" to settings.notifyHour,
+                    "prefix" to settings.prefix,
+                ),
+            ).await()
     }
 }

--- a/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
+++ b/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
@@ -12,6 +12,7 @@ import model.Share
 import org.slf4j.LoggerFactory
 import server.cache.Cacheable
 import server.util.await
+import java.time.LocalDate
 import java.time.YearMonth
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -110,7 +111,7 @@ class FirestoreMoneyRepository(
         val previousYearMonth = YearMonth.parse(targetYearMonth).minusMonths(1).toString()
         val prevData = getMonthlyMoney(previousYearMonth)
         val taggedItems =
-            filterTaggedItemsForImport(prevData?.items ?: emptyList(), tag)
+            filterTaggedItemsForImport(prevData?.items ?: emptyList(), tag, targetYearMonth)
                 .map { item -> item.copy(id = UUID.randomUUID().toString()) }
 
         val existing = getMonthlyMoney(targetYearMonth) ?: MonthlyMoney(yearMonth = targetYearMonth)
@@ -183,17 +184,38 @@ class FirestoreMoneyRepository(
     }
 
     /**
-     * 定期項目インポート対象の絞り込み + 複製時のフィールドリセット（テスト用に internal）。
+     * 定期項目インポート対象の絞り込み + 複製時の dueDate 付け替え（テスト用に internal）。
      *
      * dueDate は前月の日付のまま複製すると、期日リマインダーが二度と一致せず永久に飛ばなくなる
      * （[MoneyDueDateNotificationService] は dueDate との完全一致でしか対象を検出しない）ため、
-     * インポート時にリセットしてユーザーに毎月設定し直させる。id は呼び出し側（UUID 採番）で
-     * 差し替えるため、ここでは触れない。
+     * インポート先の月 [targetYearMonth] の同じ日に付け替える（毎月同じ日払いの家賃・サブスク等を
+     * 想定）。[rebaseDueDateToTargetMonth] が対象月に存在しない日（月末クランプが必要なケース）を
+     * 検出した場合は null にフォールバックする。id は呼び出し側（UUID 採番）で差し替えるため、
+     * ここでは触れない。
      */
     internal fun filterTaggedItemsForImport(
         items: List<MoneyItem>,
         tag: String,
-    ): List<MoneyItem> = items.filter { tag in it.tags }.map { it.copy(dueDate = null) }
+        targetYearMonth: String,
+    ): List<MoneyItem> =
+        items
+            .filter { tag in it.tags }
+            .map { item -> item.copy(dueDate = item.dueDate?.let { rebaseDueDateToTargetMonth(it, targetYearMonth) }) }
+
+    /**
+     * "YYYY-MM-DD" の日部分を維持したまま [targetYearMonth]（"YYYY-MM"）へ付け替える（テスト用に internal）。
+     * 対象月にその日が存在しない（例: 1/31 → 2月、31日が無い）場合や dueDate の形式が不正な場合は
+     * クランプせず null を返す（呼び出し側でユーザーに再設定してもらう）。
+     */
+    internal fun rebaseDueDateToTargetMonth(
+        dueDate: String,
+        targetYearMonth: String,
+    ): String? {
+        val day = dueDate.substringAfterLast('-').toIntOrNull() ?: return null
+        val ym = runCatching { YearMonth.parse(targetYearMonth) }.getOrNull() ?: return null
+        if (day < 1 || day > ym.lengthOfMonth()) return null
+        return LocalDate.of(ym.year, ym.monthValue, day).toString()
+    }
 
     /** Map リストから [MoneyItem] リストをパースする（テスト用に internal） */
     @Suppress("UNCHECKED_CAST")

--- a/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
+++ b/server/src/main/kotlin/server/money/FirestoreMoneyRepository.kt
@@ -110,8 +110,7 @@ class FirestoreMoneyRepository(
         val previousYearMonth = YearMonth.parse(targetYearMonth).minusMonths(1).toString()
         val prevData = getMonthlyMoney(previousYearMonth)
         val taggedItems =
-            (prevData?.items ?: emptyList())
-                .filter { tag in it.tags }
+            filterTaggedItemsForImport(prevData?.items ?: emptyList(), tag)
                 .map { item -> item.copy(id = UUID.randomUUID().toString()) }
 
         val existing = getMonthlyMoney(targetYearMonth) ?: MonthlyMoney(yearMonth = targetYearMonth)
@@ -182,6 +181,19 @@ class FirestoreMoneyRepository(
         }
         return if (legacyLocked == true) MonthlyMoneyStatus.FROZEN else MonthlyMoneyStatus.PENDING
     }
+
+    /**
+     * 定期項目インポート対象の絞り込み + 複製時のフィールドリセット（テスト用に internal）。
+     *
+     * dueDate は前月の日付のまま複製すると、期日リマインダーが二度と一致せず永久に飛ばなくなる
+     * （[MoneyDueDateNotificationService] は dueDate との完全一致でしか対象を検出しない）ため、
+     * インポート時にリセットしてユーザーに毎月設定し直させる。id は呼び出し側（UUID 採番）で
+     * 差し替えるため、ここでは触れない。
+     */
+    internal fun filterTaggedItemsForImport(
+        items: List<MoneyItem>,
+        tag: String,
+    ): List<MoneyItem> = items.filter { tag in it.tags }.map { it.copy(dueDate = null) }
 
     /** Map リストから [MoneyItem] リストをパースする（テスト用に internal） */
     @Suppress("UNCHECKED_CAST")

--- a/server/src/main/kotlin/server/money/MoneyDueDateNotificationRoutes.kt
+++ b/server/src/main/kotlin/server/money/MoneyDueDateNotificationRoutes.kt
@@ -1,0 +1,78 @@
+package server.money
+
+import io.github.smiley4.ktoropenapi.get
+import io.github.smiley4.ktoropenapi.post
+import io.github.smiley4.ktoropenapi.put
+import io.ktor.http.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import model.MoneyDueDateNotificationSettings
+import org.koin.ktor.ext.inject
+import server.auth.adminOnly
+import server.auth.authenticated
+
+fun Route.moneyDueDateNotificationRoutes() {
+    val moneyRepository by inject<MoneyRepository>()
+    val moneyDueDateNotificationService by inject<MoneyDueDateNotificationService>()
+
+    route("/money/due-date-notification-settings") {
+        authenticated {
+            get({
+                tags = listOf("money")
+                summary = "支払期日リマインダー設定取得"
+                response {
+                    code(HttpStatusCode.OK) {
+                        body<MoneyDueDateNotificationSettings>()
+                    }
+                }
+            }) {
+                call.respond(moneyRepository.getDueDateNotificationSettings())
+            }
+        }
+
+        adminOnly {
+            put({
+                tags = listOf("money")
+                summary = "支払期日リマインダー設定更新（admin）"
+                request {
+                    body<MoneyDueDateNotificationSettings>()
+                }
+                response {
+                    code(HttpStatusCode.OK) {
+                        body<MoneyDueDateNotificationSettings>()
+                    }
+                    code(HttpStatusCode.BadRequest) { description = "daysBefore / notifyHour が範囲外" }
+                }
+            }) {
+                val settings = call.receive<MoneyDueDateNotificationSettings>()
+                if (settings.notifyHour !in 0..23) {
+                    call.respond(HttpStatusCode.BadRequest, mapOf("error" to "notifyHour must be 0-23"))
+                    return@put
+                }
+                if (settings.daysBefore < 0) {
+                    call.respond(HttpStatusCode.BadRequest, mapOf("error" to "daysBefore must be 0 or more"))
+                    return@put
+                }
+                moneyRepository.saveDueDateNotificationSettings(settings)
+                call.respond(settings)
+            }
+
+            post("test", {
+                tags = listOf("money")
+                summary = "支払期日リマインダーのテスト送信（admin）"
+                response {
+                    code(HttpStatusCode.NoContent) { description = "送信成功" }
+                    code(HttpStatusCode.BadRequest) { description = "Webhook URL 未設定" }
+                }
+            }) {
+                try {
+                    moneyDueDateNotificationService.sendTestNotification()
+                    call.respond(HttpStatusCode.NoContent)
+                } catch (e: Exception) {
+                    call.respond(HttpStatusCode.BadRequest, mapOf("error" to (e.message ?: "送信失敗")))
+                }
+            }
+        }
+    }
+}

--- a/server/src/main/kotlin/server/money/MoneyDueDateNotificationService.kt
+++ b/server/src/main/kotlin/server/money/MoneyDueDateNotificationService.kt
@@ -1,7 +1,6 @@
 package server.money
 
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
@@ -14,6 +13,7 @@ import org.slf4j.LoggerFactory
 import server.config.EnvConfig
 import server.util.DISCORD_EMBED_COLOR
 import server.util.WebhookServiceType
+import server.util.defaultHttpClient
 import server.util.detectWebhookService
 import server.util.formatAmount
 import server.util.sanitizeForDiscord
@@ -30,12 +30,7 @@ private val JST = ZoneId.of("Asia/Tokyo")
  */
 class MoneyDueDateNotificationService(
     private val moneyRepository: MoneyRepository,
-    private val client: HttpClient =
-        HttpClient {
-            install(HttpTimeout) {
-                requestTimeoutMillis = 10_000
-            }
-        },
+    private val client: HttpClient = defaultHttpClient(),
 ) {
     private val logger = LoggerFactory.getLogger(MoneyDueDateNotificationService::class.java)
     private val json = Json

--- a/server/src/main/kotlin/server/money/MoneyDueDateNotificationService.kt
+++ b/server/src/main/kotlin/server/money/MoneyDueDateNotificationService.kt
@@ -1,0 +1,242 @@
+package server.money
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.content.TextContent
+import kotlinx.coroutines.delay
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+import server.config.EnvConfig
+import server.util.DISCORD_EMBED_COLOR
+import server.util.WebhookServiceType
+import server.util.detectWebhookService
+import server.util.formatAmount
+import server.util.sanitizeForDiscord
+import server.util.sanitizeForSlack
+import java.time.Instant
+import java.time.ZoneId
+
+private val JST = ZoneId.of("Asia/Tokyo")
+
+/**
+ * 支払期日リマインダー。項目 (MoneyItem) の dueDate の [MoneyDueDateNotificationSettings.daysBefore]
+ * 日前、JST [MoneyDueDateNotificationSettings.notifyHour] 時に、その日が期日となる項目一覧を
+ * Webhook 通知する。項目は月ごとに保存されているため、対象期日に一致する項目を探すには全月を走査する。
+ */
+class MoneyDueDateNotificationService(
+    private val moneyRepository: MoneyRepository,
+    private val client: HttpClient =
+        HttpClient {
+            install(HttpTimeout) {
+                requestTimeoutMillis = 10_000
+            }
+        },
+) {
+    private val logger = LoggerFactory.getLogger(MoneyDueDateNotificationService::class.java)
+    private val json = Json
+
+    // 通知済みの対象期日（この日付分は送信済み）。daysBefore 分ずらした対象期日が
+    // 日付跨ぎで自然に変わるため、ゴミ出し通知と異なり「日付が変わったらリセット」の処理は不要。
+    internal var notifiedTargetDate: String? = null
+
+    /** Application のコルーチンスコープから呼び出す。キャンセルで停止する。 */
+    suspend fun runPollingLoop() {
+        while (true) {
+            try {
+                checkAndNotify()
+            } catch (e: Exception) {
+                logger.warn("Money due date notification check failed", e)
+            }
+            delay(60_000L)
+        }
+    }
+
+    internal suspend fun checkAndNotify(now: Instant = Instant.now()) {
+        val settings = moneyRepository.getDueDateNotificationSettings()
+        if (!settings.enabled || settings.webhookUrl.isBlank()) return
+
+        val jstNow = now.atZone(JST)
+        if (jstNow.hour < settings.notifyHour) return
+
+        val targetDate = jstNow.toLocalDate().plusDays(settings.daysBefore.toLong()).toString()
+        // 既に当該対象期日分を送信済み
+        if (notifiedTargetDate == targetDate) return
+
+        val dueItems = collectDueItems(targetDate)
+        if (dueItems.isEmpty()) {
+            notifiedTargetDate = targetDate
+            return
+        }
+
+        sendWebhook(
+            url = settings.webhookUrl,
+            prefix = settings.prefix,
+            targetDate = targetDate,
+            items = dueItems,
+        )
+        notifiedTargetDate = targetDate
+    }
+
+    /** 全月データから dueDate == targetDate の項目を収集する（テスト用に internal） */
+    internal suspend fun collectDueItems(targetDate: String): List<DueMoneyItem> =
+        moneyRepository.getAllMonths().flatMap { monthly ->
+            monthly.items
+                .filter { it.dueDate == targetDate }
+                .map { DueMoneyItem(yearMonth = monthly.yearMonth, name = it.name, amount = it.amount) }
+        }
+
+    /** テスト送信: 保存済み設定の daysBefore から対象期日を算出し即時送信する。該当項目がなければサンプル項目で送信する。 */
+    suspend fun sendTestNotification() {
+        val settings = moneyRepository.getDueDateNotificationSettings()
+        require(settings.webhookUrl.isNotBlank()) { "Webhook URL が設定されていません" }
+        val targetDate =
+            Instant
+                .now()
+                .atZone(JST)
+                .toLocalDate()
+                .plusDays(settings.daysBefore.toLong())
+                .toString()
+        val items =
+            collectDueItems(targetDate).ifEmpty {
+                listOf(DueMoneyItem(yearMonth = targetDate.substring(0, 7), name = "(テスト項目)", amount = 1000L))
+            }
+        sendWebhook(url = settings.webhookUrl, prefix = settings.prefix, targetDate = targetDate, items = items)
+    }
+
+    internal suspend fun sendWebhook(
+        url: String,
+        prefix: String,
+        targetDate: String,
+        items: List<DueMoneyItem>,
+    ) {
+        val payload = buildPayload(url, prefix, targetDate, items)
+        try {
+            client.post(url) {
+                setBody(TextContent(payload, ContentType.Application.Json))
+            }
+        } catch (e: Exception) {
+            logger.warn("Money due date notification webhook failed", e)
+        }
+    }
+
+    internal fun buildPayload(
+        url: String,
+        prefix: String,
+        targetDate: String,
+        items: List<DueMoneyItem>,
+        moneyPageUrl: String? = appUrl?.let { "${it.trimEnd('/')}/money" },
+    ): String {
+        val total = items.sumOf { it.amount }
+        val dateLabel = formatDueDateLabel(targetDate)
+
+        fun message(sanitize: (String) -> String): String {
+            val lines = items.joinToString("\n") { "・${sanitize(it.name)}（${formatAmount(it.amount)}）" }
+            return "支払期日: ${dateLabel}の項目\n$lines\n合計 ${formatAmount(total)}"
+        }
+
+        return when (detectWebhookService(url)) {
+            WebhookServiceType.DISCORD -> {
+                val discord =
+                    DiscordDueDatePayload(
+                        content = prefix.ifBlank { null },
+                        embeds =
+                            listOf(
+                                DiscordDueDateEmbed(
+                                    title = "支払期日リマインダー",
+                                    description = message(::sanitizeForDiscord),
+                                    color = DISCORD_EMBED_COLOR,
+                                    url = moneyPageUrl,
+                                ),
+                            ),
+                    )
+                json.encodeToString(discord)
+            }
+            WebhookServiceType.SLACK -> {
+                val text = message(::sanitizeForSlack).let { if (prefix.isBlank()) it else "$prefix $it" }
+                val withLink = if (moneyPageUrl != null) "$text\n<$moneyPageUrl|お金の管理を開く>" else text
+                json.encodeToString(SlackDueDatePayload(text = withLink))
+            }
+            WebhookServiceType.GENERIC -> {
+                json.encodeToString(
+                    GenericDueDatePayload(
+                        event = "money_due_date_reminder",
+                        prefix = prefix.ifBlank { null },
+                        dueDate = targetDate,
+                        items = items.map { GenericDueDateItem(yearMonth = it.yearMonth, name = it.name, amount = it.amount) },
+                        totalAmount = total,
+                        message = message { it },
+                        moneyPageUrl = moneyPageUrl,
+                    ),
+                )
+            }
+        }
+    }
+
+    companion object {
+        private val appUrl: String? = EnvConfig["APP_URL"]
+
+        /** "YYYY-MM-DD" を "YYYY年M月D日" 表記に整形。パース失敗時は入力をそのまま返す。 */
+        internal fun formatDueDateLabel(dateStr: String): String {
+            val parts = dateStr.split("-")
+            if (parts.size != 3) return dateStr
+            val month = parts[1].toIntOrNull() ?: return dateStr
+            val day = parts[2].toIntOrNull() ?: return dateStr
+            return "${parts[0]}年${month}月${day}日"
+        }
+    }
+}
+
+/** 期日通知の対象項目（月をまたいで収集するため yearMonth を保持する） */
+internal data class DueMoneyItem(
+    val yearMonth: String,
+    val name: String,
+    val amount: Long,
+)
+
+// --- Discord ペイロード ---
+
+@Serializable
+internal data class DiscordDueDatePayload(
+    val content: String? = null,
+    val embeds: List<DiscordDueDateEmbed>,
+)
+
+@Serializable
+internal data class DiscordDueDateEmbed(
+    val title: String,
+    val description: String,
+    val color: Int,
+    val url: String? = null,
+)
+
+// --- Slack ペイロード ---
+
+@Serializable
+internal data class SlackDueDatePayload(
+    val text: String,
+)
+
+// --- 汎用ペイロード ---
+
+@Serializable
+internal data class GenericDueDateItem(
+    val yearMonth: String,
+    val name: String,
+    val amount: Long,
+)
+
+@Serializable
+internal data class GenericDueDatePayload(
+    val event: String,
+    val prefix: String? = null,
+    val dueDate: String,
+    val items: List<GenericDueDateItem>,
+    val totalAmount: Long,
+    val message: String,
+    val moneyPageUrl: String? = null,
+)

--- a/server/src/main/kotlin/server/money/MoneyModelConversions.kt
+++ b/server/src/main/kotlin/server/money/MoneyModelConversions.kt
@@ -48,6 +48,7 @@ fun MoneyItemSaveRequest.toDomain(): MoneyItem =
         note = note,
         shares = shares.map { it.toDomain() },
         tags = tags,
+        dueDate = dueDate,
     )
 
 fun ShareSaveRequest.toDomain(): Share = Share(uid = uid, amount = amount)

--- a/server/src/main/kotlin/server/money/MoneyRepository.kt
+++ b/server/src/main/kotlin/server/money/MoneyRepository.kt
@@ -1,5 +1,6 @@
 package server.money
 
+import model.MoneyDueDateNotificationSettings
 import model.MonthlyMoney
 
 /** Money データのリポジトリインターフェース */
@@ -18,6 +19,10 @@ interface MoneyRepository {
         tag: String,
     ): MonthlyMoney
 
-    /** レポート用: 全月のデータを取得 */
+    /** レポート用・支払期日リマインダー用: 全月のデータを取得 */
     suspend fun getAllMonths(): List<MonthlyMoney>
+
+    suspend fun getDueDateNotificationSettings(): MoneyDueDateNotificationSettings
+
+    suspend fun saveDueDateNotificationSettings(settings: MoneyDueDateNotificationSettings)
 }

--- a/server/src/main/kotlin/server/money/MoneyWebhookService.kt
+++ b/server/src/main/kotlin/server/money/MoneyWebhookService.kt
@@ -15,15 +15,15 @@ import kotlinx.serialization.json.Json
 import model.MoneyWebhookSettings
 import server.config.EnvConfig
 import server.util.AbstractWebhookService
-import server.util.AbstractWebhookService.Companion.defaultWebhookClient
 import server.util.DISCORD_EMBED_COLOR
 import server.util.WebhookServiceType
+import server.util.defaultHttpClient
 import server.util.detectWebhookService
 import server.util.formatYearMonth
 
 class MoneyWebhookService(
     firestore: Firestore,
-    client: HttpClient = defaultWebhookClient(),
+    client: HttpClient = defaultHttpClient(),
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AbstractWebhookService<MoneyWebhookSettings>(firestore, "money", client, dispatcher) {
     override fun defaultSettings() = MoneyWebhookSettings()

--- a/server/src/main/kotlin/server/money/PaymentWebhookService.kt
+++ b/server/src/main/kotlin/server/money/PaymentWebhookService.kt
@@ -15,9 +15,9 @@ import kotlinx.serialization.json.Json
 import model.PaymentWebhookSettings
 import server.config.EnvConfig
 import server.util.AbstractWebhookService
-import server.util.AbstractWebhookService.Companion.defaultWebhookClient
 import server.util.DISCORD_EMBED_COLOR
 import server.util.WebhookServiceType
+import server.util.defaultHttpClient
 import server.util.detectWebhookService
 import server.util.formatAmount
 import server.util.formatYearMonth
@@ -26,7 +26,7 @@ import server.util.sanitizeForSlack
 
 class PaymentWebhookService(
     firestore: Firestore,
-    client: HttpClient = defaultWebhookClient(),
+    client: HttpClient = defaultHttpClient(),
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AbstractWebhookService<PaymentWebhookSettings>(firestore, "payment", client, dispatcher) {
     override fun defaultSettings() = PaymentWebhookSettings()

--- a/server/src/main/kotlin/server/quest/QuestRoutes.kt
+++ b/server/src/main/kotlin/server/quest/QuestRoutes.kt
@@ -4,7 +4,6 @@ import io.github.smiley4.ktoropenapi.delete
 import io.github.smiley4.ktoropenapi.get
 import io.github.smiley4.ktoropenapi.post
 import io.github.smiley4.ktoropenapi.put
-import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
@@ -24,6 +23,7 @@ import server.auth.authenticated
 import server.auth.firebasePrincipal
 import server.config.EnvConfig
 import server.ratelimit.RateLimitNames
+import server.util.defaultHttpClient
 
 private val geminiApiKey: String? = EnvConfig["GEMINI_API_KEY"]
 
@@ -31,10 +31,7 @@ private val questTextGenerator: QuestTextGenerator? by lazy {
     geminiApiKey?.let { key ->
         GeminiTextGenerator(
             apiKey = key,
-            client =
-                HttpClient {
-                    install(ContentNegotiation) { json() }
-                },
+            client = defaultHttpClient { install(ContentNegotiation) { json() } },
         )
     }
 }

--- a/server/src/main/kotlin/server/quest/QuestWebhookService.kt
+++ b/server/src/main/kotlin/server/quest/QuestWebhookService.kt
@@ -15,9 +15,9 @@ import kotlinx.serialization.json.Json
 import model.Quest
 import model.QuestWebhookSettings
 import server.util.AbstractWebhookService
-import server.util.AbstractWebhookService.Companion.defaultWebhookClient
 import server.util.DISCORD_EMBED_COLOR
 import server.util.WebhookServiceType
+import server.util.defaultHttpClient
 import server.util.detectWebhookService
 import server.util.sanitizeForDiscord
 import server.util.sanitizeForSlack
@@ -25,7 +25,7 @@ import java.time.Instant
 
 class QuestWebhookService(
     firestore: Firestore,
-    client: HttpClient = defaultWebhookClient(),
+    client: HttpClient = defaultHttpClient(),
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AbstractWebhookService<QuestWebhookSettings>(firestore, "quest", client, dispatcher) {
     override fun defaultSettings() = QuestWebhookSettings()

--- a/server/src/main/kotlin/server/util/AbstractWebhookService.kt
+++ b/server/src/main/kotlin/server/util/AbstractWebhookService.kt
@@ -3,7 +3,6 @@ package server.util
 import com.google.cloud.firestore.Firestore
 import com.google.cloud.firestore.SetOptions
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.HttpTimeout
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -28,13 +27,17 @@ import org.slf4j.LoggerFactory
 abstract class AbstractWebhookService<S : WebhookSettings>(
     private val firestore: Firestore,
     private val documentName: String,
-    protected val client: HttpClient = defaultWebhookClient(),
+    protected val client: HttpClient = defaultHttpClient(),
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     protected val logger = LoggerFactory.getLogger(this::class.java)
     protected val scope = CoroutineScope(SupervisorJob() + dispatcher)
 
     private val settingsDoc get() = firestore.collection("settings").document(documentName)
+
+    // Firestore 非依存の純粋関数群と違い、HttpClient 生成そのものは他の通知サービスとも
+    // 共有したいため、companion object ではなく server.util.HttpClients.kt のトップレベル
+    // 関数 defaultHttpClient() に集約している（Money/Payment/Quest 以外の通知サービスからも使うため）。
 
     /** 設定が未保存のときに返すデフォルト値。 */
     protected abstract fun defaultSettings(): S
@@ -60,14 +63,5 @@ abstract class AbstractWebhookService<S : WebhookSettings>(
             .set(mapOf("webhook" to toWebhookMap(settings)), SetOptions.merge())
             .await()
         return settings
-    }
-
-    companion object {
-        fun defaultWebhookClient(): HttpClient =
-            HttpClient {
-                install(HttpTimeout) {
-                    requestTimeoutMillis = 10_000
-                }
-            }
     }
 }

--- a/server/src/main/kotlin/server/util/HttpClients.kt
+++ b/server/src/main/kotlin/server/util/HttpClients.kt
@@ -1,0 +1,22 @@
+package server.util
+
+import config.HttpTimeouts
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.plugins.HttpTimeout
+
+/**
+ * サーバーから外部へ送信する HttpClient 全般（Webhook 送信、Gemini 等の外部 API 呼び出し）の
+ * 既定生成関数。リクエストタイムアウトは [HttpTimeouts] で全体統一する。
+ *
+ * Money / Payment / Quest の Webhook サービス（[AbstractWebhookService]）、Feeding / Garbage / Money
+ * 期日リマインダーの通知サービス、Gemini API クライアントがすべてこれを経由する。
+ * 追加のプラグイン（ContentNegotiation 等）が必要な場合は [additionalConfig] で差し込む。
+ */
+fun defaultHttpClient(additionalConfig: HttpClientConfig<*>.() -> Unit = {}): HttpClient =
+    HttpClient {
+        install(HttpTimeout) {
+            requestTimeoutMillis = HttpTimeouts.DEFAULT_REQUEST_TIMEOUT_MILLIS
+        }
+        additionalConfig()
+    }

--- a/server/src/test/kotlin/server/money/MoneyDueDateNotificationServiceTest.kt
+++ b/server/src/test/kotlin/server/money/MoneyDueDateNotificationServiceTest.kt
@@ -1,0 +1,286 @@
+package server.money
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import model.MoneyDueDateNotificationSettings
+import model.MoneyItem
+import model.MonthlyMoney
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MoneyDueDateNotificationServiceTest {
+    private val moneyRepository = mockk<MoneyRepository>()
+    private val webhookRequests = mutableListOf<String>()
+
+    private val mockClient =
+        HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    webhookRequests.add(request.url.toString())
+                    respond("ok", HttpStatusCode.OK)
+                }
+            }
+        }
+
+    private fun createService(): MoneyDueDateNotificationService =
+        MoneyDueDateNotificationService(
+            moneyRepository = moneyRepository,
+            client = mockClient,
+        )
+
+    private fun jstInstant(
+        hour: Int,
+        minute: Int = 0,
+        year: Int = 2026,
+        month: Int = 3,
+        day: Int = 18,
+    ): Instant =
+        ZonedDateTime
+            .of(year, month, day, hour, minute, 0, 0, ZoneId.of("Asia/Tokyo"))
+            .toInstant()
+
+    private val monthWithDueItem =
+        listOf(
+            MonthlyMoney(
+                yearMonth = "2026-03",
+                items =
+                    listOf(
+                        MoneyItem(id = "i1", name = "電気代", amount = 8000L, dueDate = "2026-03-19"),
+                        MoneyItem(id = "i2", name = "水道代", amount = 3000L, dueDate = "2026-03-25"),
+                    ),
+            ),
+        )
+
+    // --- 無効 → 通知なし ---
+
+    @Test
+    fun disabledDoesNotNotify() =
+        runTest {
+            coEvery { moneyRepository.getDueDateNotificationSettings() } returns
+                MoneyDueDateNotificationSettings(enabled = false, webhookUrl = "https://discord.com/api/webhooks/x/y")
+
+            val service = createService()
+            service.checkAndNotify(jstInstant(23, 0))
+
+            assertTrue(webhookRequests.isEmpty())
+        }
+
+    // --- URL 空 → 通知なし ---
+
+    @Test
+    fun emptyUrlDoesNotNotify() =
+        runTest {
+            coEvery { moneyRepository.getDueDateNotificationSettings() } returns
+                MoneyDueDateNotificationSettings(enabled = true, webhookUrl = "")
+
+            val service = createService()
+            service.checkAndNotify(jstInstant(23, 0))
+
+            assertTrue(webhookRequests.isEmpty())
+        }
+
+    // --- 通知時刻前 → 通知なし ---
+
+    @Test
+    fun beforeNotifyHourDoesNotNotify() =
+        runTest {
+            coEvery { moneyRepository.getDueDateNotificationSettings() } returns
+                MoneyDueDateNotificationSettings(
+                    enabled = true,
+                    webhookUrl = "https://discord.com/api/webhooks/x/y",
+                    notifyHour = 23,
+                )
+
+            val service = createService()
+            service.checkAndNotify(jstInstant(22, 59))
+
+            assertTrue(webhookRequests.isEmpty())
+        }
+
+    // --- 通知時刻到達 & daysBefore 日後に期日の項目あり → 通知あり ---
+
+    @Test
+    fun atNotifyHourWithDueItemSendsNotification() =
+        runTest {
+            coEvery { moneyRepository.getDueDateNotificationSettings() } returns
+                MoneyDueDateNotificationSettings(
+                    enabled = true,
+                    webhookUrl = "https://discord.com/api/webhooks/x/y",
+                    daysBefore = 1,
+                    notifyHour = 23,
+                )
+            coEvery { moneyRepository.getAllMonths() } returns monthWithDueItem
+
+            val service = createService()
+            // 2026-03-18 23:00 + 1日前 = 2026-03-19 が期日の項目あり
+            service.checkAndNotify(jstInstant(23, 0, day = 18))
+
+            assertTrue(webhookRequests.isNotEmpty())
+        }
+
+    // --- 対象期日に項目なし → 通知なし ---
+
+    @Test
+    fun noDueItemsOnTargetDateDoesNotNotify() =
+        runTest {
+            coEvery { moneyRepository.getDueDateNotificationSettings() } returns
+                MoneyDueDateNotificationSettings(
+                    enabled = true,
+                    webhookUrl = "https://discord.com/api/webhooks/x/y",
+                    daysBefore = 1,
+                    notifyHour = 23,
+                )
+            coEvery { moneyRepository.getAllMonths() } returns monthWithDueItem
+
+            val service = createService()
+            // 2026-03-20 23:00 + 1日前 = 2026-03-21 は該当項目なし
+            service.checkAndNotify(jstInstant(23, 0, day = 20))
+
+            assertTrue(webhookRequests.isEmpty())
+        }
+
+    // --- 同一対象期日の重複通知なし ---
+
+    @Test
+    fun doesNotSendDuplicateNotificationForSameTargetDate() =
+        runTest {
+            coEvery { moneyRepository.getDueDateNotificationSettings() } returns
+                MoneyDueDateNotificationSettings(
+                    enabled = true,
+                    webhookUrl = "https://discord.com/api/webhooks/x/y",
+                    daysBefore = 1,
+                    notifyHour = 23,
+                )
+            coEvery { moneyRepository.getAllMonths() } returns monthWithDueItem
+
+            val service = createService()
+            service.checkAndNotify(jstInstant(23, 0, day = 18))
+            val firstCount = webhookRequests.size
+
+            service.checkAndNotify(jstInstant(23, 5, day = 18))
+            assertEquals(firstCount, webhookRequests.size)
+        }
+
+    // --- 日付が変わり対象期日が変われば再度通知される ---
+
+    @Test
+    fun notifiesAgainWhenTargetDateAdvances() =
+        runTest {
+            coEvery { moneyRepository.getDueDateNotificationSettings() } returns
+                MoneyDueDateNotificationSettings(
+                    enabled = true,
+                    webhookUrl = "https://discord.com/api/webhooks/x/y",
+                    daysBefore = 1,
+                    notifyHour = 23,
+                )
+            coEvery { moneyRepository.getAllMonths() } returns monthWithDueItem
+
+            val service = createService()
+            // 対象期日 2026-03-19 の項目で通知
+            service.checkAndNotify(jstInstant(23, 0, day = 18))
+            val firstCount = webhookRequests.size
+            assertTrue(firstCount > 0)
+
+            // 対象期日 2026-03-25 の項目で再度通知
+            service.checkAndNotify(jstInstant(23, 0, day = 24))
+            assertTrue(webhookRequests.size > firstCount)
+        }
+
+    // --- collectDueItems: 全月を横断して収集 ---
+
+    @Test
+    fun collectDueItemsScansAllMonths() =
+        runTest {
+            coEvery { moneyRepository.getAllMonths() } returns
+                listOf(
+                    MonthlyMoney(
+                        yearMonth = "2026-03",
+                        items = listOf(MoneyItem(id = "i1", name = "電気代", amount = 8000L, dueDate = "2026-04-01")),
+                    ),
+                    MonthlyMoney(
+                        yearMonth = "2026-04",
+                        items = listOf(MoneyItem(id = "i2", name = "家賃", amount = 80000L, dueDate = "2026-04-01")),
+                    ),
+                )
+
+            val service = createService()
+            val dueItems = service.collectDueItems("2026-04-01")
+
+            assertEquals(2, dueItems.size)
+            assertTrue(dueItems.any { it.yearMonth == "2026-03" && it.name == "電気代" })
+            assertTrue(dueItems.any { it.yearMonth == "2026-04" && it.name == "家賃" })
+        }
+
+    // --- Discord ペイロード ---
+
+    @Test
+    fun discordPayloadContainsEmbed() {
+        val service = createService()
+        val payload =
+            service.buildPayload(
+                url = "https://discord.com/api/webhooks/x/y",
+                prefix = "@everyone",
+                targetDate = "2026-03-19",
+                items = listOf(DueMoneyItem(yearMonth = "2026-03", name = "電気代", amount = 8000L)),
+                moneyPageUrl = "https://example.com/money",
+            )
+        assertTrue(payload.contains("embeds"))
+        assertTrue(payload.contains("@everyone"))
+        assertTrue(payload.contains("電気代"))
+        assertTrue(payload.contains("https://example.com/money"))
+    }
+
+    // --- Slack ペイロード ---
+
+    @Test
+    fun slackPayloadContainsLink() {
+        val service = createService()
+        val payload =
+            service.buildPayload(
+                url = "https://hooks.slack.com/services/x/y/z",
+                prefix = "",
+                targetDate = "2026-03-19",
+                items = listOf(DueMoneyItem(yearMonth = "2026-03", name = "電気代", amount = 8000L)),
+                moneyPageUrl = "https://example.com/money",
+            )
+        assertTrue(payload.contains("\"text\""))
+        assertTrue(payload.contains("電気代"))
+        assertTrue(payload.contains("<https://example.com/money|"))
+    }
+
+    // --- 汎用ペイロード ---
+
+    @Test
+    fun genericPayloadContainsItems() {
+        val service = createService()
+        val payload =
+            service.buildPayload(
+                url = "https://example.com/webhook",
+                prefix = "",
+                targetDate = "2026-03-19",
+                items = listOf(DueMoneyItem(yearMonth = "2026-03", name = "電気代", amount = 8000L)),
+                moneyPageUrl = null,
+            )
+        assertTrue(payload.contains("money_due_date_reminder"))
+        assertTrue(payload.contains("電気代"))
+        assertTrue(payload.contains("2026-03-19"))
+        assertFalse(payload.contains("moneyPageUrl\":\""))
+    }
+
+    // --- formatDueDateLabel ---
+
+    @Test
+    fun formatDueDateLabelFormatsCorrectly() {
+        assertEquals("2026年3月19日", MoneyDueDateNotificationService.formatDueDateLabel("2026-03-19"))
+    }
+}

--- a/server/src/test/kotlin/server/money/MoneyParsingTest.kt
+++ b/server/src/test/kotlin/server/money/MoneyParsingTest.kt
@@ -250,12 +250,27 @@ class MoneyParsingTest {
     // ---------------------------------------------------------------------------------
 
     @Test
-    fun filterTaggedItemsForImportResetsDueDate() {
+    fun filterTaggedItemsForImportRebasesDueDateToTargetMonth() {
         // 前月の dueDate をそのまま複製すると、期日リマインダーが二度と一致せず
-        // 永久に飛ばなくなるため、インポート時にリセットされることを保証する回帰テスト。
+        // 永久に飛ばなくなるため、対象月の同じ日に付け替えられることを保証する回帰テスト。
         val items = listOf(MoneyItem(id = "i1", name = "家賃", amount = 80000L, tags = listOf(MoneyTags.RECURRING), dueDate = "2024-06-25"))
-        val result = repository.filterTaggedItemsForImport(items, MoneyTags.RECURRING)
+        val result = repository.filterTaggedItemsForImport(items, MoneyTags.RECURRING, "2024-07")
         assertEquals(1, result.size)
+        assertEquals("2024-07-25", result[0].dueDate)
+    }
+
+    @Test
+    fun filterTaggedItemsForImportNullsDueDateWhenTargetMonthHasNoSuchDay() {
+        // 1/31 の項目を 2月にインポートすると 2月に31日は存在しないため、クランプせず null にする。
+        val items = listOf(MoneyItem(id = "i1", name = "家賃", amount = 80000L, tags = listOf(MoneyTags.RECURRING), dueDate = "2024-01-31"))
+        val result = repository.filterTaggedItemsForImport(items, MoneyTags.RECURRING, "2024-02")
+        assertNull(result[0].dueDate)
+    }
+
+    @Test
+    fun filterTaggedItemsForImportKeepsNullDueDateAsNull() {
+        val items = listOf(MoneyItem(id = "i1", name = "家賃", amount = 80000L, tags = listOf(MoneyTags.RECURRING), dueDate = null))
+        val result = repository.filterTaggedItemsForImport(items, MoneyTags.RECURRING, "2024-07")
         assertNull(result[0].dueDate)
     }
 
@@ -266,7 +281,7 @@ class MoneyParsingTest {
                 MoneyItem(id = "i1", name = "家賃", amount = 80000L, tags = listOf(MoneyTags.RECURRING)),
                 MoneyItem(id = "i2", name = "外食", amount = 3000L, tags = emptyList()),
             )
-        val result = repository.filterTaggedItemsForImport(items, MoneyTags.RECURRING)
+        val result = repository.filterTaggedItemsForImport(items, MoneyTags.RECURRING, "2024-07")
         assertEquals(listOf("i1"), result.map { it.id })
     }
 
@@ -283,10 +298,37 @@ class MoneyParsingTest {
                     dueDate = "2024-06-25",
                 ),
             )
-        val result = repository.filterTaggedItemsForImport(items, MoneyTags.RECURRING)
+        val result = repository.filterTaggedItemsForImport(items, MoneyTags.RECURRING, "2024-07")
         assertEquals("家賃", result[0].name)
         assertEquals(80000L, result[0].amount)
         assertEquals("毎月25日払い", result[0].note)
         assertEquals(listOf(MoneyTags.RECURRING), result[0].tags)
+    }
+
+    // ---------------------------------------------------------------------------------
+    // rebaseDueDateToTargetMonth
+    // ---------------------------------------------------------------------------------
+
+    @Test
+    fun rebaseDueDateToTargetMonthKeepsSameDay() {
+        assertEquals("2024-07-25", repository.rebaseDueDateToTargetMonth("2024-06-25", "2024-07"))
+    }
+
+    @Test
+    fun rebaseDueDateToTargetMonthReturnsNullWhenDayDoesNotExistInTargetMonth() {
+        // 1/31 → 2月（うるう年でも29日まで）
+        assertNull(repository.rebaseDueDateToTargetMonth("2024-01-31", "2024-02"))
+    }
+
+    @Test
+    fun rebaseDueDateToTargetMonthHandlesLeapYearFebruary29() {
+        assertEquals("2024-02-29", repository.rebaseDueDateToTargetMonth("2024-01-29", "2024-02"))
+        assertNull(repository.rebaseDueDateToTargetMonth("2024-01-30", "2025-02"))
+    }
+
+    @Test
+    fun rebaseDueDateToTargetMonthReturnsNullForMalformedInput() {
+        assertNull(repository.rebaseDueDateToTargetMonth("not-a-date", "2024-07"))
+        assertNull(repository.rebaseDueDateToTargetMonth("2024-06-25", "not-a-yearmonth"))
     }
 }

--- a/server/src/test/kotlin/server/money/MoneyParsingTest.kt
+++ b/server/src/test/kotlin/server/money/MoneyParsingTest.kt
@@ -2,10 +2,12 @@ package server.money
 
 import com.google.cloud.firestore.Firestore
 import io.mockk.mockk
+import model.MoneyItem
 import model.MoneyTags
 import model.MonthlyMoneyStatus
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class MoneyParsingTest {
     // parse 関数群は Firestore に触れない純粋関数だが、メンバ関数なので
@@ -241,5 +243,50 @@ class MoneyParsingTest {
     fun parseStatusTrimsSurroundingWhitespace() {
         assertEquals(MonthlyMoneyStatus.CONFIRMED, repository.parseStatus(" CONFIRMED ", null))
         assertEquals(MonthlyMoneyStatus.FROZEN, repository.parseStatus("\tFROZEN\n", null))
+    }
+
+    // ---------------------------------------------------------------------------------
+    // filterTaggedItemsForImport
+    // ---------------------------------------------------------------------------------
+
+    @Test
+    fun filterTaggedItemsForImportResetsDueDate() {
+        // 前月の dueDate をそのまま複製すると、期日リマインダーが二度と一致せず
+        // 永久に飛ばなくなるため、インポート時にリセットされることを保証する回帰テスト。
+        val items = listOf(MoneyItem(id = "i1", name = "家賃", amount = 80000L, tags = listOf(MoneyTags.RECURRING), dueDate = "2024-06-25"))
+        val result = repository.filterTaggedItemsForImport(items, MoneyTags.RECURRING)
+        assertEquals(1, result.size)
+        assertNull(result[0].dueDate)
+    }
+
+    @Test
+    fun filterTaggedItemsForImportExcludesUntaggedItems() {
+        val items =
+            listOf(
+                MoneyItem(id = "i1", name = "家賃", amount = 80000L, tags = listOf(MoneyTags.RECURRING)),
+                MoneyItem(id = "i2", name = "外食", amount = 3000L, tags = emptyList()),
+            )
+        val result = repository.filterTaggedItemsForImport(items, MoneyTags.RECURRING)
+        assertEquals(listOf("i1"), result.map { it.id })
+    }
+
+    @Test
+    fun filterTaggedItemsForImportPreservesOtherFields() {
+        val items =
+            listOf(
+                MoneyItem(
+                    id = "i1",
+                    name = "家賃",
+                    amount = 80000L,
+                    note = "毎月25日払い",
+                    tags = listOf(MoneyTags.RECURRING),
+                    dueDate = "2024-06-25",
+                ),
+            )
+        val result = repository.filterTaggedItemsForImport(items, MoneyTags.RECURRING)
+        assertEquals("家賃", result[0].name)
+        assertEquals(80000L, result[0].amount)
+        assertEquals("毎月25日払い", result[0].note)
+        assertEquals(listOf(MoneyTags.RECURRING), result[0].tags)
     }
 }

--- a/server/src/test/kotlin/server/money/MoneyParsingTest.kt
+++ b/server/src/test/kotlin/server/money/MoneyParsingTest.kt
@@ -44,6 +44,37 @@ class MoneyParsingTest {
     }
 
     @Test
+    fun parseItemsReadsDueDate() {
+        val raw: List<Map<String, Any?>> =
+            listOf(
+                mapOf(
+                    "id" to "item1",
+                    "name" to "Rent",
+                    "amount" to 100000L,
+                    "dueDate" to "2024-06-25",
+                    "shares" to emptyList<Map<String, Any?>>(),
+                ),
+            )
+        val items = repository.parseItems(raw)
+        assertEquals("2024-06-25", items[0].dueDate)
+    }
+
+    @Test
+    fun parseItemsDueDateDefaultsToNullWhenAbsent() {
+        val raw: List<Map<String, Any?>> =
+            listOf(
+                mapOf(
+                    "id" to "item1",
+                    "name" to "Rent",
+                    "amount" to 100000L,
+                    "shares" to emptyList<Map<String, Any?>>(),
+                ),
+            )
+        val items = repository.parseItems(raw)
+        assertEquals(null, items[0].dueDate)
+    }
+
+    @Test
     fun parseItemsLegacyPaymentsFieldFallbacksToShares() {
         // 旧スキーマ: items[].payments → 新スキーマ items[].shares への過渡期互換
         val raw: List<Map<String, Any?>> =

--- a/shared/src/commonMain/kotlin/config/HttpTimeouts.kt
+++ b/shared/src/commonMain/kotlin/config/HttpTimeouts.kt
@@ -1,0 +1,13 @@
+package config
+
+/**
+ * アプリ全体で使う HTTP リクエストタイムアウトの既定値（ミリ秒）。
+ *
+ * サーバー側（Webhook 送信・Gemini API 呼び出し）とクライアント側（API クライアント）の
+ * 両方の HttpClient 生成箇所から参照し、タイムアウト値を1箇所に統一する。
+ * :shared は server（JVM）・core:network（wasmJs）の双方から参照できる唯一の共通モジュールのため、
+ * ここに置く。
+ */
+object HttpTimeouts {
+    const val DEFAULT_REQUEST_TIMEOUT_MILLIS = 10_000L
+}

--- a/shared/src/commonMain/kotlin/model/MoneyModels.kt
+++ b/shared/src/commonMain/kotlin/model/MoneyModels.kt
@@ -47,7 +47,7 @@ data class MoneyItem(
     val note: String = "",
     val shares: List<Share> = emptyList(),
     val tags: List<String> = emptyList(),
-    /** 支払期日（"YYYY-MM-DD"）。時刻は持たない。未設定は null（一覧では「期日無し」として表示）。 */
+    /** 支払期日（"YYYY-MM-DD"）。時刻は持たない。未設定は null（一覧では「支払期日なし」として表示）。 */
     val dueDate: String? = null,
 )
 

--- a/shared/src/commonMain/kotlin/model/MoneyModels.kt
+++ b/shared/src/commonMain/kotlin/model/MoneyModels.kt
@@ -47,6 +47,8 @@ data class MoneyItem(
     val note: String = "",
     val shares: List<Share> = emptyList(),
     val tags: List<String> = emptyList(),
+    /** 支払期日（"YYYY-MM-DD"）。時刻は持たない。未設定は null（一覧では「期日無し」として表示）。 */
+    val dueDate: String? = null,
 )
 
 /** 項目ごとの負担分担。「このユーザーはこの項目でこの金額を負担する」を表す。 */
@@ -114,6 +116,7 @@ data class MoneyItemSaveRequest(
     val note: String = "",
     val shares: List<ShareSaveRequest> = emptyList(),
     val tags: List<String> = emptyList(),
+    val dueDate: String? = null,
 )
 
 @Serializable
@@ -148,6 +151,7 @@ fun MoneyItem.toSaveRequest(): MoneyItemSaveRequest =
         note = note,
         shares = shares.map { it.toSaveRequest() },
         tags = tags,
+        dueDate = dueDate,
     )
 
 fun Share.toSaveRequest(): ShareSaveRequest = ShareSaveRequest(uid = uid, amount = amount)
@@ -172,3 +176,18 @@ data class PaymentWebhookSettings(
     override val enabled: Boolean = false,
     val message: String = "",
 ) : WebhookSettings
+
+/**
+ * 支払期日リマインダーの通知設定。
+ *
+ * 期日の [daysBefore] 日前、JST [notifyHour] 時に、その日が期日となる項目一覧を Webhook 通知する。
+ * デフォルトは「前日の夜11時」（daysBefore=1, notifyHour=23）。
+ */
+@Serializable
+data class MoneyDueDateNotificationSettings(
+    val enabled: Boolean = false,
+    val webhookUrl: String = "",
+    val daysBefore: Int = 1,
+    val notifyHour: Int = 23,
+    val prefix: String = "",
+)

--- a/shared/src/commonMain/kotlin/model/MoneyModels.kt
+++ b/shared/src/commonMain/kotlin/model/MoneyModels.kt
@@ -156,6 +156,18 @@ fun MoneyItem.toSaveRequest(): MoneyItemSaveRequest =
 
 fun Share.toSaveRequest(): ShareSaveRequest = ShareSaveRequest(uid = uid, amount = amount)
 
+/**
+ * 項目を支払期日でグルーピングする。期日昇順、未設定（null）は最後。
+ * グループ内の順序は元の並び順を維持する。money / payment 双方の画面で共用する。
+ */
+fun List<MoneyItem>.groupedByDueDate(): List<Pair<String?, List<MoneyItem>>> {
+    val grouped = groupBy { it.dueDate }
+    val dueDates = grouped.keys.filterNotNull().sorted()
+    val ordered = dueDates.map { it to grouped.getValue(it) }
+    val withoutDueDate = grouped[null]
+    return if (withoutDueDate != null) ordered + (null to withoutDueDate) else ordered
+}
+
 // =================================================================================================
 // Webhook 設定（API request + response として共用、admin only エンドポイント）
 //

--- a/shared/src/commonTest/kotlin/model/MoneyModelsTest.kt
+++ b/shared/src/commonTest/kotlin/model/MoneyModelsTest.kt
@@ -208,6 +208,37 @@ class MoneyModelsTest {
     }
 
     // ---------------------------------------------------------------------------------
+    // groupedByDueDate
+    // ---------------------------------------------------------------------------------
+
+    @Test
+    fun groupedByDueDateSortsAscendingWithUnsetLast() {
+        val items =
+            listOf(
+                MoneyItem(id = "i1", name = "B", amount = 1000L, dueDate = "2024-06-25"),
+                MoneyItem(id = "i2", name = "A", amount = 2000L, dueDate = null),
+                MoneyItem(id = "i3", name = "C", amount = 3000L, dueDate = "2024-06-10"),
+            )
+        val grouped = items.groupedByDueDate()
+        assertEquals(listOf("2024-06-10", "2024-06-25", null), grouped.map { it.first })
+        assertEquals(listOf("i3"), grouped[0].second.map { it.id })
+        assertEquals(listOf("i1"), grouped[1].second.map { it.id })
+        assertEquals(listOf("i2"), grouped[2].second.map { it.id })
+    }
+
+    @Test
+    fun groupedByDueDateOmitsUnsetGroupWhenAllItemsHaveDueDate() {
+        val items = listOf(MoneyItem(id = "i1", name = "A", amount = 1000L, dueDate = "2024-06-25"))
+        val grouped = items.groupedByDueDate()
+        assertEquals(listOf("2024-06-25"), grouped.map { it.first })
+    }
+
+    @Test
+    fun groupedByDueDateReturnsEmptyForEmptyList() {
+        assertEquals(emptyList(), emptyList<MoneyItem>().groupedByDueDate())
+    }
+
+    // ---------------------------------------------------------------------------------
     // MoneyDueDateNotificationSettings
     // ---------------------------------------------------------------------------------
 

--- a/shared/src/commonTest/kotlin/model/MoneyModelsTest.kt
+++ b/shared/src/commonTest/kotlin/model/MoneyModelsTest.kt
@@ -47,10 +47,19 @@ class MoneyModelsTest {
                 note = "June",
                 shares = listOf(Share(uid = "u1", amount = 4000L), Share(uid = "u2", amount = 4000L)),
                 tags = listOf(MoneyTags.RECURRING),
+                dueDate = "2024-06-25",
             )
         val encoded = json.encodeToString(MoneyItem.serializer(), item)
         val decoded = json.decodeFromString(MoneyItem.serializer(), encoded)
         assertEquals(item, decoded)
+        assertEquals("2024-06-25", decoded.dueDate)
+    }
+
+    @Test
+    fun moneyItemDueDateDefaultsToNull() {
+        val jsonStr = """{"id":"m1","name":"Rent","amount":100000}"""
+        val decoded = json.decodeFromString(MoneyItem.serializer(), jsonStr)
+        assertEquals(null, decoded.dueDate)
     }
 
     @Test
@@ -190,5 +199,40 @@ class MoneyModelsTest {
         assertEquals("June", request.items[0].note)
         assertEquals(1, request.items[0].shares.size)
         assertEquals("u1", request.items[0].shares[0].uid)
+    }
+
+    @Test
+    fun moneyItemToSaveRequestPreservesDueDate() {
+        val item = MoneyItem(id = "i1", name = "Rent", amount = 80000L, dueDate = "2024-06-25")
+        assertEquals("2024-06-25", item.toSaveRequest().dueDate)
+    }
+
+    // ---------------------------------------------------------------------------------
+    // MoneyDueDateNotificationSettings
+    // ---------------------------------------------------------------------------------
+
+    @Test
+    fun moneyDueDateNotificationSettingsDefaults() {
+        val settings = MoneyDueDateNotificationSettings()
+        assertEquals(false, settings.enabled)
+        assertEquals("", settings.webhookUrl)
+        assertEquals(1, settings.daysBefore)
+        assertEquals(23, settings.notifyHour)
+        assertEquals("", settings.prefix)
+    }
+
+    @Test
+    fun moneyDueDateNotificationSettingsRoundTrip() {
+        val settings =
+            MoneyDueDateNotificationSettings(
+                enabled = true,
+                webhookUrl = "https://discord.com/api/webhooks/x/y",
+                daysBefore = 3,
+                notifyHour = 9,
+                prefix = "@everyone",
+            )
+        val encoded = json.encodeToString(MoneyDueDateNotificationSettings.serializer(), settings)
+        val decoded = json.decodeFromString(MoneyDueDateNotificationSettings.serializer(), encoded)
+        assertEquals(settings, decoded)
     }
 }


### PR DESCRIPTION
## 概要

支払い項目（`MoneyItem`）に支払期日（年月日、時刻無し、nullable）を追加し、一覧を期日ごとにグルーピング表示するようにした。あわせて、支払期日リマインダーの Webhook 通知機能を追加した。ついでにアプリ内の HttpClient タイムアウト設定も統一した。

## 変更内容

### データモデル
- `MoneyItem` / `MoneyItemSaveRequest` に `dueDate: String?`（`"YYYY-MM-DD"`）を追加
- `MoneyDueDateNotificationSettings` を新設(enabled / webhookUrl / daysBefore / notifyHour / prefix)
- `List<MoneyItem>.groupedByDueDate()`（shared）: 期日昇順・未設定は最後、というグルーピングを money/payment 両画面で共用

### UI
- お金の管理画面(`MoneyContent`): 項目編集フォームに `CalendarView` によるインライン日付選択(クリア可)を追加。一覧を支払期日でグルーピング表示(期日昇順、未設定は「期日無し」として最後に表示するグループ見出し)
- 支払い画面(`PaymentContent`): 内訳一覧も同様に支払期日でグルーピング表示
- 期日はグループ見出しとして表示する（グルーピングにより文脈が明らかなため、カード単体には表示しない設計とした）。見出しは「支払期日: 6月25日」形式で、日付だけだと項目の入力日と誤読されるため「支払期日:」プレフィックスを付ける。未設定グループは「支払期日なし」

### 通知
- `MoneyDueDateNotificationService`(サーバー): 60秒間隔でポーリングし、期日の `daysBefore` 日前・JST `notifyHour` 時(デフォルト: 前日の23時)に、その日が期日となる項目一覧を Discord / Slack / 汎用 Webhook で通知する(既存の給餌・ゴミ出しリマインダーと同じパターン)
- 設定画面(お金カテゴリ)に「支払期日リマインダー」カードを追加し、有効/無効・Webhook URL・通知テキスト・何日前の何時に通知するかを変更可能にした。テスト送信ボタンも追加(給餌リマインダーの導線と同じパターン)
- admin 向けテスト送信エンドポイント(`POST /api/money/due-date-notification-settings/test`)を追加

### バグ修正
- 定期項目インポート(`importItemsByTag`)時、前月の `dueDate` がそのまま複製されると期日リマインダーが二度と発火しなくなる不具合を修正。毎月同じ日払いを想定し、インポート先の月の同じ日に付け替える（対象月にその日が存在しない場合はクランプせず null にフォールバック）

### リファクタ: HttpClient タイムアウトの統一
- `shared` に `HttpTimeouts.DEFAULT_REQUEST_TIMEOUT_MILLIS`（10秒）を追加し、サーバー・クライアント双方の HttpClient から参照する唯一のタイムアウト値にした
- サーバー側は `server.util.defaultHttpClient()` に一本化(Money/Payment/Quest Webhook サービス、給餌・ゴミ出し・支払期日リマインダー、Gemini API クライアントがすべて経由)。特に `GarbageNotificationService` は従来タイムアウト設定が無く、接続がハングするとポーリングループが無期限に止まりうる問題があったため、これも解消
- クライアント側(`core.network.AuthHttpClient`)の認証あり/なし両クライアントにも同じタイムアウトを設定(従来は無制限だった)
- 注意: Gemini でのクエスト文章生成呼び出しと、フロントエンドの認証済みクライアントの両方に同じ10秒タイムアウトが新たに掛かるため、ブラウザ→サーバー→Gemini の合計で最大約20秒でタイムアウトしうる。生成に時間がかかる場合はこの値の見直しが必要になる可能性がある

## テスト
- `./gradlew :shared:jvmTest :server:test -PskipFrontend` ✅
- `./gradlew :feature:money:jvmTest :feature:payment:jvmTest :feature:settings:jvmTest` ✅
- `./gradlew :app:compileKotlinWasmJs` ✅(フロントエンド側コンパイル確認)
- `./gradlew ktlintCheck` ✅
- self-review スキルによる3セットのセルフレビュー(2セット目で `importItemsByTag` の `dueDate` 複製バグを検出・修正、3セット目で Approved)を実施済み。レビュー後、ユーザー指示によりインポート挙動の見直し（null化→月付け替え）と HttpClient タイムアウト統一を追加

## 動作確認
ローカル開発環境(`dev.sh`)を起動し、サーバーが新しいルート・DI 配線込みで正常起動することを確認。`MoneyDueDateNotificationService` を実際のローカル HTTP サーバーへ Webhook 送信させ、Discord/Slack/汎用いずれの形式でも正しいペイロードが届くことを確認済み(検証用の一時ファイルはコミットに含めていない)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

