### PR TITLE
feat: ボタン連続クリック対策（デバウンス共通ボタン + 実行中フラグ + ナビのジョブキャンセル）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,9 @@ docker compose pull && docker compose up -d
 ## UI Rules
 
 - **Popup 系コンポーネント（AlertDialog, DropdownMenu 等）は使用禁止。** Compose for WASM の描画システム上、Popup の DOM teardown とリスト recomposition が同時に走ると高確率で UI フリーズが発生するため。入力フォームはインライン（Card ベース）、選択 UI はインライン（FilterChip 等）で実装すること。
+- **material3 の Button 系（`Button`, `IconButton`, `TextButton`, `OutlinedButton`）は直接使用禁止。** 必ず `core/ui` の `AppButton` / `AppIconButton` / `AppTextButton` / `AppOutlinedButton` を経由すること。デフォルトで 300ms のクリックデバウンスが入り、同一フレーム内の連続クリックによる多重実行を防ぐ（`enabled` ベースの制御は再コンポーズ反映まで効かないため、デバウンスと併用して初めて隙がなくなる）。
+  - **更新系ボタン（API でサーバー状態を変えるもの）**: ViewModel に実行中フラグ（`isSaving` 等）を持たせ、処理完了まで `enabled = false` にする。フラグは `launch` の前（メソッド先頭）で同期的にセットし、`finally` で戻す。デバウンス（0〜300ms）とフラグ（次フレーム〜完了）の合わせ技で全期間をカバーする。
+  - **画面操作系ボタン（月送り・日送りナビゲーション、ローカル UI トグル）**: 連打が正当な操作なので `debounceMillis = 0` を指定してよい。ロードを伴うナビゲーションは ViewModel 側で前のリクエストの `Job` をキャンセルし、最後の操作の結果のみ反映する（レスポンス順序逆転による表示不整合の防止）。
 
 ## Testing
 

--- a/app/src/commonMain/kotlin/app/components/Sidebar.kt
+++ b/app/src/commonMain/kotlin/app/components/Sidebar.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -21,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import app.Screen
+import core.ui.components.AppIconButton
 
 @Composable
 fun Sidebar(
@@ -42,9 +42,10 @@ fun Sidebar(
     ) {
         Column(modifier = Modifier.fillMaxHeight().padding(vertical = 8.dp)) {
             if (expandable) {
-                IconButton(
+                AppIconButton(
                     onClick = { expanded = !expanded },
                     modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
+                    debounceMillis = 0,
                 ) {
                     Icon(
                         imageVector = Icons.Default.Menu,

--- a/app/src/wasmJsMain/kotlin/app/App.kt
+++ b/app/src/wasmJsMain/kotlin/app/App.kt
@@ -19,6 +19,7 @@ import core.auth.AuthRepository
 import core.auth.AuthStateHolder
 import core.ui.LocalWindowSizeClass
 import core.ui.WindowSizeClass
+import core.ui.components.AppIconButton
 import core.ui.theme.AppTheme
 import feature.dashboard.DashboardScreen
 import feature.feeding.FeedingScreen
@@ -185,7 +186,7 @@ private fun CompactLayout(
                 TopAppBar(
                     title = { Text(currentScreen.title) },
                     navigationIcon = {
-                        IconButton(onClick = { scope.launch { drawerState.open() } }) {
+                        AppIconButton(onClick = { scope.launch { drawerState.open() } }, debounceMillis = 0) {
                             Icon(Icons.Default.Menu, contentDescription = "メニュー")
                         }
                     },

--- a/core/ui/src/commonMain/kotlin/core/ui/components/AppButtons.kt
+++ b/core/ui/src/commonMain/kotlin/core/ui/components/AppButtons.kt
@@ -1,0 +1,125 @@
+package core.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ButtonElevation
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonColors
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+
+// material3 の Button 系は連続クリックで onClick が多重実行されるため直接使わず、
+// 必ずデバウンス付きの本ラッパー群を経由する（CLAUDE.md の UI Rules 参照）。
+
+@Composable
+fun AppButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    debounceMillis: Long = DEFAULT_CLICK_DEBOUNCE_MILLIS,
+    shape: Shape = ButtonDefaults.shape,
+    colors: ButtonColors = ButtonDefaults.buttonColors(),
+    elevation: ButtonElevation? = ButtonDefaults.buttonElevation(),
+    border: BorderStroke? = null,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    interactionSource: MutableInteractionSource? = null,
+    content: @Composable RowScope.() -> Unit,
+) {
+    Button(
+        onClick = rememberDebouncedOnClick(debounceMillis, onClick),
+        modifier = modifier,
+        enabled = enabled,
+        shape = shape,
+        colors = colors,
+        elevation = elevation,
+        border = border,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        content = content,
+    )
+}
+
+@Composable
+fun AppOutlinedButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    debounceMillis: Long = DEFAULT_CLICK_DEBOUNCE_MILLIS,
+    shape: Shape = ButtonDefaults.outlinedShape,
+    colors: ButtonColors = ButtonDefaults.outlinedButtonColors(),
+    elevation: ButtonElevation? = null,
+    border: BorderStroke? = ButtonDefaults.outlinedButtonBorder(enabled),
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    interactionSource: MutableInteractionSource? = null,
+    content: @Composable RowScope.() -> Unit,
+) {
+    OutlinedButton(
+        onClick = rememberDebouncedOnClick(debounceMillis, onClick),
+        modifier = modifier,
+        enabled = enabled,
+        shape = shape,
+        colors = colors,
+        elevation = elevation,
+        border = border,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        content = content,
+    )
+}
+
+@Composable
+fun AppTextButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    debounceMillis: Long = DEFAULT_CLICK_DEBOUNCE_MILLIS,
+    shape: Shape = ButtonDefaults.textShape,
+    colors: ButtonColors = ButtonDefaults.textButtonColors(),
+    elevation: ButtonElevation? = null,
+    border: BorderStroke? = null,
+    contentPadding: PaddingValues = ButtonDefaults.TextButtonContentPadding,
+    interactionSource: MutableInteractionSource? = null,
+    content: @Composable RowScope.() -> Unit,
+) {
+    TextButton(
+        onClick = rememberDebouncedOnClick(debounceMillis, onClick),
+        modifier = modifier,
+        enabled = enabled,
+        shape = shape,
+        colors = colors,
+        elevation = elevation,
+        border = border,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        content = content,
+    )
+}
+
+@Composable
+fun AppIconButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    debounceMillis: Long = DEFAULT_CLICK_DEBOUNCE_MILLIS,
+    colors: IconButtonColors = IconButtonDefaults.iconButtonColors(),
+    interactionSource: MutableInteractionSource? = null,
+    content: @Composable () -> Unit,
+) {
+    IconButton(
+        onClick = rememberDebouncedOnClick(debounceMillis, onClick),
+        modifier = modifier,
+        enabled = enabled,
+        colors = colors,
+        interactionSource = interactionSource,
+        content = content,
+    )
+}

--- a/core/ui/src/commonMain/kotlin/core/ui/components/CalendarView.kt
+++ b/core/ui/src/commonMain/kotlin/core/ui/components/CalendarView.kt
@@ -96,12 +96,13 @@ fun CalendarView(
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        TextButton(
+        AppTextButton(
             onClick = {
                 displayYear = todayYear
                 displayMonth = todayMonth
                 onDateSelected(today)
             },
+            debounceMillis = 0,
             modifier = Modifier.align(Alignment.CenterHorizontally),
         ) {
             Text("今日")
@@ -121,14 +122,14 @@ private fun MonthHeader(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        IconButton(onClick = onPreviousMonth) {
+        AppIconButton(onClick = onPreviousMonth, debounceMillis = 0) {
             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "前月")
         }
         Text(
             text = "${year}年 ${MONTH_NAMES[month - 1]}",
             style = MaterialTheme.typography.titleMedium,
         )
-        IconButton(onClick = onNextMonth) {
+        AppIconButton(onClick = onNextMonth, debounceMillis = 0) {
             Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = "翌月")
         }
     }

--- a/core/ui/src/commonMain/kotlin/core/ui/components/DebouncedClick.kt
+++ b/core/ui/src/commonMain/kotlin/core/ui/components/DebouncedClick.kt
@@ -1,0 +1,54 @@
+package core.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+
+/** 連続クリック抑止のデフォルト間隔（ミリ秒） */
+const val DEFAULT_CLICK_DEBOUNCE_MILLIS = 300L
+
+/**
+ * onClick をデバウンス付きラムダに包んで返す。
+ *
+ * 判定はクリックイベントハンドラ内で完結するため、enabled ベースの制御と違い
+ * 再コンポーズの反映を待たずに同一フレーム内の連続クリックも弾ける。
+ * [debounceMillis] に 0 を渡すとデバウンスなし（連打が正当な操作であるナビゲーション等向け）。
+ */
+@Composable
+fun rememberDebouncedOnClick(
+    debounceMillis: Long = DEFAULT_CLICK_DEBOUNCE_MILLIS,
+    onClick: () -> Unit,
+): () -> Unit {
+    val currentOnClick by rememberUpdatedState(onClick)
+    val state = remember { ClickDebounceState() }
+    return remember(debounceMillis) {
+        {
+            if (state.tryClick(debounceMillis)) {
+                currentOnClick()
+            }
+        }
+    }
+}
+
+/**
+ * 前回受理したクリックからの経過時間で受理可否を判定する。
+ * Snapshot 状態を使わないため、判定・記録によって再コンポーズは発生しない。
+ */
+class ClickDebounceState(
+    private val timeSource: TimeSource = TimeSource.Monotonic,
+) {
+    private var lastAcceptedMark: TimeMark? = null
+
+    /** クリックを受理できるなら記録して true、デバウンス間隔内なら false を返す */
+    fun tryClick(debounceMillis: Long): Boolean {
+        val mark = lastAcceptedMark
+        if (mark != null && mark.elapsedNow().inWholeMilliseconds < debounceMillis) {
+            return false
+        }
+        lastAcceptedMark = timeSource.markNow()
+        return true
+    }
+}

--- a/core/ui/src/commonMain/kotlin/core/ui/components/LoadErrorContent.kt
+++ b/core/ui/src/commonMain/kotlin/core/ui/components/LoadErrorContent.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -36,7 +35,7 @@ fun LoadErrorContent(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-        OutlinedButton(onClick = onRetry) {
+        AppOutlinedButton(onClick = onRetry) {
             Text("再試行")
         }
     }

--- a/core/ui/src/commonTest/kotlin/core/ui/components/ClickDebounceStateTest.kt
+++ b/core/ui/src/commonTest/kotlin/core/ui/components/ClickDebounceStateTest.kt
@@ -1,0 +1,52 @@
+package core.ui.components
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TestTimeSource
+
+class ClickDebounceStateTest {
+    @Test
+    fun tryClick_firstClickIsAccepted() {
+        val state = ClickDebounceState(TestTimeSource())
+        assertTrue(state.tryClick(300))
+    }
+
+    @Test
+    fun tryClick_rejectsClickWithinDebounceWindow() {
+        val timeSource = TestTimeSource()
+        val state = ClickDebounceState(timeSource)
+        assertTrue(state.tryClick(300))
+        timeSource += 299.milliseconds
+        assertFalse(state.tryClick(300))
+    }
+
+    @Test
+    fun tryClick_acceptsClickAfterDebounceWindow() {
+        val timeSource = TestTimeSource()
+        val state = ClickDebounceState(timeSource)
+        assertTrue(state.tryClick(300))
+        timeSource += 300.milliseconds
+        assertTrue(state.tryClick(300))
+    }
+
+    @Test
+    fun tryClick_rejectionDoesNotResetWindow() {
+        val timeSource = TestTimeSource()
+        val state = ClickDebounceState(timeSource)
+        assertTrue(state.tryClick(300))
+        timeSource += 200.milliseconds
+        assertFalse(state.tryClick(300))
+        timeSource += 100.milliseconds
+        // 拒否されたクリックが基準時刻を更新しないこと（最初の受理から300ms経過で受理）
+        assertTrue(state.tryClick(300))
+    }
+
+    @Test
+    fun tryClick_zeroDebounceAlwaysAccepts() {
+        val state = ClickDebounceState(TestTimeSource())
+        assertTrue(state.tryClick(0))
+        assertTrue(state.tryClick(0))
+    }
+}

--- a/feature/auth/src/commonMain/kotlin/feature/auth/LoginScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/feature/auth/LoginScreen.kt
@@ -20,6 +20,9 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import core.ui.components.AppButton
+import core.ui.components.AppIconButton
+import core.ui.components.AppTextButton
 import core.ui.theme.AppTheme
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -176,7 +179,7 @@ private fun PasskeyLoginSection(
 ) {
     Spacer(modifier = Modifier.height(8.dp))
 
-    Button(
+    AppButton(
         onClick = onPasskeySignIn,
         modifier = Modifier.fillMaxWidth().height(48.dp),
         enabled = !isLoading,
@@ -198,7 +201,7 @@ private fun PasskeyLoginSection(
         }
     }
 
-    TextButton(
+    AppTextButton(
         onClick = onSwitchToEmailPassword,
         enabled = !isLoading,
     ) {
@@ -223,7 +226,7 @@ private fun EmailPasswordLoginSection(
         label = { Text("パスワード") },
         leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) },
         trailingIcon = {
-            IconButton(onClick = onTogglePasswordVisibility) {
+            AppIconButton(onClick = onTogglePasswordVisibility, debounceMillis = 0) {
                 Icon(
                     if (passwordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
                     contentDescription = if (passwordVisible) "パスワードを隠す" else "パスワードを表示",
@@ -252,7 +255,7 @@ private fun EmailPasswordLoginSection(
 
     Spacer(modifier = Modifier.height(8.dp))
 
-    Button(
+    AppButton(
         onClick = onSignIn,
         modifier = Modifier.fillMaxWidth().height(48.dp),
         enabled = !isLoading,
@@ -269,7 +272,7 @@ private fun EmailPasswordLoginSection(
     }
 
     if (isWebAuthnSupported) {
-        TextButton(
+        AppTextButton(
             onClick = onSwitchToPasskey,
             enabled = !isLoading,
         ) {

--- a/feature/auth/src/commonMain/kotlin/feature/auth/PasskeySetupContent.kt
+++ b/feature/auth/src/commonMain/kotlin/feature/auth/PasskeySetupContent.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import core.ui.components.AppButton
+import core.ui.components.AppTextButton
 import core.ui.theme.AppTheme
 
 @Composable
@@ -74,7 +76,7 @@ internal fun PasskeySetupContent(
 
                             Spacer(modifier = Modifier.height(8.dp))
 
-                            Button(
+                            AppButton(
                                 onClick = onRegister,
                                 modifier = Modifier.fillMaxWidth().height(48.dp),
                                 enabled = !isRegistering,
@@ -90,7 +92,7 @@ internal fun PasskeySetupContent(
                                 }
                             }
 
-                            TextButton(
+                            AppTextButton(
                                 onClick = onSkip,
                                 enabled = !isRegistering,
                             ) {

--- a/feature/dashboard/src/commonMain/kotlin/feature/dashboard/DashboardContent.kt
+++ b/feature/dashboard/src/commonMain/kotlin/feature/dashboard/DashboardContent.kt
@@ -46,6 +46,7 @@ internal fun DashboardContent(
     onFeedClick: (MealTime) -> Unit,
     onRefreshFeeding: () -> Unit,
     windowSizeClass: WindowSizeClass = WindowSizeClass.Expanded,
+    feedingInProgress: MealTime? = null,
 ) {
     Column(
         modifier =
@@ -78,6 +79,7 @@ internal fun DashboardContent(
                     isLoading = feedingLoading,
                     error = feedingError,
                     actionError = feedingActionError,
+                    feedingInProgress = feedingInProgress,
                     onFeedClick = onFeedClick,
                     onRefresh = onRefreshFeeding,
                 )
@@ -106,6 +108,7 @@ internal fun DashboardContent(
                     isLoading = feedingLoading,
                     error = feedingError,
                     actionError = feedingActionError,
+                    feedingInProgress = feedingInProgress,
                     onFeedClick = onFeedClick,
                     onRefresh = onRefreshFeeding,
                 )
@@ -228,6 +231,7 @@ fun DailyFeedingCard(
     isLoading: Boolean,
     error: String?,
     actionError: String?,
+    feedingInProgress: MealTime?,
     onFeedClick: (MealTime) -> Unit,
     onRefresh: () -> Unit,
     modifier: Modifier = Modifier,
@@ -310,6 +314,7 @@ fun DailyFeedingCard(
                                 tint = mealTime.color,
                                 isDone = feeding?.done == true,
                                 time = feeding?.timestamp?.let { toJstHHMM(it) },
+                                feedEnabled = feedingInProgress == null,
                                 onClick = { onFeedClick(mealTime) },
                                 modifier = Modifier.weight(1f),
                             )
@@ -399,6 +404,7 @@ private fun FeedingSection(
     tint: Color,
     isDone: Boolean,
     time: String?,
+    feedEnabled: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -448,6 +454,7 @@ private fun FeedingSection(
         } else {
             AppButton(
                 onClick = onClick,
+                enabled = feedEnabled,
                 modifier = Modifier.fillMaxWidth(),
                 contentPadding = PaddingValues(0.dp),
             ) {

--- a/feature/dashboard/src/commonMain/kotlin/feature/dashboard/DashboardContent.kt
+++ b/feature/dashboard/src/commonMain/kotlin/feature/dashboard/DashboardContent.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import core.ui.WindowSizeClass
+import core.ui.components.AppButton
+import core.ui.components.AppIconButton
 import core.ui.extensions.FeedingDoneColor
 import core.ui.extensions.color
 import core.ui.extensions.icon
@@ -255,7 +257,7 @@ fun DailyFeedingCard(
                     petName = petName,
                     modifier = Modifier.weight(1f),
                 )
-                IconButton(onClick = onRefresh) {
+                AppIconButton(onClick = onRefresh) {
                     Icon(
                         imageVector = Icons.Default.Refresh,
                         contentDescription = "更新",
@@ -444,7 +446,7 @@ private fun FeedingSection(
                 )
             }
         } else {
-            Button(
+            AppButton(
                 onClick = onClick,
                 modifier = Modifier.fillMaxWidth(),
                 contentPadding = PaddingValues(0.dp),

--- a/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardScreen.kt
+++ b/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardScreen.kt
@@ -21,6 +21,7 @@ fun DashboardScreen(vm: DashboardViewModel = koinViewModel()) {
         currentYear = vm.uiState.currentYear,
         dateWithDay = vm.uiState.dateWithDay,
         onFeedClick = vm::onFeed,
+        feedingInProgress = vm.uiState.feedingInProgress,
         onRefreshFeeding = vm::onRefreshFeeding,
         windowSizeClass = windowSizeClass,
     )

--- a/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
+++ b/feature/dashboard/src/wasmJsMain/kotlin/feature/dashboard/DashboardViewModel.kt
@@ -38,6 +38,7 @@ data class DashboardUiState(
     val feedingLoading: Boolean = true,
     val feedingError: String? = null,
     val feedingActionError: String? = null,
+    val feedingInProgress: MealTime? = null,
     val petName: String? = null,
     val mealOrder: List<MealTime> = FeedingSettings.DEFAULT_MEAL_ORDER,
     val todayGarbageTypes: List<GarbageType> = emptyList(),
@@ -255,8 +256,8 @@ class DashboardViewModel(
 
     fun onFeed(mealTime: MealTime) {
         val id = petId ?: return
+        uiState = uiState.copy(feedingInProgress = mealTime, feedingActionError = null)
         viewModelScope.launch {
-            uiState = uiState.copy(feedingActionError = null)
             try {
                 val feeding = feedingRepository.feed(id, today, mealTime)
                 uiState =
@@ -268,6 +269,8 @@ class DashboardViewModel(
                     )
             } catch (e: Exception) {
                 uiState = uiState.copy(feedingActionError = e.message)
+            } finally {
+                uiState = uiState.copy(feedingInProgress = null)
             }
         }
     }

--- a/feature/feeding/src/commonMain/kotlin/feature/feeding/FeedingContent.kt
+++ b/feature/feeding/src/commonMain/kotlin/feature/feeding/FeedingContent.kt
@@ -54,6 +54,9 @@ internal fun FeedingContent(
     onCancelEditTimestamp: () -> Unit,
     onSaveTimestamp: (MealTime, Int, Int) -> Unit,
     windowSizeClass: WindowSizeClass = WindowSizeClass.Expanded,
+    feedingInProgress: MealTime? = null,
+    isSavingNote: Boolean = false,
+    isSavingTimestamp: Boolean = false,
 ) {
     val isCompact = windowSizeClass == WindowSizeClass.Compact
 
@@ -98,6 +101,9 @@ internal fun FeedingContent(
                     onStartEditTimestamp = onStartEditTimestamp,
                     onCancelEditTimestamp = onCancelEditTimestamp,
                     onSaveTimestamp = onSaveTimestamp,
+                    feedingInProgress = feedingInProgress,
+                    isSavingNote = isSavingNote,
+                    isSavingTimestamp = isSavingTimestamp,
                 )
             }
         } else {
@@ -122,6 +128,9 @@ internal fun FeedingContent(
                         onStartEditTimestamp = onStartEditTimestamp,
                         onCancelEditTimestamp = onCancelEditTimestamp,
                         onSaveTimestamp = onSaveTimestamp,
+                        feedingInProgress = feedingInProgress,
+                        isSavingNote = isSavingNote,
+                        isSavingTimestamp = isSavingTimestamp,
                     )
                 }
 
@@ -155,6 +164,9 @@ private fun FeedingDetailSection(
     onStartEditTimestamp: (MealTime) -> Unit,
     onCancelEditTimestamp: () -> Unit,
     onSaveTimestamp: (MealTime, Int, Int) -> Unit,
+    feedingInProgress: MealTime?,
+    isSavingNote: Boolean,
+    isSavingTimestamp: Boolean,
 ) {
     DateSelector(
         date = selectedDate,
@@ -182,6 +194,8 @@ private fun FeedingDetailSection(
                         mealTime = mealTime,
                         feeding = log.feedings[mealTime] ?: Feeding(),
                         isEditing = editingMealTime == mealTime,
+                        feedEnabled = feedingInProgress == null,
+                        saveTimestampEnabled = !isSavingTimestamp,
                         onFeed = { onFeed(mealTime) },
                         onStartEdit = { onStartEditTimestamp(mealTime) },
                         onCancelEdit = onCancelEditTimestamp,
@@ -194,6 +208,7 @@ private fun FeedingDetailSection(
 
             NoteSection(
                 note = noteDraft,
+                saveEnabled = !isSavingNote,
                 onNoteChange = onNoteChange,
                 onSave = onSaveNote,
             )
@@ -230,6 +245,8 @@ private fun MealCard(
     mealTime: MealTime,
     feeding: Feeding,
     isEditing: Boolean,
+    feedEnabled: Boolean,
+    saveTimestampEnabled: Boolean,
     onFeed: () -> Unit,
     onStartEdit: () -> Unit,
     onCancelEdit: () -> Unit,
@@ -279,6 +296,7 @@ private fun MealCard(
                     if (isEditing) {
                         TimestampEditor(
                             timestamp = ts,
+                            saveEnabled = saveTimestampEnabled,
                             onCancel = onCancelEdit,
                             onSave = onSaveTimestamp,
                         )
@@ -298,7 +316,7 @@ private fun MealCard(
                         modifier = Modifier.size(24.dp),
                     )
                 } else {
-                    AppButton(onClick = onFeed) {
+                    AppButton(onClick = onFeed, enabled = feedEnabled) {
                         Text("あげる")
                     }
                 }
@@ -329,6 +347,7 @@ private fun TimestampBadge(
 @Composable
 private fun TimestampEditor(
     timestamp: String,
+    saveEnabled: Boolean,
     onCancel: () -> Unit,
     onSave: (hour: Int, minute: Int) -> Unit,
 ) {
@@ -378,6 +397,7 @@ private fun TimestampEditor(
                         onSave(h, m)
                     }
                 },
+                enabled = saveEnabled,
                 modifier = Modifier.size(28.dp),
             ) {
                 Icon(
@@ -405,6 +425,7 @@ private fun TimestampEditor(
 @Composable
 private fun NoteSection(
     note: String,
+    saveEnabled: Boolean,
     onNoteChange: (String) -> Unit,
     onSave: () -> Unit,
 ) {
@@ -422,7 +443,7 @@ private fun NoteSection(
         maxLines = 4,
     )
     Spacer(modifier = Modifier.height(8.dp))
-    AppButton(onClick = onSave) {
+    AppButton(onClick = onSave, enabled = saveEnabled) {
         Text("保存する")
     }
 }

--- a/feature/feeding/src/commonMain/kotlin/feature/feeding/FeedingContent.kt
+++ b/feature/feeding/src/commonMain/kotlin/feature/feeding/FeedingContent.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import core.ui.WindowSizeClass
+import core.ui.components.AppButton
+import core.ui.components.AppIconButton
 import core.ui.components.CalendarView
 import core.ui.extensions.FeedingDoneColor
 import core.ui.extensions.color
@@ -210,14 +212,14 @@ private fun DateSelector(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        IconButton(onClick = onPrevious) {
+        AppIconButton(onClick = onPrevious, debounceMillis = 0) {
             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "前日")
         }
         Text(
             text = "$date ($dow)",
             style = MaterialTheme.typography.titleLarge,
         )
-        IconButton(onClick = onNext) {
+        AppIconButton(onClick = onNext, debounceMillis = 0) {
             Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = "翌日")
         }
     }
@@ -296,7 +298,7 @@ private fun MealCard(
                         modifier = Modifier.size(24.dp),
                     )
                 } else {
-                    Button(onClick = onFeed) {
+                    AppButton(onClick = onFeed) {
                         Text("あげる")
                     }
                 }
@@ -368,7 +370,7 @@ private fun TimestampEditor(
                 textStyle = MaterialTheme.typography.labelMedium,
                 singleLine = true,
             )
-            IconButton(
+            AppIconButton(
                 onClick = {
                     val h = hourText.toIntOrNull()
                     val m = minuteText.toIntOrNull()
@@ -385,7 +387,7 @@ private fun TimestampEditor(
                     modifier = Modifier.size(16.dp),
                 )
             }
-            IconButton(
+            AppIconButton(
                 onClick = onCancel,
                 modifier = Modifier.size(28.dp),
             ) {
@@ -420,7 +422,7 @@ private fun NoteSection(
         maxLines = 4,
     )
     Spacer(modifier = Modifier.height(8.dp))
-    Button(onClick = onSave) {
+    AppButton(onClick = onSave) {
         Text("保存する")
     }
 }

--- a/feature/feeding/src/wasmJsMain/kotlin/feature/feeding/FeedingScreen.kt
+++ b/feature/feeding/src/wasmJsMain/kotlin/feature/feeding/FeedingScreen.kt
@@ -31,5 +31,8 @@ fun FeedingScreen(vm: FeedingViewModel = koinViewModel()) {
         onCancelEditTimestamp = vm::onCancelEditTimestamp,
         onSaveTimestamp = vm::onSaveTimestamp,
         windowSizeClass = windowSizeClass,
+        feedingInProgress = vm.uiState.feedingInProgress,
+        isSavingNote = vm.uiState.isSavingNote,
+        isSavingTimestamp = vm.uiState.isSavingTimestamp,
     )
 }

--- a/feature/feeding/src/wasmJsMain/kotlin/feature/feeding/FeedingViewModel.kt
+++ b/feature/feeding/src/wasmJsMain/kotlin/feature/feeding/FeedingViewModel.kt
@@ -30,6 +30,9 @@ data class FeedingUiState(
     val pet: Pet? = null,
     val editingMealTime: MealTime? = null,
     val mealOrder: List<MealTime> = FeedingSettings.DEFAULT_MEAL_ORDER,
+    val feedingInProgress: MealTime? = null,
+    val isSavingNote: Boolean = false,
+    val isSavingTimestamp: Boolean = false,
 )
 
 class FeedingViewModel(
@@ -107,6 +110,7 @@ class FeedingViewModel(
 
     fun onFeed(mealTime: MealTime) {
         val petId = uiState.pet?.id ?: return
+        uiState = uiState.copy(feedingInProgress = mealTime)
         viewModelScope.launch {
             try {
                 val feeding = feedingRepository.feed(petId, uiState.selectedDate, mealTime)
@@ -122,6 +126,8 @@ class FeedingViewModel(
                     )
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
+            } finally {
+                uiState = uiState.copy(feedingInProgress = null)
             }
         }
     }
@@ -132,12 +138,15 @@ class FeedingViewModel(
 
     fun onSaveNote() {
         val petId = uiState.pet?.id ?: return
+        uiState = uiState.copy(isSavingNote = true)
         viewModelScope.launch {
             try {
                 feedingRepository.updateNote(petId, uiState.selectedDate, uiState.noteDraft)
                 uiState = uiState.copy(log = uiState.log.copy(note = uiState.noteDraft))
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
+            } finally {
+                uiState = uiState.copy(isSavingNote = false)
             }
         }
     }
@@ -157,6 +166,7 @@ class FeedingViewModel(
     ) {
         val petId = uiState.pet?.id ?: return
         val timestamp = "${uiState.selectedDate}T${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}:00+09:00"
+        uiState = uiState.copy(isSavingTimestamp = true)
         viewModelScope.launch {
             try {
                 val feeding =
@@ -179,6 +189,8 @@ class FeedingViewModel(
                     )
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
+            } finally {
+                uiState = uiState.copy(isSavingTimestamp = false)
             }
         }
     }

--- a/feature/feeding/src/wasmJsMain/kotlin/feature/feeding/FeedingViewModel.kt
+++ b/feature/feeding/src/wasmJsMain/kotlin/feature/feeding/FeedingViewModel.kt
@@ -148,11 +148,16 @@ class FeedingViewModel(
 
     fun onSaveNote() {
         val petId = uiState.pet?.id ?: return
+        val date = uiState.selectedDate
+        val note = uiState.noteDraft
         uiState = uiState.copy(isSavingNote = true)
         viewModelScope.launch {
             try {
-                feedingRepository.updateNote(petId, uiState.selectedDate, uiState.noteDraft)
-                uiState = uiState.copy(log = uiState.log.copy(note = uiState.noteDraft))
+                feedingRepository.updateNote(petId, date, note)
+                // 保存 API 実行中に日送りされた場合、古い日付の結果を表示中ログへ混ぜない
+                if (uiState.selectedDate == date) {
+                    uiState = uiState.copy(log = uiState.log.copy(note = note))
+                }
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
             } finally {
@@ -175,28 +180,34 @@ class FeedingViewModel(
         minute: Int,
     ) {
         val petId = uiState.pet?.id ?: return
-        val timestamp = "${uiState.selectedDate}T${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}:00+09:00"
+        val date = uiState.selectedDate
+        val timestamp = "${date}T${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}:00+09:00"
         uiState = uiState.copy(isSavingTimestamp = true)
         viewModelScope.launch {
             try {
                 val feeding =
                     feedingRepository.updateFeedingTimestamp(
                         petId,
-                        uiState.selectedDate,
+                        date,
                         mealTime,
                         timestamp,
                     )
-                uiState =
-                    uiState.copy(
-                        editingMealTime = null,
-                        log =
-                            uiState.log.copy(
-                                feedings =
-                                    uiState.log.feedings
-                                        .toMutableMap()
-                                        .apply { put(mealTime, feeding) },
-                            ),
-                    )
+                // 保存 API 実行中に日送りされた場合、古い日付の結果を表示中ログへ混ぜない
+                if (uiState.selectedDate == date) {
+                    uiState =
+                        uiState.copy(
+                            editingMealTime = null,
+                            log =
+                                uiState.log.copy(
+                                    feedings =
+                                        uiState.log.feedings
+                                            .toMutableMap()
+                                            .apply { put(mealTime, feeding) },
+                                ),
+                        )
+                } else {
+                    uiState = uiState.copy(editingMealTime = null)
+                }
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
             } finally {

--- a/feature/feeding/src/wasmJsMain/kotlin/feature/feeding/FeedingViewModel.kt
+++ b/feature/feeding/src/wasmJsMain/kotlin/feature/feeding/FeedingViewModel.kt
@@ -116,20 +116,24 @@ class FeedingViewModel(
 
     fun onFeed(mealTime: MealTime) {
         val petId = uiState.pet?.id ?: return
+        val date = uiState.selectedDate
         uiState = uiState.copy(feedingInProgress = mealTime)
         viewModelScope.launch {
             try {
-                val feeding = feedingRepository.feed(petId, uiState.selectedDate, mealTime)
-                uiState =
-                    uiState.copy(
-                        log =
-                            uiState.log.copy(
-                                feedings =
-                                    uiState.log.feedings
-                                        .toMutableMap()
-                                        .apply { put(mealTime, feeding) },
-                            ),
-                    )
+                val feeding = feedingRepository.feed(petId, date, mealTime)
+                // 給餌 API 実行中に日送りされた場合、古い日付の結果を表示中ログへ混ぜない
+                if (uiState.selectedDate == date) {
+                    uiState =
+                        uiState.copy(
+                            log =
+                                uiState.log.copy(
+                                    feedings =
+                                        uiState.log.feedings
+                                            .toMutableMap()
+                                            .apply { put(mealTime, feeding) },
+                                ),
+                        )
+                }
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
             } finally {

--- a/feature/feeding/src/wasmJsMain/kotlin/feature/feeding/FeedingViewModel.kt
+++ b/feature/feeding/src/wasmJsMain/kotlin/feature/feeding/FeedingViewModel.kt
@@ -51,6 +51,7 @@ class FeedingViewModel(
         private set
 
     private var feedingSettingsJob: Job? = null
+    private var loadLogJob: Job? = null
 
     init {
         viewModelScope.launch {
@@ -95,17 +96,22 @@ class FeedingViewModel(
             }
     }
 
+    /** 日送り連打時は前のリクエストをキャンセルし、最後の操作の結果のみ反映する */
     fun onLoadLog(date: String) {
         val petId = uiState.pet?.id ?: return
         uiState = uiState.copy(selectedDate = date, isLoading = true, error = null)
-        viewModelScope.launch {
-            try {
-                val log = feedingRepository.getFeedingLog(petId, date)
-                uiState = uiState.copy(log = log, noteDraft = log.note, isLoading = false)
-            } catch (e: Exception) {
-                uiState = uiState.copy(error = e.message, isLoading = false)
+        loadLogJob?.cancel()
+        loadLogJob =
+            viewModelScope.launch {
+                try {
+                    val log = feedingRepository.getFeedingLog(petId, date)
+                    uiState = uiState.copy(log = log, noteDraft = log.note, isLoading = false)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    uiState = uiState.copy(error = e.message, isLoading = false)
+                }
             }
-        }
     }
 
     fun onFeed(mealTime: MealTime) {

--- a/feature/feeding/src/wasmJsMain/kotlin/feature/feeding/FeedingViewModel.kt
+++ b/feature/feeding/src/wasmJsMain/kotlin/feature/feeding/FeedingViewModel.kt
@@ -192,7 +192,8 @@ class FeedingViewModel(
                         mealTime,
                         timestamp,
                     )
-                // 保存 API 実行中に日送りされた場合、古い日付の結果を表示中ログへ混ぜない
+                // 保存 API 実行中に日送りされた場合、古い日付の結果を表示中ログへ混ぜない。
+                // editingMealTime も同様に、日送り後は別の日で開いた編集フォームを誤って閉じないよう触れない。
                 if (uiState.selectedDate == date) {
                     uiState =
                         uiState.copy(
@@ -205,8 +206,6 @@ class FeedingViewModel(
                                             .apply { put(mealTime, feeding) },
                                 ),
                         )
-                } else {
-                    uiState = uiState.copy(editingMealTime = null)
                 }
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)

--- a/feature/money/src/commonMain/kotlin/feature/money/MoneyContent.kt
+++ b/feature/money/src/commonMain/kotlin/feature/money/MoneyContent.kt
@@ -29,6 +29,10 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import core.ui.WindowSizeClass
+import core.ui.components.AppButton
+import core.ui.components.AppIconButton
+import core.ui.components.AppOutlinedButton
+import core.ui.components.AppTextButton
 import core.ui.components.CalendarView
 import core.ui.extensions.displayName
 import core.ui.extensions.icon
@@ -144,7 +148,7 @@ internal fun MoneyContent(
 
                     // 追加ボタン + インポートボタン
                     if (!loading && error == null) {
-                        Button(
+                        AppButton(
                             onClick = {
                                 onClearForm()
                                 showFormCompact = true
@@ -158,7 +162,7 @@ internal fun MoneyContent(
                         }
                         if (!frozen) {
                             Spacer(modifier = Modifier.height(4.dp))
-                            OutlinedButton(
+                            AppOutlinedButton(
                                 onClick = onImportRecurringItems,
                                 modifier = Modifier.fillMaxWidth(),
                                 enabled = !saving,
@@ -215,7 +219,7 @@ internal fun MoneyContent(
                         enabled = !statusSaving,
                     )
                     if (!frozen && !loading && error == null) {
-                        OutlinedButton(
+                        AppOutlinedButton(
                             onClick = onImportRecurringItems,
                             enabled = !saving,
                         ) {
@@ -473,7 +477,7 @@ private fun MoneyItemForm(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    OutlinedButton(
+                    AppOutlinedButton(
                         onClick = { showCalendar = !showCalendar },
                         enabled = !saving,
                     ) {
@@ -486,7 +490,7 @@ private fun MoneyItemForm(
                         Text(dueDate.ifBlank { "日付を選択" })
                     }
                     if (dueDate.isNotBlank()) {
-                        TextButton(onClick = {
+                        AppTextButton(onClick = {
                             dueDate = ""
                             showCalendar = false
                         }, enabled = !saving) {
@@ -534,7 +538,7 @@ private fun MoneyItemForm(
                             suffix = { Text("円") },
                             enabled = !saving,
                         )
-                        OutlinedButton(
+                        AppOutlinedButton(
                             onClick = {
                                 shareAmounts =
                                     shareAmounts.toMutableMap().apply {
@@ -546,7 +550,7 @@ private fun MoneyItemForm(
                         ) {
                             Text("半額", style = MaterialTheme.typography.labelSmall)
                         }
-                        OutlinedButton(
+                        AppOutlinedButton(
                             onClick = {
                                 shareAmounts =
                                     shareAmounts.toMutableMap().apply {
@@ -558,7 +562,7 @@ private fun MoneyItemForm(
                         ) {
                             Text("全額", style = MaterialTheme.typography.labelSmall)
                         }
-                        OutlinedButton(
+                        AppOutlinedButton(
                             onClick = {
                                 val othersTotal =
                                     shareAmounts
@@ -622,11 +626,11 @@ private fun MoneyItemForm(
                 horizontalArrangement = Arrangement.End,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                TextButton(onClick = onCancel, enabled = !saving) {
+                AppTextButton(onClick = onCancel, enabled = !saving) {
                     Text("キャンセル")
                 }
                 Spacer(modifier = Modifier.width(8.dp))
-                Button(
+                AppButton(
                     onClick = { onSave(name, amount, note, dueDate.ifBlank { null }, shares, selectedTags) },
                     enabled = name.isNotBlank() && isAmountValid && !saving && !frozen,
                 ) {
@@ -650,14 +654,14 @@ private fun MonthSelector(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        IconButton(onClick = onPrevious) {
+        AppIconButton(onClick = onPrevious, debounceMillis = 0) {
             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "前月")
         }
         Text(
             text = displayText,
             style = MaterialTheme.typography.titleLarge,
         )
-        IconButton(onClick = onNext) {
+        AppIconButton(onClick = onNext, debounceMillis = 0) {
             Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = "翌月")
         }
     }
@@ -884,28 +888,28 @@ private fun MoneyItemCard(
 
                 Row {
                     if (!frozen) {
-                        IconButton(onClick = onMovePrev) {
+                        AppIconButton(onClick = onMovePrev) {
                             Icon(
                                 Icons.AutoMirrored.Filled.ArrowBack,
                                 contentDescription = "前月へ移動",
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         }
-                        IconButton(onClick = onMoveNext) {
+                        AppIconButton(onClick = onMoveNext) {
                             Icon(
                                 Icons.AutoMirrored.Filled.ArrowForward,
                                 contentDescription = "次月へ移動",
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         }
-                        IconButton(onClick = onEdit) {
+                        AppIconButton(onClick = onEdit) {
                             Icon(
                                 Icons.Default.Edit,
                                 contentDescription = "編集",
                                 tint = MaterialTheme.colorScheme.primary,
                             )
                         }
-                        IconButton(onClick = onDelete) {
+                        AppIconButton(onClick = onDelete) {
                             Icon(
                                 Icons.Default.Delete,
                                 contentDescription = "削除",

--- a/feature/money/src/commonMain/kotlin/feature/money/MoneyContent.kt
+++ b/feature/money/src/commonMain/kotlin/feature/money/MoneyContent.kt
@@ -176,6 +176,7 @@ internal fun MoneyContent(
                     MoneyListContent(
                         monthlyMoney = monthlyMoney,
                         loading = loading,
+                        saving = saving,
                         error = error,
                         users = users,
                         isCompact = true,
@@ -234,6 +235,7 @@ internal fun MoneyContent(
                     MoneyListContent(
                         monthlyMoney = monthlyMoney,
                         loading = loading,
+                        saving = saving,
                         error = error,
                         users = users,
                         isCompact = false,
@@ -271,6 +273,7 @@ internal fun MoneyContent(
 private fun MoneyListContent(
     monthlyMoney: MonthlyMoney,
     loading: Boolean,
+    saving: Boolean,
     error: String?,
     users: List<User>,
     isCompact: Boolean,
@@ -347,6 +350,7 @@ private fun MoneyListContent(
                             onMoveNext = { onMoveItem(item, 1) },
                             isCompact = isCompact,
                             frozen = frozen,
+                            saving = saving,
                         )
                     }
                 }
@@ -836,6 +840,7 @@ private fun MoneyItemCard(
     onMoveNext: () -> Unit,
     isCompact: Boolean,
     frozen: Boolean,
+    saving: Boolean,
 ) {
     val shareTotal = item.shares.sumOf { it.amount }
     val mismatch = shareTotal != item.amount && item.shares.isNotEmpty()
@@ -888,28 +893,28 @@ private fun MoneyItemCard(
 
                 Row {
                     if (!frozen) {
-                        AppIconButton(onClick = onMovePrev) {
+                        AppIconButton(onClick = onMovePrev, enabled = !saving) {
                             Icon(
                                 Icons.AutoMirrored.Filled.ArrowBack,
                                 contentDescription = "前月へ移動",
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         }
-                        AppIconButton(onClick = onMoveNext) {
+                        AppIconButton(onClick = onMoveNext, enabled = !saving) {
                             Icon(
                                 Icons.AutoMirrored.Filled.ArrowForward,
                                 contentDescription = "次月へ移動",
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         }
-                        AppIconButton(onClick = onEdit) {
+                        AppIconButton(onClick = onEdit, enabled = !saving) {
                             Icon(
                                 Icons.Default.Edit,
                                 contentDescription = "編集",
                                 tint = MaterialTheme.colorScheme.primary,
                             )
                         }
-                        AppIconButton(onClick = onDelete) {
+                        AppIconButton(onClick = onDelete, enabled = !saving) {
                             Icon(
                                 Icons.Default.Delete,
                                 contentDescription = "削除",

--- a/feature/money/src/commonMain/kotlin/feature/money/MoneyContent.kt
+++ b/feature/money/src/commonMain/kotlin/feature/money/MoneyContent.kt
@@ -137,6 +137,7 @@ internal fun MoneyContent(
                         yearMonth = currentYearMonth,
                         onPrevious = onPreviousMonth,
                         onNext = onNextMonth,
+                        enabled = !saving,
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     MonthStatusSelector(
@@ -213,6 +214,7 @@ internal fun MoneyContent(
                         yearMonth = currentYearMonth,
                         onPrevious = onPreviousMonth,
                         onNext = onNextMonth,
+                        enabled = !saving,
                     )
                     MonthStatusSelector(
                         status = status,
@@ -650,6 +652,7 @@ private fun MonthSelector(
     yearMonth: String,
     onPrevious: () -> Unit,
     onNext: () -> Unit,
+    enabled: Boolean = true,
 ) {
     val parts = yearMonth.split("-")
     val displayText = "${parts[0]}年${parts[1].toInt()}月"
@@ -658,14 +661,14 @@ private fun MonthSelector(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        AppIconButton(onClick = onPrevious, debounceMillis = 0) {
+        AppIconButton(onClick = onPrevious, enabled = enabled, debounceMillis = 0) {
             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "前月")
         }
         Text(
             text = displayText,
             style = MaterialTheme.typography.titleLarge,
         )
-        AppIconButton(onClick = onNext, debounceMillis = 0) {
+        AppIconButton(onClick = onNext, enabled = enabled, debounceMillis = 0) {
             Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = "翌月")
         }
     }

--- a/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyViewModel.kt
+++ b/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyViewModel.kt
@@ -139,11 +139,15 @@ class MoneyViewModel(
 
     fun onUpdateStatus(status: MonthlyMoneyStatus) {
         if (uiState.monthlyMoney.status == status || uiState.isStatusSaving) return
+        val yearMonth = uiState.currentYearMonth
         uiState = uiState.copy(isStatusSaving = true)
         viewModelScope.launch {
             try {
-                val updated = moneyRepository.updateStatus(uiState.currentYearMonth, status)
-                uiState = uiState.copy(monthlyMoney = updated)
+                val updated = moneyRepository.updateStatus(yearMonth, status)
+                // 保存中に月送りされていた場合、古い月のデータで現在の表示を上書きしない
+                if (uiState.currentYearMonth == yearMonth) {
+                    uiState = uiState.copy(monthlyMoney = updated)
+                }
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
             } finally {
@@ -205,11 +209,15 @@ class MoneyViewModel(
     }
 
     fun onImportRecurringItems() {
+        val yearMonth = uiState.currentYearMonth
         uiState = uiState.copy(isSaving = true)
         viewModelScope.launch {
             try {
-                val updated = moneyRepository.importRecurringItems(uiState.currentYearMonth)
-                uiState = uiState.copy(monthlyMoney = updated)
+                val updated = moneyRepository.importRecurringItems(yearMonth)
+                // 保存中に月送りされていた場合、古い月のデータで現在の表示を上書きしない
+                if (uiState.currentYearMonth == yearMonth) {
+                    uiState = uiState.copy(monthlyMoney = updated)
+                }
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
             } finally {
@@ -218,12 +226,19 @@ class MoneyViewModel(
         }
     }
 
-    /** 項目を前月または次月に移動する（一時機能） */
+    /**
+     * 項目を前月または次月に移動する（一時機能）。
+     *
+     * [MonthSelector] は保存中（[MoneyUiState.isSaving]）は disable されるため月送り自体は起こらないが、
+     * 移動元・移動先の GET → SAVE という非冪等な多段処理の途中で他の要因により
+     * [MoneyUiState.currentYearMonth] が変わった場合に備え、書き込み前後でも一致を確認する。
+     */
     fun onMoveItem(
         item: MoneyItem,
         offset: Int,
     ) {
-        val targetYearMonth = shiftYearMonthJs(uiState.currentYearMonth.toJsString(), offset).toString()
+        val sourceYearMonth = uiState.currentYearMonth
+        val targetYearMonth = shiftYearMonthJs(sourceYearMonth.toJsString(), offset).toString()
         uiState = uiState.copy(isSaving = true)
         viewModelScope.launch {
             try {
@@ -231,14 +246,16 @@ class MoneyViewModel(
                 val targetData = moneyRepository.getMonthlyMoney(targetYearMonth)
                 val updatedTarget = targetData.copy(items = targetData.items + item)
                 moneyRepository.saveMonthlyMoney(targetYearMonth, updatedTarget.toSaveRequest())
-                // 現在の月から項目を削除
-                val updatedCurrent =
-                    uiState.monthlyMoney.copy(
-                        items = uiState.monthlyMoney.items.filter { it.id != item.id },
-                    )
-                moneyRepository.saveMonthlyMoney(uiState.currentYearMonth, updatedCurrent.toSaveRequest())
-                uiState = uiState.copy(monthlyMoney = updatedCurrent)
-                if (uiState.editingItem?.id == item.id) onClearForm()
+                // 現在の月から項目を削除（表示中の月が移動時から変わっていない場合のみ）
+                if (uiState.currentYearMonth == sourceYearMonth) {
+                    val updatedCurrent =
+                        uiState.monthlyMoney.copy(
+                            items = uiState.monthlyMoney.items.filter { it.id != item.id },
+                        )
+                    moneyRepository.saveMonthlyMoney(sourceYearMonth, updatedCurrent.toSaveRequest())
+                    uiState = uiState.copy(monthlyMoney = updatedCurrent)
+                    if (uiState.editingItem?.id == item.id) onClearForm()
+                }
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
             } finally {
@@ -251,12 +268,16 @@ class MoneyViewModel(
         data: MonthlyMoney,
         onSuccess: () -> Unit,
     ) {
+        val yearMonth = uiState.currentYearMonth
         uiState = uiState.copy(isSaving = true)
         viewModelScope.launch {
             try {
-                moneyRepository.saveMonthlyMoney(uiState.currentYearMonth, data.toSaveRequest())
-                uiState = uiState.copy(monthlyMoney = data)
-                onSuccess()
+                moneyRepository.saveMonthlyMoney(yearMonth, data.toSaveRequest())
+                // 保存中に月送りされていた場合、古い月のデータで現在の表示を上書きしない
+                if (uiState.currentYearMonth == yearMonth) {
+                    uiState = uiState.copy(monthlyMoney = data)
+                    onSuccess()
+                }
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
             } finally {

--- a/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyViewModel.kt
+++ b/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyViewModel.kt
@@ -99,7 +99,12 @@ class MoneyViewModel(
                     uiState = uiState.copy(users = users)
                 }
             } catch (e: Exception) {
-                uiState = uiState.copy(users = users, error = e.message, isLoading = false)
+                // 成功パスと同様、初回読み込み中に月送りされた場合は古い月のエラーで上書きしない
+                if (uiState.currentYearMonth == yearMonth) {
+                    uiState = uiState.copy(users = users, error = e.message, isLoading = false)
+                } else {
+                    uiState = uiState.copy(users = users)
+                }
             }
         }
     }

--- a/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyViewModel.kt
+++ b/feature/money/src/wasmJsMain/kotlin/feature/money/MoneyViewModel.kt
@@ -10,6 +10,8 @@ import androidx.lifecycle.viewModelScope
 import core.auth.toJsString
 import core.network.MoneyRepository
 import core.network.UserRepository
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import model.MoneyItem
 import model.MonthlyMoney
@@ -76,6 +78,8 @@ class MoneyViewModel(
         loadInitialData()
     }
 
+    private var loadJob: Job? = null
+
     /** 初回読み込み: ユーザー一覧と月次データを1つの coroutine で取得し、state を一度に更新 */
     private fun loadInitialData() {
         viewModelScope.launch {
@@ -85,33 +89,39 @@ class MoneyViewModel(
                 } catch (_: Exception) {
                     emptyList()
                 }
+            val yearMonth = uiState.currentYearMonth
             try {
-                val monthly = moneyRepository.getMonthlyMoney(uiState.currentYearMonth)
-                uiState =
-                    uiState.copy(
-                        users = users,
-                        monthlyMoney = monthly,
-                        isLoading = false,
-                    )
+                val monthly = moneyRepository.getMonthlyMoney(yearMonth)
+                // 初回読み込み中に月送りされた場合は、古い月次データで上書きしない
+                if (uiState.currentYearMonth == yearMonth) {
+                    uiState = uiState.copy(users = users, monthlyMoney = monthly, isLoading = false)
+                } else {
+                    uiState = uiState.copy(users = users)
+                }
             } catch (e: Exception) {
                 uiState = uiState.copy(users = users, error = e.message, isLoading = false)
             }
         }
     }
 
+    /** 月送り連打時は前のリクエストをキャンセルし、最後の操作の結果のみ反映する */
     fun onLoadYearMonth(yearMonth: String) {
         uiState = uiState.copy(currentYearMonth = yearMonth, isLoading = true, error = null)
-        viewModelScope.launch {
-            try {
-                uiState =
-                    uiState.copy(
-                        monthlyMoney = moneyRepository.getMonthlyMoney(yearMonth),
-                        isLoading = false,
-                    )
-            } catch (e: Exception) {
-                uiState = uiState.copy(error = e.message, isLoading = false)
+        loadJob?.cancel()
+        loadJob =
+            viewModelScope.launch {
+                try {
+                    uiState =
+                        uiState.copy(
+                            monthlyMoney = moneyRepository.getMonthlyMoney(yearMonth),
+                            isLoading = false,
+                        )
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    uiState = uiState.copy(error = e.message, isLoading = false)
+                }
             }
-        }
     }
 
     fun onGoToPreviousMonth() {

--- a/feature/payment/src/commonMain/kotlin/feature/payment/PaymentContent.kt
+++ b/feature/payment/src/commonMain/kotlin/feature/payment/PaymentContent.kt
@@ -94,6 +94,7 @@ internal fun PaymentContent(
                     yearMonth = currentYearMonth,
                     onPrevious = onPreviousMonth,
                     onNext = onNextMonth,
+                    enabled = !saving && deletingPaymentId == null,
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 PaymentListContent(
@@ -151,6 +152,7 @@ internal fun PaymentContent(
                     yearMonth = currentYearMonth,
                     onPrevious = onPreviousMonth,
                     onNext = onNextMonth,
+                    enabled = !saving && deletingPaymentId == null,
                 )
                 Spacer(modifier = Modifier.height(16.dp))
                 Row(
@@ -425,6 +427,7 @@ private fun MonthSelector(
     yearMonth: String,
     onPrevious: () -> Unit,
     onNext: () -> Unit,
+    enabled: Boolean = true,
 ) {
     val parts = yearMonth.split("-")
     val displayText = "${parts[0]}年${parts[1].toInt()}月"
@@ -433,14 +436,14 @@ private fun MonthSelector(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        AppIconButton(onClick = onPrevious, debounceMillis = 0) {
+        AppIconButton(onClick = onPrevious, enabled = enabled, debounceMillis = 0) {
             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "前月")
         }
         Text(
             text = displayText,
             style = MaterialTheme.typography.titleLarge,
         )
-        AppIconButton(onClick = onNext, debounceMillis = 0) {
+        AppIconButton(onClick = onNext, enabled = enabled, debounceMillis = 0) {
             Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = "翌月")
         }
     }

--- a/feature/payment/src/commonMain/kotlin/feature/payment/PaymentContent.kt
+++ b/feature/payment/src/commonMain/kotlin/feature/payment/PaymentContent.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import core.ui.WindowSizeClass
+import core.ui.components.AppButton
+import core.ui.components.AppIconButton
 import core.ui.extensions.displayName
 import core.ui.extensions.icon
 import core.ui.formatYen
@@ -364,7 +366,7 @@ private fun PaymentInlineForm(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.End,
             ) {
-                Button(
+                AppButton(
                     onClick = { onConfirmPay(amount) },
                     enabled = amount > 0 && inputEnabled,
                 ) {
@@ -431,14 +433,14 @@ private fun MonthSelector(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        IconButton(onClick = onPrevious) {
+        AppIconButton(onClick = onPrevious, debounceMillis = 0) {
             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "前月")
         }
         Text(
             text = displayText,
             style = MaterialTheme.typography.titleLarge,
         )
-        IconButton(onClick = onNext) {
+        AppIconButton(onClick = onNext, debounceMillis = 0) {
             Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = "翌月")
         }
     }
@@ -592,7 +594,7 @@ private fun PaymentCard(
                         color = MaterialTheme.colorScheme.error,
                     )
                 } else if (onDelete != null) {
-                    IconButton(onClick = onDelete, modifier = Modifier.size(32.dp)) {
+                    AppIconButton(onClick = onDelete, modifier = Modifier.size(32.dp)) {
                         Icon(
                             imageVector = Icons.Default.Delete,
                             contentDescription = "支払いを取り消す",

--- a/feature/payment/src/wasmJsMain/kotlin/feature/payment/PaymentViewModel.kt
+++ b/feature/payment/src/wasmJsMain/kotlin/feature/payment/PaymentViewModel.kt
@@ -11,6 +11,8 @@ import core.auth.AuthStateHolder
 import core.auth.toJsString
 import core.network.MoneyRepository
 import core.network.UserRepository
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import model.MonthlyMoney
 import model.PayRequest
@@ -75,6 +77,8 @@ class PaymentViewModel(
     )
         private set
 
+    private var loadJob: Job? = null
+
     init {
         loadInitialData()
     }
@@ -92,18 +96,24 @@ class PaymentViewModel(
                     emptyList()
                 }
             uiState = uiState.copy(users = users)
-            loadYearMonth(uiState.currentYearMonth)
+            startLoadYearMonth(uiState.currentYearMonth)
         }
     }
 
     fun onLoadYearMonth(yearMonth: String) {
         uiState = uiState.copy(currentYearMonth = yearMonth, isLoading = true, error = null)
-        viewModelScope.launch { loadYearMonth(yearMonth) }
+        startLoadYearMonth(yearMonth)
     }
 
     fun onSwitchUser(uid: String) {
         uiState = uiState.copy(viewingUid = uid, isLoading = true, error = null)
-        viewModelScope.launch { loadYearMonth(uiState.currentYearMonth) }
+        startLoadYearMonth(uiState.currentYearMonth)
+    }
+
+    /** 月送り・ユーザー切替の連打時は前のリクエストをキャンセルし、最後の操作の結果のみ反映する */
+    private fun startLoadYearMonth(yearMonth: String) {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch { loadYearMonth(yearMonth) }
     }
 
     private suspend fun loadYearMonth(yearMonth: String) {
@@ -119,6 +129,8 @@ class PaymentViewModel(
                     moneyRepository.getMyMonthlyMoney(yearMonth)
                 }
             uiState = uiState.copy(monthlyMoney = monthly, isLoading = false)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             uiState = uiState.copy(error = e.message, isLoading = false)
         }

--- a/feature/payment/src/wasmJsMain/kotlin/feature/payment/PaymentViewModel.kt
+++ b/feature/payment/src/wasmJsMain/kotlin/feature/payment/PaymentViewModel.kt
@@ -145,14 +145,16 @@ class PaymentViewModel(
     }
 
     fun onRecordPayment(amount: Long) {
+        val yearMonth = uiState.currentYearMonth
         uiState = uiState.copy(isSaving = true)
         viewModelScope.launch {
             try {
                 val request = PayRequest(amount = amount)
-                uiState =
-                    uiState.copy(
-                        monthlyMoney = moneyRepository.recordPayment(uiState.currentYearMonth, request),
-                    )
+                val monthly = moneyRepository.recordPayment(yearMonth, request)
+                // 保存中に月送りされていた場合、古い月のデータで現在の表示を上書きしない
+                if (uiState.currentYearMonth == yearMonth) {
+                    uiState = uiState.copy(monthlyMoney = monthly)
+                }
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
             } finally {
@@ -162,15 +164,17 @@ class PaymentViewModel(
     }
 
     fun onDeletePayment(paymentId: String) {
+        val yearMonth = uiState.currentYearMonth
         uiState = uiState.copy(deletingPaymentId = paymentId)
         viewModelScope.launch {
             try {
                 // サーバーは filterForUser 済みのデータを返す（onRecordPayment と同じパターン）。
                 // 他ユーザー閲覧中には削除ボタン自体が非表示なので isViewingOther の再フィルタは不要。
-                uiState =
-                    uiState.copy(
-                        monthlyMoney = moneyRepository.deletePayment(uiState.currentYearMonth, paymentId),
-                    )
+                val monthly = moneyRepository.deletePayment(yearMonth, paymentId)
+                // 保存中に月送りされていた場合、古い月のデータで現在の表示を上書きしない
+                if (uiState.currentYearMonth == yearMonth) {
+                    uiState = uiState.copy(monthlyMoney = monthly)
+                }
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
             } finally {

--- a/feature/quest/src/commonMain/kotlin/feature/quest/QuestContent.kt
+++ b/feature/quest/src/commonMain/kotlin/feature/quest/QuestContent.kt
@@ -480,8 +480,9 @@ private fun RewardsTab(
         rewards.forEach { reward ->
             RewardCard(
                 reward = reward,
-                canExchange = (myPoints?.balance ?: 0) >= reward.cost && reward.isAvailable && actionsEnabled,
-                canDelete = (reward.creatorUid == currentUserUid || isAdmin) && actionsEnabled,
+                canExchange = (myPoints?.balance ?: 0) >= reward.cost && reward.isAvailable,
+                canDelete = reward.creatorUid == currentUserUid || isAdmin,
+                actionsEnabled = actionsEnabled,
                 onExchange = { onExchange(reward.id) },
                 onDelete = { onDeleteReward(reward.id) },
             )
@@ -494,6 +495,7 @@ private fun RewardCard(
     reward: Reward,
     canExchange: Boolean,
     canDelete: Boolean,
+    actionsEnabled: Boolean,
     onExchange: () -> Unit,
     onDelete: () -> Unit,
 ) {
@@ -533,12 +535,12 @@ private fun RewardCard(
             Row {
                 AppButton(
                     onClick = onExchange,
-                    enabled = canExchange,
+                    enabled = canExchange && actionsEnabled,
                 ) {
                     Text("交換")
                 }
                 if (canDelete) {
-                    AppIconButton(onClick = onDelete) {
+                    AppIconButton(onClick = onDelete, enabled = actionsEnabled) {
                         Icon(
                             Icons.Default.Delete,
                             contentDescription = "削除",

--- a/feature/quest/src/commonMain/kotlin/feature/quest/QuestContent.kt
+++ b/feature/quest/src/commonMain/kotlin/feature/quest/QuestContent.kt
@@ -20,15 +20,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -41,6 +38,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import core.ui.WindowSizeClass
+import core.ui.components.AppButton
+import core.ui.components.AppIconButton
+import core.ui.components.AppOutlinedButton
 import feature.quest.components.CreateQuestForm
 import feature.quest.components.QuestCard
 import model.PointHistory
@@ -231,7 +231,7 @@ private fun BoardTab(
                 )
                 Spacer(Modifier.height(16.dp))
             } else {
-                Button(
+                AppButton(
                     onClick = { showForm = true },
                     enabled = canCreateQuest,
                     modifier = Modifier.padding(bottom = 12.dp),
@@ -423,7 +423,7 @@ private fun RewardsTab(
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         if (!isCreatingReward) {
-            Button(
+            AppButton(
                 onClick = onToggleCreateReward,
                 modifier = Modifier.padding(bottom = 12.dp),
             ) {
@@ -510,14 +510,14 @@ private fun RewardCard(
                 )
             }
             Row {
-                Button(
+                AppButton(
                     onClick = onExchange,
                     enabled = canExchange,
                 ) {
                     Text("交換")
                 }
                 if (canDelete) {
-                    IconButton(onClick = onDelete) {
+                    AppIconButton(onClick = onDelete) {
                         Icon(
                             Icons.Default.Delete,
                             contentDescription = "削除",
@@ -579,8 +579,8 @@ private fun CreateRewardForm(
             )
             Spacer(Modifier.height(12.dp))
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedButton(onClick = onCancel) { Text("キャンセル") }
-                Button(
+                AppOutlinedButton(onClick = onCancel) { Text("キャンセル") }
+                AppButton(
                     onClick = { onSubmit(name, description, costText.toIntOrNull() ?: 0) },
                     enabled = name.isNotBlank() && (costText.toIntOrNull() ?: 0) > 0,
                 ) {

--- a/feature/quest/src/commonMain/kotlin/feature/quest/QuestContent.kt
+++ b/feature/quest/src/commonMain/kotlin/feature/quest/QuestContent.kt
@@ -79,6 +79,10 @@ internal fun QuestBoardContent(
     onDeleteReward: (String) -> Unit,
     onDismissError: () -> Unit,
     windowSizeClass: WindowSizeClass = WindowSizeClass.Expanded,
+    isSubmittingQuest: Boolean = false,
+    isSubmittingReward: Boolean = false,
+    isQuestActionInProgress: Boolean = false,
+    isRewardActionInProgress: Boolean = false,
 ) {
     val isCompact = windowSizeClass == WindowSizeClass.Compact
 
@@ -156,6 +160,8 @@ internal fun QuestBoardContent(
                     canCreateQuest = canCreateQuest,
                     isAiAvailable = isAiAvailable,
                     isGenerating = isGenerating,
+                    isSubmittingQuest = isSubmittingQuest,
+                    actionsEnabled = !isQuestActionInProgress,
                     currentUserUid = currentUserUid,
                     onCreateQuest = onCreateQuest,
                     onGenerateText = onGenerateText,
@@ -174,6 +180,8 @@ internal fun QuestBoardContent(
                     currentUserUid = currentUserUid,
                     isAdmin = isAdmin,
                     isCreatingReward = isCreatingReward,
+                    isSubmittingReward = isSubmittingReward,
+                    actionsEnabled = !isRewardActionInProgress,
                     onExchange = onExchangeReward,
                     onToggleCreateReward = onToggleCreateReward,
                     onCreateReward = onCreateReward,
@@ -198,6 +206,8 @@ private fun BoardTab(
     canCreateQuest: Boolean,
     isAiAvailable: Boolean,
     isGenerating: Boolean,
+    isSubmittingQuest: Boolean,
+    actionsEnabled: Boolean,
     currentUserUid: String,
     onCreateQuest: (String, String, QuestCategory, Int, String?) -> Unit,
     onGenerateText: (String, String, QuestCategory, Int, String?, onResult: (String, String) -> Unit, onError: (String) -> Unit) -> Unit,
@@ -225,6 +235,7 @@ private fun BoardTab(
                     onCancel = { showForm = false },
                     showCloseButton = true,
                     enabled = canCreateQuest,
+                    isSubmitting = isSubmittingQuest,
                     isAiAvailable = isAiAvailable,
                     isGenerating = isGenerating,
                     onGenerateText = onGenerateText,
@@ -249,6 +260,7 @@ private fun BoardTab(
                 quests = quests,
                 isLoading = isLoading,
                 currentUserUid = currentUserUid,
+                actionsEnabled = actionsEnabled,
                 onAcceptQuest = onAcceptQuest,
                 onVerifyQuest = onVerifyQuest,
                 onDeleteQuest = onDeleteQuest,
@@ -262,6 +274,7 @@ private fun BoardTab(
                 quests = quests,
                 isLoading = isLoading,
                 currentUserUid = currentUserUid,
+                actionsEnabled = actionsEnabled,
                 onAcceptQuest = onAcceptQuest,
                 onVerifyQuest = onVerifyQuest,
                 onDeleteQuest = onDeleteQuest,
@@ -282,6 +295,7 @@ private fun BoardTab(
                     onCancel = {},
                     showCloseButton = false,
                     enabled = canCreateQuest,
+                    isSubmitting = isSubmittingQuest,
                     isAiAvailable = isAiAvailable,
                     isGenerating = isGenerating,
                     onGenerateText = onGenerateText,
@@ -296,6 +310,7 @@ private fun QuestListContent(
     quests: List<Quest>,
     isLoading: Boolean,
     currentUserUid: String,
+    actionsEnabled: Boolean,
     onAcceptQuest: (String) -> Unit,
     onVerifyQuest: (String) -> Unit,
     onDeleteQuest: (String) -> Unit,
@@ -337,6 +352,7 @@ private fun QuestListContent(
                         onVerify = { onVerifyQuest(quest.id) },
                         onDelete = { onDeleteQuest(quest.id) },
                         modifier = Modifier.widthIn(max = 600.dp),
+                        actionsEnabled = actionsEnabled,
                     )
                 }
             }
@@ -350,6 +366,7 @@ private fun QuestListInline(
     quests: List<Quest>,
     isLoading: Boolean,
     currentUserUid: String,
+    actionsEnabled: Boolean,
     onAcceptQuest: (String) -> Unit,
     onVerifyQuest: (String) -> Unit,
     onDeleteQuest: (String) -> Unit,
@@ -387,6 +404,7 @@ private fun QuestListInline(
                         onVerify = { onVerifyQuest(quest.id) },
                         onDelete = { onDeleteQuest(quest.id) },
                         modifier = Modifier.fillMaxWidth(),
+                        actionsEnabled = actionsEnabled,
                     )
                 }
             }
@@ -402,6 +420,8 @@ private fun RewardsTab(
     currentUserUid: String,
     isAdmin: Boolean,
     isCreatingReward: Boolean,
+    isSubmittingReward: Boolean,
+    actionsEnabled: Boolean,
     onExchange: (String) -> Unit,
     onToggleCreateReward: () -> Unit,
     onCreateReward: (String, String, Int) -> Unit,
@@ -440,6 +460,7 @@ private fun RewardsTab(
             CreateRewardForm(
                 onSubmit = onCreateReward,
                 onCancel = onToggleCreateReward,
+                isSubmitting = isSubmittingReward,
             )
         }
 
@@ -459,8 +480,8 @@ private fun RewardsTab(
         rewards.forEach { reward ->
             RewardCard(
                 reward = reward,
-                canExchange = (myPoints?.balance ?: 0) >= reward.cost && reward.isAvailable,
-                canDelete = reward.creatorUid == currentUserUid || isAdmin,
+                canExchange = (myPoints?.balance ?: 0) >= reward.cost && reward.isAvailable && actionsEnabled,
+                canDelete = (reward.creatorUid == currentUserUid || isAdmin) && actionsEnabled,
                 onExchange = { onExchange(reward.id) },
                 onDelete = { onDeleteReward(reward.id) },
             )
@@ -534,6 +555,7 @@ private fun RewardCard(
 private fun CreateRewardForm(
     onSubmit: (String, String, Int) -> Unit,
     onCancel: () -> Unit,
+    isSubmitting: Boolean = false,
 ) {
     var name by remember { mutableStateOf("") }
     var description by remember { mutableStateOf("") }
@@ -582,7 +604,7 @@ private fun CreateRewardForm(
                 AppOutlinedButton(onClick = onCancel) { Text("キャンセル") }
                 AppButton(
                     onClick = { onSubmit(name, description, costText.toIntOrNull() ?: 0) },
-                    enabled = name.isNotBlank() && (costText.toIntOrNull() ?: 0) > 0,
+                    enabled = name.isNotBlank() && (costText.toIntOrNull() ?: 0) > 0 && !isSubmitting,
                 ) {
                     Text("追加")
                 }

--- a/feature/quest/src/commonMain/kotlin/feature/quest/QuestViewModel.kt
+++ b/feature/quest/src/commonMain/kotlin/feature/quest/QuestViewModel.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.viewModelScope
 import core.network.PointRepository
 import core.network.QuestRepository
 import core.network.RewardRepository
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import model.CreateQuestRequest
 import model.CreateRewardRequest
@@ -54,6 +56,8 @@ class QuestViewModel(
     var uiState by mutableStateOf(QuestUiState())
         private set
 
+    private var loadJob: Job? = null
+
     init {
         loadQuests()
         loadPoints()
@@ -69,17 +73,21 @@ class QuestViewModel(
 
     fun loadQuests() {
         uiState = uiState.copy(isLoading = true, error = null)
-        viewModelScope.launch {
-            try {
-                val quests =
-                    questRepository
-                        .getQuests(null)
-                        .filter { it.status != QuestStatus.Verified }
-                uiState = uiState.copy(quests = quests, isLoading = false)
-            } catch (e: Exception) {
-                uiState = uiState.copy(error = e.message, isLoading = false)
+        loadJob?.cancel()
+        loadJob =
+            viewModelScope.launch {
+                try {
+                    val quests =
+                        questRepository
+                            .getQuests(null)
+                            .filter { it.status != QuestStatus.Verified }
+                    uiState = uiState.copy(quests = quests, isLoading = false)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    uiState = uiState.copy(error = e.message, isLoading = false)
+                }
             }
-        }
     }
 
     private fun loadPoints() {
@@ -105,26 +113,34 @@ class QuestViewModel(
 
     private fun loadRewards() {
         uiState = uiState.copy(isLoading = true)
-        viewModelScope.launch {
-            try {
-                val rewards = rewardRepository.getRewards()
-                uiState = uiState.copy(rewards = rewards, isLoading = false)
-            } catch (e: Exception) {
-                uiState = uiState.copy(error = e.message, isLoading = false)
+        loadJob?.cancel()
+        loadJob =
+            viewModelScope.launch {
+                try {
+                    val rewards = rewardRepository.getRewards()
+                    uiState = uiState.copy(rewards = rewards, isLoading = false)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    uiState = uiState.copy(error = e.message, isLoading = false)
+                }
             }
-        }
     }
 
     private fun loadHistory() {
         uiState = uiState.copy(isLoading = true)
-        viewModelScope.launch {
-            try {
-                val history = pointRepository.getHistory()
-                uiState = uiState.copy(history = history, isLoading = false)
-            } catch (e: Exception) {
-                uiState = uiState.copy(error = e.message, isLoading = false)
+        loadJob?.cancel()
+        loadJob =
+            viewModelScope.launch {
+                try {
+                    val history = pointRepository.getHistory()
+                    uiState = uiState.copy(history = history, isLoading = false)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    uiState = uiState.copy(error = e.message, isLoading = false)
+                }
             }
-        }
     }
 
     fun onToggleCreateForm() {

--- a/feature/quest/src/commonMain/kotlin/feature/quest/QuestViewModel.kt
+++ b/feature/quest/src/commonMain/kotlin/feature/quest/QuestViewModel.kt
@@ -211,7 +211,10 @@ class QuestViewModel(
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
             } finally {
-                uiState = uiState.copy(processingQuestId = null)
+                // 並行操作で他 ID のフラグを消さないよう、自分が立てたときだけ解除する
+                if (uiState.processingQuestId == id) {
+                    uiState = uiState.copy(processingQuestId = null)
+                }
             }
         }
     }
@@ -226,7 +229,10 @@ class QuestViewModel(
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
             } finally {
-                uiState = uiState.copy(processingQuestId = null)
+                // 並行操作で他 ID のフラグを消さないよう、自分が立てたときだけ解除する
+                if (uiState.processingQuestId == id) {
+                    uiState = uiState.copy(processingQuestId = null)
+                }
             }
         }
     }
@@ -240,7 +246,10 @@ class QuestViewModel(
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
             } finally {
-                uiState = uiState.copy(processingQuestId = null)
+                // 並行操作で他 ID のフラグを消さないよう、自分が立てたときだけ解除する
+                if (uiState.processingQuestId == id) {
+                    uiState = uiState.copy(processingQuestId = null)
+                }
             }
         }
     }
@@ -255,7 +264,10 @@ class QuestViewModel(
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
             } finally {
-                uiState = uiState.copy(processingRewardId = null)
+                // 並行操作で他 ID のフラグを消さないよう、自分が立てたときだけ解除する
+                if (uiState.processingRewardId == id) {
+                    uiState = uiState.copy(processingRewardId = null)
+                }
             }
         }
     }
@@ -295,7 +307,10 @@ class QuestViewModel(
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
             } finally {
-                uiState = uiState.copy(processingRewardId = null)
+                // 並行操作で他 ID のフラグを消さないよう、自分が立てたときだけ解除する
+                if (uiState.processingRewardId == id) {
+                    uiState = uiState.copy(processingRewardId = null)
+                }
             }
         }
     }

--- a/feature/quest/src/commonMain/kotlin/feature/quest/QuestViewModel.kt
+++ b/feature/quest/src/commonMain/kotlin/feature/quest/QuestViewModel.kt
@@ -36,6 +36,10 @@ data class QuestUiState(
     val isCreatingReward: Boolean = false,
     val isAiAvailable: Boolean = false,
     val isGenerating: Boolean = false,
+    val isSubmittingQuest: Boolean = false,
+    val isSubmittingReward: Boolean = false,
+    val processingQuestId: String? = null,
+    val processingRewardId: String? = null,
 ) {
     /** 同時発行上限（Open + Accepted が10件未満なら作成可能） */
     val canCreateQuest: Boolean
@@ -156,6 +160,7 @@ class QuestViewModel(
         rewardPoints: Int,
         deadline: String?,
     ) {
+        uiState = uiState.copy(isSubmittingQuest = true)
         viewModelScope.launch {
             try {
                 val quest =
@@ -175,22 +180,28 @@ class QuestViewModel(
                     )
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
+            } finally {
+                uiState = uiState.copy(isSubmittingQuest = false)
             }
         }
     }
 
     fun onAcceptQuest(id: String) {
+        uiState = uiState.copy(processingQuestId = id)
         viewModelScope.launch {
             try {
                 val updated = questRepository.acceptQuest(id)
                 uiState = uiState.copy(quests = uiState.quests.map { if (it.id == id) updated else it })
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
+            } finally {
+                uiState = uiState.copy(processingQuestId = null)
             }
         }
     }
 
     fun onVerifyQuest(id: String) {
+        uiState = uiState.copy(processingQuestId = id)
         viewModelScope.launch {
             try {
                 questRepository.verifyQuest(id)
@@ -198,22 +209,28 @@ class QuestViewModel(
                 loadPoints()
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
+            } finally {
+                uiState = uiState.copy(processingQuestId = null)
             }
         }
     }
 
     fun onDeleteQuest(id: String) {
+        uiState = uiState.copy(processingQuestId = id)
         viewModelScope.launch {
             try {
                 questRepository.deleteQuest(id)
                 uiState = uiState.copy(quests = uiState.quests.filter { it.id != id })
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
+            } finally {
+                uiState = uiState.copy(processingQuestId = null)
             }
         }
     }
 
     fun onExchangeReward(id: String) {
+        uiState = uiState.copy(processingRewardId = id)
         viewModelScope.launch {
             try {
                 rewardRepository.exchangeReward(id)
@@ -221,6 +238,8 @@ class QuestViewModel(
                 loadRewards()
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
+            } finally {
+                uiState = uiState.copy(processingRewardId = null)
             }
         }
     }
@@ -234,6 +253,7 @@ class QuestViewModel(
         description: String,
         cost: Int,
     ) {
+        uiState = uiState.copy(isSubmittingReward = true)
         viewModelScope.launch {
             try {
                 val reward = rewardRepository.createReward(CreateRewardRequest(name, description, cost))
@@ -244,17 +264,22 @@ class QuestViewModel(
                     )
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
+            } finally {
+                uiState = uiState.copy(isSubmittingReward = false)
             }
         }
     }
 
     fun onDeleteReward(id: String) {
+        uiState = uiState.copy(processingRewardId = id)
         viewModelScope.launch {
             try {
                 rewardRepository.deleteReward(id)
                 uiState = uiState.copy(rewards = uiState.rewards.filter { it.id != id })
             } catch (e: Exception) {
                 uiState = uiState.copy(error = e.message)
+            } finally {
+                uiState = uiState.copy(processingRewardId = null)
             }
         }
     }

--- a/feature/quest/src/commonMain/kotlin/feature/quest/components/CreateQuestForm.kt
+++ b/feature/quest/src/commonMain/kotlin/feature/quest/components/CreateQuestForm.kt
@@ -18,7 +18,6 @@ import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Schedule
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
@@ -26,12 +25,9 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -42,6 +38,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import core.ui.components.AppButton
+import core.ui.components.AppIconButton
+import core.ui.components.AppOutlinedButton
+import core.ui.components.AppTextButton
 import core.ui.components.CalendarView
 import core.ui.extensions.icon
 import core.ui.extensions.label
@@ -124,7 +124,7 @@ internal fun CreateQuestForm(
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 if (showCloseButton) {
-                    IconButton(onClick = onCancel) {
+                    AppIconButton(onClick = onCancel) {
                         Icon(Icons.Default.Close, contentDescription = "閉じる")
                     }
                 }
@@ -197,7 +197,7 @@ internal fun CreateQuestForm(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                OutlinedButton(
+                AppOutlinedButton(
                     onClick = { showCalendar = !showCalendar },
                 ) {
                     Icon(
@@ -210,7 +210,7 @@ internal fun CreateQuestForm(
                 }
 
                 if (deadlineDate.isNotBlank()) {
-                    TextButton(onClick = {
+                    AppTextButton(onClick = {
                         deadlineDate = ""
                         showCalendar = false
                         hasTime = false
@@ -312,7 +312,7 @@ internal fun CreateQuestForm(
                     )
                     Spacer(Modifier.height(4.dp))
                 }
-                Button(
+                AppButton(
                     onClick = {
                         aiError = null
                         onGenerateText(
@@ -373,7 +373,7 @@ internal fun CreateQuestForm(
                 Spacer(Modifier.height(4.dp))
             }
 
-            Button(
+            AppButton(
                 onClick = {
                     onSubmit(
                         title,

--- a/feature/quest/src/commonMain/kotlin/feature/quest/components/CreateQuestForm.kt
+++ b/feature/quest/src/commonMain/kotlin/feature/quest/components/CreateQuestForm.kt
@@ -73,6 +73,7 @@ internal fun CreateQuestForm(
     modifier: Modifier = Modifier,
     showCloseButton: Boolean = true,
     enabled: Boolean = true,
+    isSubmitting: Boolean = false,
 ) {
     var title by remember { mutableStateOf("") }
     var description by remember { mutableStateOf("") }
@@ -392,7 +393,7 @@ internal fun CreateQuestForm(
                     deadlineMinute = ""
                     aiError = null
                 },
-                enabled = isValid && enabled,
+                enabled = isValid && enabled && !isSubmitting,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text("クエストを投稿")

--- a/feature/quest/src/commonMain/kotlin/feature/quest/components/QuestCard.kt
+++ b/feature/quest/src/commonMain/kotlin/feature/quest/components/QuestCard.kt
@@ -46,6 +46,7 @@ internal fun QuestCard(
     onVerify: () -> Unit,
     onDelete: () -> Unit,
     modifier: Modifier = Modifier,
+    actionsEnabled: Boolean = true,
 ) {
     val isCreator = quest.creatorUid == currentUserUid
     val isAssignee = quest.assigneeUid == currentUserUid
@@ -95,7 +96,7 @@ internal fun QuestCard(
                     ) {
                         StatusBadge(status = quest.status)
                         if (isCreator && (quest.status == QuestStatus.Open || quest.status == QuestStatus.Expired)) {
-                            AppIconButton(onClick = onDelete) {
+                            AppIconButton(onClick = onDelete, enabled = actionsEnabled) {
                                 Icon(
                                     Icons.Default.Delete,
                                     contentDescription = "削除",
@@ -188,6 +189,7 @@ internal fun QuestCard(
                 QuestActionButton(
                     quest = quest,
                     isCreator = isCreator,
+                    enabled = actionsEnabled,
                     onAccept = onAccept,
                     onVerify = onVerify,
                 )
@@ -235,6 +237,7 @@ private fun StatusBadge(status: QuestStatus) {
 private fun QuestActionButton(
     quest: Quest,
     isCreator: Boolean,
+    enabled: Boolean,
     onAccept: () -> Unit,
     onVerify: () -> Unit,
 ) {
@@ -243,6 +246,7 @@ private fun QuestActionButton(
             if (!isCreator) {
                 AppButton(
                     onClick = onAccept,
+                    enabled = enabled,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text("受注する")
@@ -253,6 +257,7 @@ private fun QuestActionButton(
             if (isCreator) {
                 AppButton(
                     onClick = onVerify,
+                    enabled = enabled,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text("承認する")

--- a/feature/quest/src/commonMain/kotlin/feature/quest/components/QuestCard.kt
+++ b/feature/quest/src/commonMain/kotlin/feature/quest/components/QuestCard.kt
@@ -15,12 +15,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -32,6 +30,8 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import core.ui.components.AppButton
+import core.ui.components.AppIconButton
 import core.ui.extensions.icon
 import core.ui.extensions.label
 import core.ui.util.remainingTime
@@ -95,7 +95,7 @@ internal fun QuestCard(
                     ) {
                         StatusBadge(status = quest.status)
                         if (isCreator && (quest.status == QuestStatus.Open || quest.status == QuestStatus.Expired)) {
-                            IconButton(onClick = onDelete) {
+                            AppIconButton(onClick = onDelete) {
                                 Icon(
                                     Icons.Default.Delete,
                                     contentDescription = "削除",
@@ -241,7 +241,7 @@ private fun QuestActionButton(
     when (quest.status) {
         QuestStatus.Open -> {
             if (!isCreator) {
-                Button(
+                AppButton(
                     onClick = onAccept,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
@@ -251,7 +251,7 @@ private fun QuestActionButton(
         }
         QuestStatus.Accepted -> {
             if (isCreator) {
-                Button(
+                AppButton(
                     onClick = onVerify,
                     modifier = Modifier.fillMaxWidth(),
                 ) {

--- a/feature/quest/src/jvmTest/kotlin/feature/quest/QuestViewModelTest.kt
+++ b/feature/quest/src/jvmTest/kotlin/feature/quest/QuestViewModelTest.kt
@@ -432,6 +432,99 @@ class QuestViewModelTest {
             assertEquals("AI 生成に失敗しました: api error", errorMsg)
         }
 
+    // --- in-flight flags (連続クリック防止) ---
+
+    @Test
+    fun `onCreateQuest sets isSubmittingQuest while in flight`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            coEvery { questRepository.createQuest(any()) } returns Quest(id = "q9", title = "新規")
+
+            viewModel.onCreateQuest("新規", "説明", QuestCategory.Other, 5, null)
+            assertTrue(viewModel.uiState.isSubmittingQuest)
+
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.isSubmittingQuest)
+        }
+
+    @Test
+    fun `onCreateQuest clears isSubmittingQuest on failure`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            coEvery { questRepository.createQuest(any()) } throws RuntimeException("create error")
+
+            viewModel.onCreateQuest("新規", "説明", QuestCategory.Other, 5, null)
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.isSubmittingQuest)
+            assertEquals("create error", viewModel.uiState.error)
+        }
+
+    @Test
+    fun `onAcceptQuest sets processingQuestId while in flight`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            coEvery { questRepository.acceptQuest("q1") } returns testQuests[0].copy(status = QuestStatus.Accepted)
+
+            viewModel.onAcceptQuest("q1")
+            assertEquals("q1", viewModel.uiState.processingQuestId)
+
+            advanceUntilIdle()
+            assertNull(viewModel.uiState.processingQuestId)
+        }
+
+    @Test
+    fun `onVerifyQuest clears processingQuestId on failure`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            coEvery { questRepository.verifyQuest("q2") } throws RuntimeException("verify error")
+
+            viewModel.onVerifyQuest("q2")
+            advanceUntilIdle()
+
+            assertNull(viewModel.uiState.processingQuestId)
+            assertEquals("verify error", viewModel.uiState.error)
+        }
+
+    @Test
+    fun `onExchangeReward sets processingRewardId while in flight`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            coEvery { rewardRepository.exchangeReward("r1") } returns Unit
+            coEvery { rewardRepository.getRewards() } returns emptyList()
+
+            viewModel.onExchangeReward("r1")
+            assertEquals("r1", viewModel.uiState.processingRewardId)
+
+            advanceUntilIdle()
+            assertNull(viewModel.uiState.processingRewardId)
+        }
+
+    @Test
+    fun `onCreateReward sets isSubmittingReward while in flight`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            coEvery { rewardRepository.createReward(any()) } returns Reward(id = "r9", name = "新報酬", cost = 10)
+
+            viewModel.onCreateReward("新報酬", "", 10)
+            assertTrue(viewModel.uiState.isSubmittingReward)
+
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.isSubmittingReward)
+        }
+
     // --- error dismissal ---
 
     @Test

--- a/feature/quest/src/wasmJsMain/kotlin/feature/quest/QuestScreen.kt
+++ b/feature/quest/src/wasmJsMain/kotlin/feature/quest/QuestScreen.kt
@@ -41,5 +41,9 @@ fun QuestScreen(vm: QuestViewModel = koinViewModel()) {
         onDeleteReward = vm::onDeleteReward,
         onDismissError = vm::onDismissError,
         windowSizeClass = windowSizeClass,
+        isSubmittingQuest = vm.uiState.isSubmittingQuest,
+        isSubmittingReward = vm.uiState.isSubmittingReward,
+        isQuestActionInProgress = vm.uiState.processingQuestId != null,
+        isRewardActionInProgress = vm.uiState.processingRewardId != null,
     )
 }

--- a/feature/report/src/commonMain/kotlin/feature/report/OverpaymentContent.kt
+++ b/feature/report/src/commonMain/kotlin/feature/report/OverpaymentContent.kt
@@ -22,23 +22,23 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import core.ui.components.AppButton
+import core.ui.components.AppIconButton
+import core.ui.components.AppOutlinedButton
+import core.ui.components.AppTextButton
 import feature.report.components.UserBalanceCard
 import model.UserBalance
 
@@ -221,7 +221,7 @@ private fun RedemptionInlineCard(
                     enabled = inputEnabled && !frozen,
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 )
-                OutlinedButton(
+                AppOutlinedButton(
                     onClick = onFillRemaining,
                     enabled = inputEnabled && !frozen && form.selectedUid.isNotEmpty(),
                     contentPadding = PaddingValues(horizontal = 8.dp),
@@ -255,14 +255,14 @@ private fun RedemptionInlineCard(
                 horizontalArrangement = Arrangement.End,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                TextButton(
+                AppTextButton(
                     onClick = onClear,
                     enabled = inputEnabled,
                 ) {
                     Text("クリア")
                 }
                 Spacer(modifier = Modifier.width(8.dp))
-                Button(
+                AppButton(
                     onClick = onConfirm,
                     enabled = form.canSubmit,
                 ) {
@@ -287,14 +287,14 @@ private fun RedemptionMonthSelector(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        IconButton(onClick = onPrevious, enabled = enabled) {
+        AppIconButton(onClick = onPrevious, enabled = enabled, debounceMillis = 0) {
             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "前月")
         }
         Text(
             text = displayText,
             style = MaterialTheme.typography.titleMedium,
         )
-        IconButton(onClick = onNext, enabled = enabled) {
+        AppIconButton(onClick = onNext, enabled = enabled, debounceMillis = 0) {
             Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = "翌月")
         }
     }

--- a/feature/report/src/commonMain/kotlin/feature/report/ReportContent.kt
+++ b/feature/report/src/commonMain/kotlin/feature/report/ReportContent.kt
@@ -18,7 +18,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,6 +34,7 @@ import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.unit.dp
 import core.ui.WindowSizeClass
+import core.ui.components.AppIconButton
 import feature.report.components.CategoryBreakdown
 import feature.report.components.MonthlyBarChart
 import feature.report.components.ReportSummaryCard
@@ -198,14 +198,14 @@ private fun MonthSelector(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        IconButton(onClick = onPrevious) {
+        AppIconButton(onClick = onPrevious, debounceMillis = 0) {
             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "前月")
         }
         Text(
             text = displayText,
             style = MaterialTheme.typography.titleLarge,
         )
-        IconButton(onClick = onNext) {
+        AppIconButton(onClick = onNext, debounceMillis = 0) {
             Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = "翌月")
         }
     }

--- a/feature/report/src/commonMain/kotlin/feature/report/components/UserBalanceCard.kt
+++ b/feature/report/src/commonMain/kotlin/feature/report/components/UserBalanceCard.kt
@@ -15,13 +15,13 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import core.ui.components.AppIconButton
 import core.ui.formatYen
 import model.UserBalance
 
@@ -61,7 +61,7 @@ fun UserBalanceCard(
                     )
                 }
                 Spacer(modifier = Modifier.weight(1f))
-                IconButton(onClick = onRefresh) {
+                AppIconButton(onClick = onRefresh) {
                     Icon(
                         imageVector = Icons.Default.Refresh,
                         contentDescription = "更新",

--- a/feature/report/src/wasmJsMain/kotlin/feature/report/ReportViewModel.kt
+++ b/feature/report/src/wasmJsMain/kotlin/feature/report/ReportViewModel.kt
@@ -9,6 +9,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import core.auth.toJsString
 import core.network.ReportRepository
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import model.ExpenseReport
 import model.MonthlyExpenseSummary
@@ -71,20 +73,27 @@ class ReportViewModel(
     )
         private set
 
+    private var loadJob: Job? = null
+
     init {
         loadReport(uiState.selectedYearMonth)
     }
 
+    /** 月送り連打時は前のリクエストをキャンセルし、最後の操作の結果のみ反映する */
     private fun loadReport(center: String) {
-        viewModelScope.launch {
-            try {
-                uiState = uiState.copy(isLoading = true, error = null)
-                val report = reportRepository.getExpenseReport(center)
-                uiState = uiState.copy(report = report, isLoading = false)
-            } catch (e: Exception) {
-                uiState = uiState.copy(error = e.message, isLoading = false)
+        loadJob?.cancel()
+        loadJob =
+            viewModelScope.launch {
+                try {
+                    uiState = uiState.copy(isLoading = true, error = null)
+                    val report = reportRepository.getExpenseReport(center)
+                    uiState = uiState.copy(report = report, isLoading = false)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    uiState = uiState.copy(error = e.message, isLoading = false)
+                }
             }
-        }
     }
 
     fun onGoToPreviousMonth() {

--- a/feature/settings/src/commonMain/kotlin/feature/settings/AccountScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/AccountScreen.kt
@@ -13,12 +13,10 @@ import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -34,6 +32,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import core.ui.components.AppButton
+import core.ui.components.AppIconButton
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -146,7 +146,7 @@ private fun PasswordChangeCard(
                 label = { Text("現在のパスワード") },
                 leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) },
                 trailingIcon = {
-                    IconButton(onClick = { currentPasswordVisible = !currentPasswordVisible }) {
+                    AppIconButton(onClick = { currentPasswordVisible = !currentPasswordVisible }, debounceMillis = 0) {
                         Icon(
                             if (currentPasswordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
                             contentDescription = if (currentPasswordVisible) "パスワードを隠す" else "パスワードを表示",
@@ -166,7 +166,7 @@ private fun PasswordChangeCard(
                 label = { Text("新しいパスワード") },
                 leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) },
                 trailingIcon = {
-                    IconButton(onClick = { newPasswordVisible = !newPasswordVisible }) {
+                    AppIconButton(onClick = { newPasswordVisible = !newPasswordVisible }, debounceMillis = 0) {
                         Icon(
                             if (newPasswordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
                             contentDescription = if (newPasswordVisible) "パスワードを隠す" else "パスワードを表示",
@@ -186,7 +186,7 @@ private fun PasswordChangeCard(
                 label = { Text("新しいパスワード（確認）") },
                 leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) },
                 trailingIcon = {
-                    IconButton(onClick = { confirmPasswordVisible = !confirmPasswordVisible }) {
+                    AppIconButton(onClick = { confirmPasswordVisible = !confirmPasswordVisible }, debounceMillis = 0) {
                         Icon(
                             if (confirmPasswordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
                             contentDescription = if (confirmPasswordVisible) "パスワードを隠す" else "パスワードを表示",
@@ -208,7 +208,7 @@ private fun PasswordChangeCard(
                 Text(text = successMessage, color = MaterialTheme.colorScheme.primary, style = MaterialTheme.typography.bodySmall)
             }
 
-            Button(
+            AppButton(
                 onClick = onChangePassword,
                 modifier = Modifier.height(48.dp),
                 enabled = !isLoading,
@@ -272,7 +272,7 @@ private fun PasskeyManagementCard(
                 Text(text = successMessage, color = MaterialTheme.colorScheme.primary, style = MaterialTheme.typography.bodySmall)
             }
 
-            Button(
+            AppButton(
                 onClick = onRegisterPasskey,
                 modifier = Modifier.height(48.dp),
                 enabled = !isRegistering,

--- a/feature/settings/src/commonMain/kotlin/feature/settings/CacheScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/CacheScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -15,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import core.ui.components.AppButton
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -73,7 +73,7 @@ private fun CacheRefreshCard(
                 )
             }
 
-            Button(
+            AppButton(
                 onClick = onClearCache,
                 modifier = Modifier.height(48.dp),
                 enabled = !isClearing,

--- a/feature/settings/src/commonMain/kotlin/feature/settings/CreditsCard.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/CreditsCard.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -25,6 +24,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import com.mikepenz.aboutlibraries.entity.Library
+import core.ui.components.AppButton
 import core.ui.util.ExternalUrlLinkInteractionListener
 
 @Composable
@@ -122,7 +122,7 @@ internal fun CreditsCard(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.error,
                     )
-                    Button(
+                    AppButton(
                         onClick = onRetry,
                         modifier = Modifier.align(Alignment.CenterHorizontally),
                     ) {

--- a/feature/settings/src/commonMain/kotlin/feature/settings/GarbageScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/GarbageScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -30,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import core.ui.components.AppButton
 import core.ui.components.LoadableCardContent
 import core.ui.extensions.color
 import core.ui.extensions.icon
@@ -196,7 +196,7 @@ private fun GarbageScheduleCard(
                     Text(text = garbageMessage, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
                 }
 
-                Button(onClick = onSaveClick, modifier = Modifier.height(48.dp), enabled = !garbageSaving) {
+                AppButton(onClick = onSaveClick, modifier = Modifier.height(48.dp), enabled = !garbageSaving) {
                     if (garbageSaving) {
                         CircularProgressIndicator(
                             modifier = Modifier.size(20.dp),

--- a/feature/settings/src/commonMain/kotlin/feature/settings/MoneyScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/MoneyScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -19,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import core.ui.components.AppOutlinedButton
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -166,7 +166,7 @@ internal fun MoneyContent(
                 )
                 Text(": 00", style = MaterialTheme.typography.titleMedium)
             }
-            OutlinedButton(
+            AppOutlinedButton(
                 onClick = onDueDateTest,
                 modifier = Modifier.height(48.dp),
                 enabled =

--- a/feature/settings/src/commonMain/kotlin/feature/settings/PetSettingsCard.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/PetSettingsCard.kt
@@ -9,14 +9,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
@@ -28,6 +26,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import core.ui.components.AppButton
+import core.ui.components.AppOutlinedButton
 import core.ui.extensions.label
 import model.MealTime
 import model.Pet
@@ -73,7 +73,7 @@ internal fun PetNameCard(
                         enabled = !isSaving,
                     )
                     val nameChanged = (editingPetNames[pet.id] ?: pet.name) != pet.name
-                    Button(
+                    AppButton(
                         onClick = { onSavePetName(pet.id) },
                         enabled = !isSaving && nameChanged,
                     ) {
@@ -194,7 +194,7 @@ internal fun FeedingSettingsCard(
                 )
             }
 
-            Button(
+            AppButton(
                 onClick = onSave,
                 modifier = Modifier.height(48.dp),
                 enabled = !isSaving,
@@ -281,7 +281,7 @@ internal fun FeedingReminderCard(
             )
         }
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            OutlinedButton(
+            AppOutlinedButton(
                 onClick = onTestScheduled,
                 modifier = Modifier.height(48.dp),
                 enabled = testEnabled,
@@ -295,7 +295,7 @@ internal fun FeedingReminderCard(
                     Text("定刻テスト")
                 }
             }
-            OutlinedButton(
+            AppOutlinedButton(
                 onClick = onTestReminder,
                 modifier = Modifier.height(48.dp),
                 enabled = testEnabled,

--- a/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/SettingsScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Pets
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -46,6 +45,7 @@ import core.auth.AuthStateHolder
 import core.ui.LocalWindowSizeClass
 import core.ui.WindowSizeClass
 import core.ui.components.AdminBadge
+import core.ui.components.AppIconButton
 import org.koin.compose.koinInject
 
 internal enum class SettingsCategory(
@@ -281,7 +281,7 @@ private fun CategoryDetailPane(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 if (showBackButton) {
-                    IconButton(onClick = onBack) {
+                    AppIconButton(onClick = onBack) {
                         Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "戻る")
                     }
                 }

--- a/feature/settings/src/commonMain/kotlin/feature/settings/UserManagementScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/UserManagementScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -20,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import core.ui.components.AppButton
 import core.ui.components.LoadableCardContent
 import model.User
 import org.koin.compose.viewmodel.koinViewModel
@@ -102,7 +102,7 @@ private fun UserNameManagementCard(
                     Text(text = usersMessage, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
                 }
 
-                Button(
+                AppButton(
                     onClick = {
                         for (user in users) {
                             val newName = editedNames[user.uid] ?: ""

--- a/feature/settings/src/commonMain/kotlin/feature/settings/WebhookSettingsCard.kt
+++ b/feature/settings/src/commonMain/kotlin/feature/settings/WebhookSettingsCard.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -20,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import core.ui.components.AppButton
 import core.ui.components.LoadableCardContent
 
 /**
@@ -132,7 +132,7 @@ internal fun WebhookSettingsCard(
                     )
                 }
 
-                Button(
+                AppButton(
                     onClick = onSave,
                     modifier = Modifier.height(48.dp),
                     enabled = saveEnabled,


### PR DESCRIPTION
## Overview

全画面のボタンを対象に、連続クリックによる多重実行を防止する。

- **共通デバウンスボタン**: `core/ui` に `AppButton` / `AppIconButton` / `AppTextButton` / `AppOutlinedButton` を新設（デフォルト 300ms デバウンス）。判定はクリックハンドラ内で完結するため、`enabled` ベース制御では防げない同一フレーム内の連続クリックも弾ける
- **更新系アクションの実行中フラグ**: フラグ皆無だった Quest（作成・受注・承認・削除・報酬作成・交換・削除）、Feeding（給餌・メモ保存・時刻保存）、Dashboard（給餌）、Money（項目保存・削除・移動・定期項目インポート・ステータス変更）に in-flight フラグを追加し、処理完了までボタンを disable。デバウンス（0〜300ms）+ disable（次フレーム〜完了）で全期間をカバー
- **ナビゲーション連打対策**: 月送り・日送り・タブ切替は `debounceMillis = 0`（連打は正当な操作）とし、代わりに ViewModel 側で前のロード Job をキャンセルして最後の操作のみ反映（レスポンス順序逆転による表示不整合を防止）
- **月/日コンテキストのレース防止**: Money / Payment の保存系処理は、完了時に「保存対象の年月」と「現在表示中の年月」が一致する場合のみ state を書き込むガードを追加。保存中に月送りが発生しても、古い月のレスポンスで別の月の表示・保存内容を上書きしない

## Changes

- `core/ui`: `DebouncedClick.kt`（`rememberDebouncedOnClick` + `ClickDebounceState`）、`AppButtons.kt`（4種のラッパー）を追加。`ClickDebounceState` は `TestTimeSource` による単体テスト付き
- feature/app 全 25 ファイルの material3 Button 系（78 箇所）を App* ラッパーへ置換
- ナビ矢印・サイドバー/ドロワー開閉・パスワード表示トグル等の画面操作系は `debounceMillis = 0` を指定
- `QuestViewModel`: `isSubmittingQuest` / `isSubmittingReward` / `processingQuestId` / `processingRewardId` を追加し、UI の enabled に配線（テスト6件追加）
- `FeedingViewModel`: `feedingInProgress` / `isSavingNote` / `isSavingTimestamp` を追加。保存 API 実行中に日送りされた場合、古い日付の保存結果を表示中ログへ混ぜないガードも追加
- `DashboardViewModel`: `feedingInProgress` を追加
- `MoneyViewModel`: `MonthSelector` を `isSaving` 中は disable。`onSaveItem`/`onDeleteItem`/`onImportRecurringItems`/`onMoveItem`/`onUpdateStatus` の完了ハンドラに月一致ガードを追加（`onMoveItem` は GET→SAVE の非冪等な2段書き込みの両方でチェック）
- `PaymentViewModel`: `MonthSelector` を `isSaving || deletingPaymentId != null` 中は disable。`onRecordPayment`/`onDeletePayment` の完了ハンドラに月一致ガードを追加
- Money / Payment / Report / Feeding / Quest の各ロードに `loadJob?.cancel()` パターンを導入（`CancellationException` は rethrow）
- CLAUDE.md の UI Rules に「material3 Button 直接使用禁止・App* 経由必須」の規約を追記

## Note

- 実行中フラグは `launch` 前にメソッド先頭で同期セットし `finally` で解除する規約（CLAUDE.md 記載）
- クエスト受注/承認/削除はサーバー側のステータス遷移チェックでも二重実行を弾くが、UI 側でも disable してエラーメッセージ表示自体を防ぐ
- `POST /pay` などサーバー側の冪等化は本 PR のスコープ外
- 本 PR は self-review スキルによる3セットのレビュー（うち2セットで指摘→修正）を経ている。Money/Payment の月コンテキストガードは self-review の指摘（保存中の月送りによるデータ破損リスク）を受けて追加したもの

🤖 Generated with [Claude Code](https://claude.com/claude-code)
