### PR TITLE
支払い画面: 支払期日グループごとに全額支払うボタンを追加

### DIFF
--- a/feature/payment/src/commonMain/kotlin/feature/payment/PaymentContent.kt
+++ b/feature/payment/src/commonMain/kotlin/feature/payment/PaymentContent.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import core.ui.WindowSizeClass
 import core.ui.components.AppButton
 import core.ui.components.AppIconButton
+import core.ui.components.AppOutlinedButton
 import core.ui.extensions.displayName
 import core.ui.extensions.icon
 import core.ui.formatYen
@@ -107,8 +108,10 @@ internal fun PaymentContent(
                     error = error,
                     isCompact = true,
                     status = status,
+                    saving = saving,
                     onDeletePayment = if (!frozen && !isViewingOther) onDeletePayment else null,
                     deletingPaymentId = deletingPaymentId,
+                    onPayDueDate = if (!frozen && !isViewingOther) onConfirmPay else null,
                     modifier = Modifier.weight(1f),
                 )
                 if (!loading && error == null && !frozen && !isViewingOther) {
@@ -168,8 +171,10 @@ internal fun PaymentContent(
                         error = error,
                         isCompact = false,
                         status = status,
+                        saving = saving,
                         onDeletePayment = if (!frozen && !isViewingOther) onDeletePayment else null,
                         deletingPaymentId = deletingPaymentId,
+                        onPayDueDate = if (!frozen && !isViewingOther) onConfirmPay else null,
                         modifier = Modifier.weight(1f),
                     )
 
@@ -207,8 +212,10 @@ private fun PaymentListContent(
     error: String?,
     isCompact: Boolean,
     status: MonthlyMoneyStatus,
+    saving: Boolean = false,
     onDeletePayment: ((String) -> Unit)? = null,
     deletingPaymentId: String? = null,
+    onPayDueDate: ((Long) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     when {
@@ -283,10 +290,15 @@ private fun PaymentListContent(
                     }
                     for ((dueDate, groupItems) in monthlyMoney.items.groupedByDueDate()) {
                         item(key = "due-header-${dueDate ?: "none"}") {
-                            Text(
-                                text = dueDateGroupLabel(dueDate),
-                                style = MaterialTheme.typography.labelLarge,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            val groupTotal =
+                                groupItems.sumOf { item ->
+                                    item.shares.filter { it.uid == currentUid }.sumOf { it.amount }
+                                }
+                            DueDateGroupHeader(
+                                dueDate = dueDate,
+                                total = groupTotal,
+                                enabled = !saving && deletingPaymentId == null,
+                                onPay = if (onPayDueDate != null && groupTotal > 0) ({ onPayDueDate(groupTotal) }) else null,
                             )
                         }
                         items(groupItems, key = { it.id }) { item ->
@@ -314,6 +326,53 @@ private fun PaymentListContent(
                     }
                 }
             }
+        }
+    }
+}
+
+/**
+ * 支払期日グループの見出し。合計額と、その額をそのまま支払い記録として登録するボタンを表示する。
+ *
+ * [onPay] は null（凍結中・他ユーザー閲覧中・合計額が0円のいずれか）の場合、合計額のテキスト表示のみになる。
+ * ボタンを押すと [PaymentInlineForm] で金額入力して「記録」するのと同じ処理が、合計額を引数として即実行される。
+ * 支払い記録は月次の合計にのみ加算され、どの支払期日グループ向けかという紐付けは持たない
+ * （押した後もこのグループの表示自体は変化しない）ため、ボタンラベルに金額を明記して押す前に確認できるようにしている。
+ */
+@Composable
+private fun DueDateGroupHeader(
+    dueDate: String?,
+    total: Long,
+    enabled: Boolean,
+    onPay: (() -> Unit)?,
+) {
+    val label = dueDateGroupLabel(dueDate)
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (onPay != null) {
+            AppOutlinedButton(
+                onClick = onPay,
+                enabled = enabled,
+                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
+            ) {
+                Text(
+                    text = "${formatYen(total)} 支払う",
+                    style = MaterialTheme.typography.labelLarge,
+                )
+            }
+        } else {
+            Text(
+                text = formatYen(total),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/feature/payment/src/commonMain/kotlin/feature/payment/PaymentContent.kt
+++ b/feature/payment/src/commonMain/kotlin/feature/payment/PaymentContent.kt
@@ -30,6 +30,8 @@ import model.MonthlyMoneyStatus
 import model.Payment
 import model.User
 import model.groupedByDueDate
+import model.myShareTotal
+import model.shareFor
 
 @Composable
 internal fun PaymentContent(
@@ -53,10 +55,7 @@ internal fun PaymentContent(
     val isCompact = windowSizeClass == WindowSizeClass.Compact
 
     // 自分の割当合計
-    val totalAllocated =
-        monthlyMoney.items.sumOf { item ->
-            item.shares.filter { it.uid == currentUid }.sumOf { it.amount }
-        }
+    val totalAllocated = monthlyMoney.items.myShareTotal(currentUid)
     // 支払い済み合計
     val totalPaid = monthlyMoney.payments.sumOf { it.amount }
     val remaining = totalAllocated - totalPaid
@@ -290,10 +289,7 @@ private fun PaymentListContent(
                     }
                     for ((dueDate, groupItems) in monthlyMoney.items.groupedByDueDate()) {
                         item(key = "due-header-${dueDate ?: "none"}") {
-                            val groupTotal =
-                                groupItems.sumOf { item ->
-                                    item.shares.filter { it.uid == currentUid }.sumOf { it.amount }
-                                }
+                            val groupTotal = groupItems.myShareTotal(currentUid)
                             DueDateGroupHeader(
                                 dueDate = dueDate,
                                 total = groupTotal,
@@ -676,7 +672,7 @@ private fun ItemBreakdownCard(
     currentUid: String,
     isCompact: Boolean,
 ) {
-    val myAllocation = item.shares.filter { it.uid == currentUid }.sumOf { it.amount }
+    val myAllocation = item.shareFor(currentUid)
     if (myAllocation == 0L) return
 
     Card(

--- a/feature/payment/src/jvmTest/kotlin/feature/payment/PreviewScreenshotGeneratorTest.kt
+++ b/feature/payment/src/jvmTest/kotlin/feature/payment/PreviewScreenshotGeneratorTest.kt
@@ -41,6 +41,20 @@ class PreviewScreenshotGeneratorTest {
                             name = "電気代",
                             amount = 8000,
                             shares = listOf(Share("user1", 4000), Share("user2", 4000)),
+                            dueDate = "2026-07-15",
+                        ),
+                        MoneyItem(
+                            id = "item2",
+                            name = "水道代",
+                            amount = 6000,
+                            shares = listOf(Share("user1", 3000), Share("user2", 3000)),
+                            dueDate = "2026-07-15",
+                        ),
+                        MoneyItem(
+                            id = "item3",
+                            name = "雑費",
+                            amount = 2000,
+                            shares = listOf(Share("user1", 2000)),
                         ),
                     ),
                 payments =

--- a/shared/src/commonMain/kotlin/model/MoneyModels.kt
+++ b/shared/src/commonMain/kotlin/model/MoneyModels.kt
@@ -168,6 +168,12 @@ fun List<MoneyItem>.groupedByDueDate(): List<Pair<String?, List<MoneyItem>>> {
     return if (withoutDueDate != null) ordered + (null to withoutDueDate) else ordered
 }
 
+/** この項目のうち、指定ユーザーが負担する金額。 */
+fun MoneyItem.shareFor(uid: String): Long = shares.filter { it.uid == uid }.sumOf { it.amount }
+
+/** 項目リストのうち、指定ユーザーが負担する金額の合計。payment 画面の集計で共用する。 */
+fun List<MoneyItem>.myShareTotal(uid: String): Long = sumOf { it.shareFor(uid) }
+
 // =================================================================================================
 // Webhook 設定（API request + response として共用、admin only エンドポイント）
 //

--- a/shared/src/commonTest/kotlin/model/MoneyModelsTest.kt
+++ b/shared/src/commonTest/kotlin/model/MoneyModelsTest.kt
@@ -239,6 +239,45 @@ class MoneyModelsTest {
     }
 
     // ---------------------------------------------------------------------------------
+    // shareFor / myShareTotal
+    // ---------------------------------------------------------------------------------
+
+    @Test
+    fun shareForReturnsAmountForMatchingUid() {
+        val item =
+            MoneyItem(
+                id = "i1",
+                name = "Rent",
+                amount = 8000L,
+                shares = listOf(Share("u1", 5000L), Share("u2", 3000L)),
+            )
+        assertEquals(5000L, item.shareFor("u1"))
+        assertEquals(3000L, item.shareFor("u2"))
+    }
+
+    @Test
+    fun shareForReturnsZeroWhenUidHasNoShare() {
+        val item = MoneyItem(id = "i1", name = "Rent", amount = 8000L, shares = listOf(Share("u1", 8000L)))
+        assertEquals(0L, item.shareFor("u2"))
+    }
+
+    @Test
+    fun myShareTotalSumsAcrossItems() {
+        val items =
+            listOf(
+                MoneyItem(id = "i1", name = "Rent", amount = 8000L, shares = listOf(Share("u1", 5000L), Share("u2", 3000L))),
+                MoneyItem(id = "i2", name = "Food", amount = 2000L, shares = listOf(Share("u1", 2000L))),
+            )
+        assertEquals(7000L, items.myShareTotal("u1"))
+        assertEquals(3000L, items.myShareTotal("u2"))
+    }
+
+    @Test
+    fun myShareTotalReturnsZeroForEmptyList() {
+        assertEquals(0L, emptyList<MoneyItem>().myShareTotal("u1"))
+    }
+
+    // ---------------------------------------------------------------------------------
     // MoneyDueDateNotificationSettings
     // ---------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Overview

支払い画面の内訳リストで、支払期日グループの見出しにそのグループの自分の割当合計額を表示し、金額をそのまま支払い記録として登録できるボタンを追加しました。

## Changes

- 支払期日グループの見出し（`支払期日: 8月15日` など、支払期日が未設定の「支払期日なし」グループも含む）の右側に、そのグループの自分の割当合計額を表示
- 凍結中・他ユーザー閲覧中・合計額が0円のいずれかの場合は、ボタンを出さず金額のみ表示
- それ以外の場合は `¥X,XXX 支払う` ボタンを表示し、押すと `onConfirmPay(合計額)` を実行（「支払いを記録」フォームで同額を手入力して記録するのと同じ処理）
- ボタンは月送りボタンと同じ条件（`!saving && deletingPaymentId == null`）で無効化
- プレビュースクリーンショットの fixture に支払期日ありの項目を追加し、複数グループが並ぶ実際の見た目を確認できるようにした
- 「自分の割当合計」計算（`shares.filter { it.uid == uid }.sumOf { it.amount }`）が `PaymentContent` 内の3箇所で重複していたため、`shared` の `MoneyItem.shareFor(uid)` / `List<MoneyItem>.myShareTotal(uid)` に切り出して共通化（単体テスト付き）

## Note

- `Payment` は月次の合計にのみ加算され、どの支払期日グループ向けかという紐付けを持たないデータモデルです。そのため、ボタンを押した後もそのグループの表示自体は変化しません（「払った」フラグは存在しない）。押す前に金額を確認できるよう、ボタンラベルに金額を明記する設計にしています。
- 超過支払いのチェックはクライアント・サーバーともに行っていません（既存の `PayRequest` と同じ挙動）。`feature/report` の Overpayment 機能が既にこのケースを扱う前提です。
- 「支払期日グループごとに」ボタンを出す実装は、支払期日が未設定の項目群（「支払期日なし」グループ）にも同様に適用されます。特定の期日に紐づく項目に限定した機能ではなく、内訳リストの各グループ単位でまとめて支払えるようにする汎用的な機能です。
- ボタンは確認ステップなしのワンクリック即実行です（Popup による確認ダイアログはプロジェクトルールで禁止のため使用不可）。誤クリックで二重記録した場合も、その上に表示される「支払い履歴」一覧から該当の支払いを削除して復旧できるため、確認ステップは設けない設計にしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
